### PR TITLE
ls implementation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -725,6 +725,7 @@ dependencies = [
  "gettext-rs",
  "libc",
  "plib",
+ "regex",
  "walkdir",
 ]
 

--- a/tree/Cargo.toml
+++ b/tree/Cargo.toml
@@ -15,6 +15,9 @@ libc.workspace = true
 chrono = "0.4"
 atty = "0.2"
 
+[dev-dependencies]
+regex.workspace = true
+
 [[bin]]
 name = "chgrp"
 path = "src/chgrp.rs"
@@ -38,6 +41,10 @@ path = "src/link.rs"
 [[bin]]
 name = "ln"
 path = "src/ln.rs"
+
+[[bin]]
+name = "ls"
+path = "src/ls.rs"
 
 [[bin]]
 name = "mkdir"

--- a/tree/src/ls.rs
+++ b/tree/src/ls.rs
@@ -1,0 +1,1243 @@
+//
+// Copyright (c) 2024 Hemi Labs, Inc.
+//
+// This file is part of the posixutils-rs project covered under
+// the MIT License.  For the full license text, please see the LICENSE
+// file in the root directory of this project.
+// SPDX-License-Identifier: MIT
+//
+
+mod ls_util;
+
+use clap::{CommandFactory, FromArgMatches, Parser};
+use gettextrs::{bind_textdomain_codeset, gettext, textdomain};
+use plib::PROJECT_NAME;
+use std::collections::HashMap;
+use std::ffi::{CStr, CString, OsStr, OsString};
+use std::fs;
+use std::io;
+use std::mem::MaybeUninit;
+use std::os::unix::ffi::OsStrExt;
+use std::path::PathBuf;
+use std::process::ExitCode;
+
+use self::ls_util::{ls_from_utf8_lossy, Entry, LongFormatPadding, MultiColumnPadding};
+
+/// ls - list directory contents
+#[derive(Parser, Debug)]
+#[command(author, version, about, long_about)]
+struct Args {
+    /// Write out all directory entries, including those whose names begin with
+    /// a <period> ( '.' ).
+    #[arg(short = 'a', long, overrides_with_all = ["almost_all", "all"])]
+    all: bool,
+
+    /// Write out all directory entries, including those whose names begin with
+    /// a <period> ( '.' ) but excluding the entries dot and dot-dot (if they
+    /// exist).
+    #[arg(short = 'A', long, overrides_with_all = ["almost_all", "all"])]
+    almost_all: bool,
+
+    /// Use time of last modification of the file status information (see XBD
+    /// <sys/stat.h>) instead of last modification of the file itself for
+    /// sorting ( -t) or writing (-l).
+    #[arg(
+        short = 'c',
+        overrides_with_all = [
+            "use_last_status_change_time",
+            "use_last_access_time"
+        ]
+    )]
+    use_last_status_change_time: bool,
+
+    /// Write multi-text-column output with entries sorted down the columns,
+    /// according to the collating sequence. The number of text columns and the
+    /// column separator characters are unspecified, but should be adapted to
+    /// the nature of the output device. This option disables long format
+    /// output.
+    #[arg(
+        short = 'C',
+        overrides_with_all = [
+            "multi_column",
+            "stream_output_format",
+            "muti_column_across",
+            "one_entry_per_line",
+        ]
+    )]
+    multi_column: bool,
+
+    /// Do not follow symbolic links named as operands unless the -H or -L
+    /// options are specified. Do not treat directories differently than other
+    /// types of files. The use of -d with -R or -f produces unspecified
+    /// results.
+    #[arg(short = 'd', long)]
+    directory: bool,
+
+    /// List the entries in directory operands in the order they appear in the
+    /// directory. The behavior for non-directory operands is unspecified.
+    /// This option shall turn on -a. When -f is specified, any occurrences of
+    /// the -r, -S, and -t options shall be ignored and any occurrences of the
+    /// -A, -g, -l, -n, -o, and -s options may be ignored. The use of -f with
+    /// -R or -d produces unspecified results.
+    #[arg(
+        short = 'f',
+        overrides_with_all = [
+            "sort_by_file_size",
+            "sort_by_directory_order",
+            "sort_by_last_modified_time",
+        ]
+    )]
+    sort_by_directory_order: bool,
+
+    /// Do not follow symbolic links named as operands unless the -H or -L
+    /// options are specified. Write a <slash> ( '/' ) immediately after each
+    /// pathname that is a directory, an <asterisk> ( '*' ) after each that is
+    /// executable, a <vertical-line> ( '|' ) after each that is a FIFO, and an
+    /// at-sign ( '@' ) after each that is a symbolic link. For other file
+    /// types, other symbols may be written.
+    #[arg(
+        short = 'F',
+        long,
+        overrides_with_all = ["classify", "write_slash_if_directory"]
+    )]
+    classify: bool,
+
+    /// Turn on the -l (ell) option, but disable writing the file's owner name
+    /// or number. Disable the -C, -m, and -x options.
+    #[arg(short = 'g')]
+    long_format_without_owner: bool,
+
+    /// Evaluate the file information and file type for symbolic links specified
+    /// on the command line to be those of the file referenced by the link, and
+    /// not the link itself; however, ls shall write the name of the link itself
+    /// and not the file referenced by the link.
+    #[arg(
+        short = 'H',
+        long,
+        overrides_with_all = ["dereference_command_line", "dereference"]
+    )]
+    dereference_command_line: bool,
+
+    /// For each file, write the file's file serial number.
+    #[arg(short = 'i', long, overrides_with = "inode")]
+    inode: bool,
+
+    /// Set the block size for the -s option and the per-directory block count
+    /// written for the -l, -n, -s, -g, and -o options to 1024
+    /// bytes.
+    #[arg(short = 'k', long)]
+    kibibytes: bool,
+
+    /// (The letter ell.) Do not follow symbolic links named as operands unless
+    /// the -H or -L options are specified. Write out in long format.
+    /// Disable the -C, -m, and -x options.
+    #[arg(short = 'l')]
+    long_format: bool,
+
+    /// Evaluate the file information and file type for all symbolic links
+    /// (whether named on the command line or encountered in a file hierarchy)
+    /// to be those of the file referenced by the link, and not the link itself;
+    /// however, ls shall write the name of the link itself and not the file
+    /// referenced by the link. When -L is used with -l, write the contents of
+    /// symbolic links in the long format.
+    #[arg(
+        short = 'L',
+        long,
+        overrides_with_all = ["dereference_command_line", "dereference"]
+    )]
+    dereference: bool,
+
+    /// Stream output format; list pathnames across the page, separated by a
+    /// <comma> character followed by a <space> character. Use a <newline>
+    /// character as the list terminator and after the separator sequence when
+    /// there is not room on a line for the next list entry. This option
+    /// disables long format output.
+    #[arg(
+        short = 'm',
+        overrides_with_all = [
+            "multi_column",
+            "stream_output_format",
+            "muti_column_across",
+            "one_entry_per_line",
+        ]
+    )]
+    stream_output_format: bool,
+
+    /// Turn on the -l (ell) option, but when writing the file's owner or group,
+    /// write the file's numeric UID or GID rather than the user or group name,
+    /// respectively. Disable the -C, -m, and -x options.
+    #[arg(short = 'n', long = "numeric-uid-gid")]
+    long_format_numeric_uid_gid: bool,
+
+    /// Turn on the -l (ell) option, but disable writing the file's group name
+    /// or number. Disable the -C, -m, and -x options.
+    #[arg(short = 'o')]
+    long_format_without_group: bool,
+
+    /// Write a <slash> ( '/' ) after each filename if that file is a directory.
+    #[arg(
+        short = 'p',
+        overrides_with_all = ["classify", "write_slash_if_directory"]
+    )]
+    write_slash_if_directory: bool,
+
+    /// Force each instance of non-printable filename characters and <tab>
+    /// characters to be written as the <question-mark> ( '?' ) character.
+    /// Implementations may provide this option by default if the output is to a
+    /// terminal device.
+    #[arg(short = 'q', long)]
+    hide_control_chars: bool,
+
+    /// Reverse the order of the sort to get reverse collating sequence oldest
+    /// first, or smallest file size first depending on the other options given.
+    #[arg(short = 'r', long = "reverse")]
+    reverse_sorting: bool,
+
+    /// Recursively list subdirectories encountered. When a symbolic link to a
+    /// directory is encountered, the directory shall not be recursively listed
+    /// unless the -L option is specified. The use of -R with -d or -f produces
+    /// unspecified results.
+    #[arg(short = 'R', long)]
+    recursive: bool,
+
+    /// Indicate the total number of file system blocks consumed by each file
+    /// displayed. If the -k option is also specified, the block size shall be
+    /// 1024 bytes; otherwise, the block size is implementation-defined.
+    #[arg(short = 's', long = "size")]
+    display_size: bool,
+
+    /// Sort with the primary key being file size (in decreasing order) and the
+    /// secondary key being filename in the collating sequence (in increasing
+    /// order).
+    #[arg(
+        short = 'S',
+        overrides_with_all = [
+            "sort_by_file_size",
+            "sort_by_directory_order",
+            "sort_by_last_modified_time",
+        ]
+    )]
+    sort_by_file_size: bool,
+
+    /// Sort with the primary key being time modified (most recently modified
+    /// first) and the secondary key being filename in the collating sequence.
+    /// For a symbolic link, the time used as the sort key is that of the
+    /// symbolic link itself, unless ls is evaluating its file information to be
+    /// that of the file referenced by the link (see the -H and -L options).
+    #[arg(
+        short = 't',
+        overrides_with_all = [
+            "sort_by_file_size",
+            "sort_by_directory_order",
+            "sort_by_last_modified_time",
+        ]
+    )]
+    sort_by_last_modified_time: bool,
+
+    /// Use time of last access instead of last modification of the file for
+    /// sorting (-t) or writing (-l).
+    #[arg(
+        short = 'u',
+        overrides_with_all = [
+            "use_last_status_change_time",
+            "use_last_access_time"
+        ]
+    )]
+    use_last_access_time: bool,
+
+    /// The same as -C, except that the multi-text-column output is produced
+    /// with entries sorted across, rather than down, the columns. This option
+    /// disables long format output.
+    #[arg(
+        short = 'x',
+        overrides_with_all = [
+            "multi_column",
+            "stream_output_format",
+            "muti_column_across",
+            "one_entry_per_line",
+        ]
+    )]
+    muti_column_across: bool,
+
+    /// (The numeric digit one.) Force output to be one entry per line. This
+    /// option does not disable long format output. (Long format output is
+    /// enabled by -g, -l (ell), -n, and -o; and disabled by -C, -m, and -x.)
+    #[arg(
+        short = '1',
+        overrides_with_all = [
+            "multi_column",
+            "stream_output_format",
+            "muti_column_across",
+            "one_entry_per_line",
+        ]
+    )]
+    one_entry_per_line: bool,
+
+    /// A pathname of a file to be written. If the file specified is not found,
+    /// a diagnostic message shall be output on standard error.
+    #[arg()]
+    file: Vec<PathBuf>,
+}
+
+const DATE_TIME_FORMAT_RECENT: &str = "%b %d %H:%M";
+const DATE_TIME_FORMAT_OLD_OR_FUTURE: &str = "%b %d  %Y"; // Two spaces between %d and %Y
+const BLOCK_SIZE: u64 = 512;
+const BLOCK_SIZE_KIBIBYTES: u64 = 1024;
+const COLUMN_SPACING: usize = 2; // How many spaces in the column separator
+const SKIP_OPTIMAL_COLUMN_WIDTH_THRESHOLD: usize = 1000;
+
+struct LongFormatOptions {
+    numeric_uid_gid: bool,
+    without_owner: bool,
+    without_group: bool,
+}
+
+enum OutputFormat {
+    MultiColumn,
+    MultiColumnAcross,
+    StreamOutputFormat,
+    OneEntryPerLine,
+    LongFormat(LongFormatOptions),
+}
+
+enum SortBy {
+    Lexicographical,
+    FileSize,
+    DirectoryOrder,
+    Time,
+}
+
+enum ClassifyFiles {
+    Complete,
+    DirectoryOrNotDirectory,
+    None,
+}
+
+enum DereferenceSymbolicLink {
+    CommandLine,
+    All,
+    None,
+}
+
+enum FileTimeOption {
+    LastModificationTime,
+    LastStatusChangeTime,
+    LastAcessTime,
+}
+
+enum FileInclusion {
+    Default,
+    IncludeHidden, // Include hidden files (those starting with .)
+    All,           // Include everything
+}
+
+struct Config {
+    output_format: OutputFormat,
+    sort_by: SortBy,
+    classify_files: ClassifyFiles,
+    dereference_symbolic_link: DereferenceSymbolicLink,
+    file_time_option: FileTimeOption,
+    file_inclusion: FileInclusion,
+    inode: bool,
+    kibibytes: bool,
+    hide_control_chars: bool,
+    reverse_sorting: bool,
+    display_size: bool,
+    recursive: bool,
+    terminal_width: usize,
+}
+
+impl Config {
+    fn new() -> (Self, Vec<PathBuf>) {
+        let m = Args::command().get_matches();
+
+        // Enables long format (-g, -n, -l, -o)
+        const LONG_FORMAT_WITHOUT_OWNER: &str = "long_format_without_owner";
+        const LONG_FORMAT_NUMERIC_UID_GID: &str = "long_format_numeric_uid_gid";
+        const LONG_FORMAT: &str = "long_format";
+        const LONG_FORMAT_WITHOUT_GROUP: &str = "long_format_without_group";
+
+        // Disables long format (-C, -m, -x)
+        const MULTI_COLUMN: &str = "multi_column";
+        const STREAM_OUTPUT_FORMAT: &str = "stream_output_format";
+        const MUTI_COLUMN_ACROSS: &str = "muti_column_across";
+
+        // Does not enable/disable long format directly but can enable it by
+        // overriding -C, -m, or -x
+        const ONE_ENTRY_PER_LINE: &str = "one_entry_per_line";
+
+        let mut long_format_args: Vec<_> = [
+            LONG_FORMAT_WITHOUT_OWNER,
+            LONG_FORMAT_NUMERIC_UID_GID,
+            LONG_FORMAT,
+            LONG_FORMAT_WITHOUT_GROUP,
+            MULTI_COLUMN,
+            STREAM_OUTPUT_FORMAT,
+            MUTI_COLUMN_ACROSS,
+            ONE_ENTRY_PER_LINE,
+        ]
+        .into_iter()
+        .filter_map(|s| {
+            if m.get_flag(s) {
+                m.index_of(s).map(|i| (i, s))
+            } else {
+                None
+            }
+        })
+        .collect();
+
+        // Sort in order of appearance in the arguments
+        long_format_args.sort_by_key(|p| p.0);
+
+        let mut long_format_state = Vec::new();
+        let mut long_format_options = LongFormatOptions {
+            numeric_uid_gid: false,
+            without_owner: false,
+            without_group: false,
+        };
+
+        // Manually resolve the format by iterating over the args
+        for (_, s) in long_format_args.iter().copied() {
+            match s {
+                LONG_FORMAT_WITHOUT_OWNER => {
+                    long_format_state.push(true);
+                    long_format_options.without_owner = true;
+                }
+                LONG_FORMAT_NUMERIC_UID_GID => {
+                    long_format_state.push(true);
+                    long_format_options.numeric_uid_gid = true;
+                }
+                LONG_FORMAT => {
+                    long_format_state.push(true);
+                }
+                LONG_FORMAT_WITHOUT_GROUP => {
+                    long_format_state.push(true);
+                    long_format_options.without_group = true;
+                }
+                MULTI_COLUMN | STREAM_OUTPUT_FORMAT | MUTI_COLUMN_ACROSS => {
+                    long_format_state.push(false);
+                }
+                ONE_ENTRY_PER_LINE => loop {
+                    // Remove any `false` that was added by -C, -m or -x until
+                    // a `true` is reached or the vec is empty
+                    match long_format_state.last().copied() {
+                        Some(enabled) => {
+                            if enabled {
+                                break;
+                            } else {
+                                long_format_state.pop();
+                            }
+                        }
+                        None => break,
+                    }
+                },
+                _ => unreachable!(),
+            }
+        }
+
+        let long_format_enabled = long_format_state.last().copied().unwrap_or(false);
+
+        let mut args = match Args::from_arg_matches(&m) {
+            Ok(args) => args,
+            Err(e) => e.exit(),
+        };
+
+        let output_format = match (
+            args.multi_column,
+            args.stream_output_format,
+            args.muti_column_across,
+            args.one_entry_per_line,
+        ) {
+            (false, false, false, false) => {
+                if long_format_enabled {
+                    OutputFormat::LongFormat(long_format_options)
+                } else {
+                    // According to the specification:
+                    //
+                    // The default format shall be to list one entry per line to
+                    // standard output; ...If the output is to a terminal, the
+                    // format is implementation-defined.
+                    //
+                    // coreutils uses -C by default.
+                    OutputFormat::OneEntryPerLine
+                }
+            }
+            (true, false, false, false) => OutputFormat::MultiColumn,
+            (false, true, false, false) => OutputFormat::StreamOutputFormat,
+            (false, false, true, false) => OutputFormat::MultiColumnAcross,
+            (false, false, false, true) => OutputFormat::OneEntryPerLine,
+            _ => unreachable!(), // -C, -m, -x, and -1 are mutually exclusive
+        };
+
+        let sort_by = match (
+            args.sort_by_file_size,
+            args.sort_by_directory_order,
+            args.sort_by_last_modified_time,
+        ) {
+            (false, false, false) => SortBy::Lexicographical,
+            (true, false, false) => SortBy::FileSize,
+            (false, true, false) => SortBy::DirectoryOrder,
+            (false, false, true) => SortBy::Time,
+            _ => unreachable!(), // -S, -f and -t are mutually exclusive
+        };
+
+        let classify_files = match (args.classify, args.write_slash_if_directory) {
+            (false, false) => ClassifyFiles::None,
+            (true, false) => ClassifyFiles::Complete,
+            (false, true) => ClassifyFiles::DirectoryOrNotDirectory,
+            _ => unreachable!(), // -F and -p are mutually exclusive
+        };
+
+        let dereference_symbolic_link = match (args.dereference_command_line, args.dereference) {
+            (false, false) => DereferenceSymbolicLink::None,
+            (true, false) => DereferenceSymbolicLink::CommandLine,
+            (false, true) => DereferenceSymbolicLink::All,
+            _ => unreachable!(), // -H and -L are mutually exclusive
+        };
+
+        let file_time_option = match (args.use_last_status_change_time, args.use_last_access_time) {
+            (false, false) => FileTimeOption::LastModificationTime,
+            (true, false) => FileTimeOption::LastStatusChangeTime,
+            (false, true) => FileTimeOption::LastAcessTime,
+            _ => unreachable!(), // -c and -u are mutually exclusive
+        };
+
+        let mut file_inclusion = match (args.almost_all, args.all) {
+            (false, false) => FileInclusion::Default,
+            (true, false) => FileInclusion::IncludeHidden,
+            (false, true) => FileInclusion::All,
+            _ => unreachable!(), // -A and -a are mutually exclusive
+        };
+
+        // When enabling -f,
+        //  -r, -S, and -t options shall be ignored
+        //  -A, -g, -l, -n, -o, and -s options may be ignored
+        if args.sort_by_directory_order {
+            // -r is ignored
+            args.reverse_sorting = false;
+
+            // -A is also ignored
+            match file_inclusion {
+                FileInclusion::Default => file_inclusion = FileInclusion::All,
+                _ => (),
+            }
+        }
+
+        let mut file = args.file;
+        if file.is_empty() {
+            file.push(PathBuf::from("."));
+        }
+
+        let config = Self {
+            output_format,
+            sort_by,
+            classify_files,
+            dereference_symbolic_link,
+            file_time_option,
+            file_inclusion,
+
+            inode: args.inode,
+            kibibytes: args.kibibytes,
+            hide_control_chars: args.hide_control_chars,
+            reverse_sorting: args.reverse_sorting,
+            display_size: args.display_size,
+            recursive: args.recursive,
+
+            terminal_width: get_terminal_width(),
+        };
+
+        (config, file)
+    }
+}
+
+fn get_terminal_width() -> usize {
+    // Constants taken from:
+    // https://docs.rs/term_size/0.3.2/src/term_size/platform/unix.rs.html#5-19
+    const fn winsize_request_code() -> std::ffi::c_ulong {
+        #[cfg(any(target_os = "linux", target_os = "android"))]
+        return 0x5413;
+
+        #[cfg(any(
+            target_os = "macos",
+            target_os = "ios",
+            target_os = "bitrig",
+            target_os = "dragonfly",
+            target_os = "freebsd",
+            target_os = "netbsd",
+            target_os = "openbsd"
+        ))]
+        return 0x40087468;
+
+        #[cfg(target_os = "solaris")]
+        0x5468
+    }
+
+    // COLUMNS is usually automatically set and it even changes when the
+    // terminal window is resized.
+    if let Ok(s) = std::env::var("COLUMNS") {
+        if let Ok(num_columns) = s.parse() {
+            return num_columns;
+        }
+    }
+
+    // Fallback to manually querying via `ioctl`.
+    unsafe {
+        let mut winsize: MaybeUninit<libc::winsize> = MaybeUninit::zeroed();
+        let ret = libc::ioctl(
+            libc::STDOUT_FILENO,
+            winsize_request_code(),
+            winsize.as_mut_ptr(),
+        );
+
+        // We're only interested in stdout here unlike `term_size::dimensions`
+        // so we won't query further if the first `ioctl` call fails.
+        if ret == 0 {
+            let winsize = winsize.assume_init();
+            return winsize.ws_col as usize;
+        }
+    }
+
+    // Historical default terminal width is 80
+    80
+}
+
+/// Calculate how many columns will fit in `terminal_width` given
+/// `column_width`.
+fn calc_num_columns(column_width: usize, terminal_width: usize) -> usize {
+    // Derived by solving for column_width in this inequality:
+    //
+    // (num_columns - 1)*(column_width + COLUMN_SPACING) + column_width <= terminal_width
+    (terminal_width + COLUMN_SPACING) / (column_width + COLUMN_SPACING)
+}
+
+/// Calculate the padding and width for each column that will give the minimum
+/// amount of rows.
+fn calc_optimal_padding(
+    entries: &mut [Entry],
+    terminal_width: usize,
+    across: bool,
+) -> Vec<MultiColumnPadding> {
+    let mut min_len = usize::MAX;
+    let mut max_len = usize::MIN;
+
+    let mut padding = MultiColumnPadding::default();
+    for entry in entries.iter() {
+        let p = entry.get_multi_column_padding();
+        padding.update_maximum(p);
+
+        min_len = usize::min(min_len, p.total_width);
+        max_len = usize::max(max_len, p.total_width);
+    }
+
+    // Single column because at least one entry is too big to fit in
+    // multi-column
+    if max_len > terminal_width || entries.is_empty() {
+        padding.file_name_width = 0; // Don't pad when it's just a single column
+        return vec![padding];
+    }
+
+    for entry in entries.iter_mut() {
+        entry.recalculate_widths(&padding);
+    }
+
+    let mut num_columns_upperbound = calc_num_columns(min_len, terminal_width);
+    let num_columns_lowerbound = calc_num_columns(max_len, terminal_width);
+
+    // If too many
+    if entries.len() >= SKIP_OPTIMAL_COLUMN_WIDTH_THRESHOLD {
+        // `num_columns_lowerbound` is guaranteed to succeed
+        num_columns_upperbound = num_columns_lowerbound;
+    }
+
+    // This is O(n^2) hence the `entries.len()` check above to avoid being
+    // excessively slow.
+    for num_cols in (num_columns_lowerbound..=num_columns_upperbound).rev() {
+        let mut widths = Vec::with_capacity(num_cols);
+        if across {
+            for i in 0..usize::min(num_cols, entries.len()) {
+                // Get the maximum width for each column
+                if let Some(max_width) = entries[i..]
+                    .iter()
+                    .map(|e| e.get_multi_column_padding().total_width)
+                    .step_by(num_cols)
+                    .max()
+                {
+                    widths.push(max_width);
+                }
+            }
+        } else {
+            let num_rows = entries.len().div_ceil(num_cols);
+
+            for col in entries.chunks(num_rows) {
+                // Max width for each column.
+                // `unwrap` here shouldn't panic since `chunks` should always be
+                // returning a non-empty slice.
+                let max_width = col
+                    .iter()
+                    .map(|e| e.get_multi_column_padding().total_width)
+                    .max()
+                    .unwrap();
+
+                widths.push(max_width);
+            }
+        }
+
+        assert!(!widths.is_empty());
+
+        let mut total_width = widths.iter().sum::<usize>();
+
+        // Every column except the last has `COLUMN_SPACING` spaces.
+        total_width += COLUMN_SPACING * (widths.len() - 1);
+
+        if total_width <= terminal_width {
+            let mut result = Vec::with_capacity(num_cols);
+            if across {
+                for i in 0..usize::min(num_cols, entries.len()) {
+                    let mut padding = MultiColumnPadding::default();
+                    for entry in entries[i..].iter().step_by(num_cols) {
+                        padding.update_maximum(entry.get_multi_column_padding());
+                    }
+                    result.push(padding);
+                }
+            } else {
+                let num_rows = entries.len().div_ceil(num_cols);
+
+                for col in entries.chunks(num_rows) {
+                    let mut padding = MultiColumnPadding::default();
+                    for entry in col {
+                        padding.update_maximum(entry.get_multi_column_padding());
+                    }
+                    result.push(padding);
+                }
+            }
+            return result;
+        }
+    }
+
+    unreachable!()
+}
+
+// Used by the -f option. This had to be done through `libc` because it needs to
+// output the entries `.` and `..` which `std::fs::read_dir` does not do.
+fn get_file_names_in_directory_order(directory: &str) -> io::Result<Vec<OsString>> {
+    unsafe {
+        // Convert `directory` to a C-style string
+        let path = CString::new(directory)?;
+
+        let dirp = libc::opendir(path.as_ptr());
+        if dirp.is_null() {
+            // This returns the error from `errno`
+            return Err(io::Error::last_os_error());
+        }
+
+        let mut filenames = Vec::new();
+
+        let mut loop_over_entries = || -> io::Result<()> {
+            loop {
+                let dirent = libc::readdir(dirp);
+                if dirent.is_null() {
+                    // Check if an error or just end of the stream
+                    let e = io::Error::last_os_error();
+                    let errno = e.raw_os_error().unwrap();
+                    if errno != 0 {
+                        return Err(e);
+                    }
+                    break;
+                }
+
+                // `CStr::from_ptr` is less verbose but doing it this way
+                // makes sure that the string is at most 255 characters in
+                // length
+                let dirent_ref = &*dirent;
+                let bytes = std::slice::from_raw_parts(
+                    dirent_ref.d_name.as_ptr() as *const u8,
+                    dirent_ref.d_name.len(),
+                );
+                let cstr = CStr::from_bytes_until_nul(bytes).map_err(|e| io::Error::other(e))?;
+
+                // Using an `OsString` because `to_string_lossy()` could
+                // possibly cause a name collision:
+                //
+                // `a?` and `a?` with different non-UTF-8 code points for the
+                // second character.
+                filenames.push(OsStr::from_bytes(cstr.to_bytes()).to_os_string());
+            }
+            Ok(())
+        };
+
+        let loop_result = loop_over_entries();
+
+        // *Always* close the `dirp` pointer even if `loop_over_entries` has an
+        // error
+        if libc::closedir(dirp) != 0 {
+            return Err(io::Error::last_os_error());
+        }
+
+        if let Err(e) = loop_result {
+            return Err(e);
+        }
+
+        Ok(filenames)
+    }
+}
+
+fn display_entries(entries: &mut [Entry], config: &Config, dir_path: Option<&str>) {
+    match &config.sort_by {
+        SortBy::DirectoryOrder => {
+            if let Some(dir_path) = dir_path {
+                // Only considering the no-error case since the sorting
+                // order will get messed up anyway if even one entry in the
+                // `libc::readdir` call fails.
+                if let Ok(mut file_names) = get_file_names_in_directory_order(&dir_path) {
+                    if config.reverse_sorting {
+                        file_names.reverse();
+                    }
+
+                    // Map of file_name -> directory_order_index
+                    let index_map: HashMap<OsString, usize> = file_names
+                        .into_iter()
+                        .enumerate()
+                        .map(|(i, s)| (s, i))
+                        .collect();
+
+                    entries.sort_by_key(|entry| {
+                        index_map
+                            .get(entry.file_name_os_str())
+                            .copied()
+                            .unwrap_or(usize::MAX)
+                    });
+                }
+            }
+        }
+        other_sorting => {
+            entries.sort_by(|a, b| {
+                let sort_fn = match other_sorting {
+                    SortBy::Lexicographical => Entry::sorting_cmp_lexicographic,
+                    SortBy::FileSize => Entry::sorting_cmp_size,
+                    SortBy::Time => Entry::sorting_cmp_time,
+                    SortBy::DirectoryOrder => unreachable!(), // Already handled
+                };
+                if config.reverse_sorting {
+                    sort_fn(a, b).reverse()
+                } else {
+                    sort_fn(a, b)
+                }
+            });
+        }
+    }
+
+    let mut display_total_size = config.display_size;
+    if let OutputFormat::LongFormat(_) = &config.output_format {
+        display_total_size = true;
+    }
+
+    // `dir_path.is_some()` to only display the total on directories.
+    if display_total_size && dir_path.is_some() {
+        let mut total_block_size = 0;
+        for entry in entries.iter() {
+            total_block_size += BLOCK_SIZE * entry.blocks();
+        }
+
+        // The specification seems contradictory here. On the -s flag
+        // it says it is implementation-defined. But on the STDOUT
+        // section, it mandates it to be 512 when -k is not specified
+        // and 1024 when it is.
+        // coreutils seems to always have it as 1024 with or without -k.
+        if config.kibibytes {
+            total_block_size /= BLOCK_SIZE_KIBIBYTES;
+        } else {
+            total_block_size /= BLOCK_SIZE;
+        }
+        println!("{} {}", gettext("total"), total_block_size);
+    }
+
+    match &config.output_format {
+        OutputFormat::LongFormat(_) => {
+            let mut padding = LongFormatPadding::default();
+
+            // Calculate required padding
+            for entry in entries.iter() {
+                padding.update_maximum(&entry.get_long_format_padding());
+            }
+
+            // Readjust file size / device ID column
+            padding.update_file_info_padding();
+
+            for entry in entries.iter() {
+                entry.println_long_format(&padding);
+            }
+        }
+        OutputFormat::MultiColumn => {
+            let paddings = calc_optimal_padding(entries, config.terminal_width, false);
+            let last_col_idx = paddings.len() - 1;
+
+            let num_columns = paddings.len();
+            let num_rows = entries.len().div_ceil(num_columns);
+
+            // Choose a row.
+            // | 0 |   |   |   |
+            // | * |   |   |   |
+            // | 2 |   |   |   |
+            for row_idx in 0..num_rows {
+                // Create an iterator of columns.
+                // |   | 3 |   |   |
+                // |   | 4 |   |   |
+                // |   | 5 |   |   |
+                for (col_idx, (col, padding)) in
+                    entries.chunks(num_rows).zip(paddings.iter()).enumerate()
+                {
+                    // For each column, select one row.
+                    // |   | 3 |   |   |
+                    // |   | * |   |   |
+                    // |   | 5 |   |   |
+                    if let Some(entry) = col.get(row_idx) {
+                        if col_idx == last_col_idx {
+                            entry.print_multi_column(padding);
+                        } else {
+                            entry.print_multi_column(padding);
+                            print!("{:COLUMN_SPACING$}", "");
+                        }
+                    }
+                }
+                println!("");
+            }
+        }
+        OutputFormat::MultiColumnAcross => {
+            let paddings = calc_optimal_padding(entries, config.terminal_width, true);
+            let last_col_idx = paddings.len() - 1;
+
+            let num_columns = paddings.len();
+
+            // The `zip` of `entries` and `paddings` in this for loop
+            // iterates like the following:
+            //
+            // `entries`
+            // | 0 | 1 | 2 | 3 |
+            // | 4 | 5 | 6 |   |
+            // |   |   |   |   |
+            //
+            // `paddings`
+            // | 0 | 1 | 2 | 3 |
+            // | 0 | 1 | 2 |   |
+            // |   |   |   |   |
+            for (entry, (col_idx, padding)) in
+                entries.iter().zip(paddings.iter().enumerate().cycle())
+            {
+                if col_idx == last_col_idx {
+                    entry.print_multi_column(padding);
+                    println!("");
+                } else {
+                    entry.print_multi_column(padding);
+                    print!("{:COLUMN_SPACING$}", "");
+                }
+            }
+
+            // If the last entry does not end up on the bottom right of
+            // the grid
+            if entries.len() % num_columns != 0 {
+                println!("");
+            }
+        }
+        OutputFormat::StreamOutputFormat => {
+            let stream_outputs: Vec<_> = entries
+                .iter()
+                .map(|entry| entry.build_stream_mode_string())
+                .collect();
+            let char_counts: Vec<_> = stream_outputs.iter().map(|s| s.chars().count()).collect();
+            let mut start = 0;
+
+            'outer: loop {
+                let mut column_width = 0;
+                for (slice_idx, count) in char_counts[start..].iter().enumerate() {
+                    let i = start + slice_idx;
+
+                    // +2 for the ", " separator
+                    let next_width = column_width + count + 2;
+
+                    if next_width < config.terminal_width {
+                        column_width = next_width;
+                    } else {
+                        let width_without_space = column_width + count + 1;
+
+                        // `start..=i` fits in `terminal_width`
+                        if width_without_space < config.terminal_width {
+                            assert_ne!(start, i);
+
+                            for output in &stream_outputs[start..i] {
+                                print!("{}, ", output);
+                            }
+                            println!("{},", &stream_outputs[i]);
+
+                            start = i + 1;
+                        } else {
+                            // Long file name that exceeds
+                            // `terminal_width` by itself
+                            if start == i {
+                                println!("{}", &stream_outputs[i]);
+                                start = i + 1;
+
+                            // `start..i` fits in `terminal_width`
+                            } else {
+                                for output in &stream_outputs[start..(i - 1)] {
+                                    print!("{}, ", output);
+                                }
+                                println!("{},", &stream_outputs[i - 1]);
+
+                                start = i;
+                            }
+                        }
+
+                        continue 'outer;
+                    }
+                }
+                for output in &stream_outputs[start..(stream_outputs.len() - 1)] {
+                    print!("{}, ", output);
+                }
+                // No comma on the very last file name
+                println!("{}", &stream_outputs[stream_outputs.len() - 1]);
+
+                break;
+            }
+        }
+        OutputFormat::OneEntryPerLine => {
+            // Set the `terminal_width` to one to force to single column
+            let paddings = calc_optimal_padding(entries, 1, false);
+
+            let padding = paddings.first().unwrap();
+
+            for entry in entries.iter() {
+                entry.print_multi_column(padding);
+                println!("");
+            }
+        }
+    }
+}
+
+fn ls(paths: Vec<PathBuf>, config: &Config) -> io::Result<u8> {
+    let mut exit_code = 0;
+
+    let mut directories = Vec::new();
+    let mut files = Vec::new();
+
+    // Categorize into directories/files
+    for path in paths {
+        if path.is_dir() {
+            directories.push(path);
+        } else {
+            files.push(path);
+        }
+    }
+
+    let num_directory_args = directories.len();
+    let num_file_args = files.len();
+    let num_args = num_file_args + num_directory_args;
+
+    // Files get processed first
+    let mut file_entries = Vec::new();
+    for path in files {
+        let metadata = match fs::symlink_metadata(&path) {
+            Ok(m) => m,
+            Err(e) => {
+                eprintln!("ls: {e}");
+                exit_code = exit_code.max(1);
+                continue;
+            }
+        };
+        let entry = match Entry::new(
+            &path,
+            path.as_os_str().to_os_string(),
+            &metadata,
+            config,
+            true,
+        ) {
+            Ok(x) => x,
+            Err(e) => {
+                eprintln!("ls: {e}");
+                exit_code = exit_code.max(1);
+                continue;
+            }
+        };
+        file_entries.push(entry);
+    }
+    if !file_entries.is_empty() {
+        display_entries(&mut file_entries, config, None);
+    }
+
+    let mut is_first_dir_arg = true;
+    for path in directories.into_iter() {
+        // Stack for depth-first directory traversal
+        let mut subdirectories = vec![path];
+
+        // Stores visited paths to prevent infinite loops due to symbolic links
+        // Map of canonical path -> path
+        let mut visited: HashMap<PathBuf, PathBuf> = HashMap::new();
+
+        while let Some(dir) = subdirectories.pop() {
+            let canonical_dir_path = fs::canonicalize(&dir)?;
+            if let Some(noncanonical_dir_path) = visited.get(&canonical_dir_path) {
+                eprintln!(
+                    "ls: {}: {}",
+                    ls_from_utf8_lossy(noncanonical_dir_path.as_os_str().as_bytes()),
+                    gettext("not listing already-listed directory")
+                );
+                // This is the only error that has exit code 2 for now.
+                exit_code = exit_code.max(2);
+                continue;
+            }
+
+            visited.insert(canonical_dir_path, dir.clone());
+
+            let mut entries = Vec::new();
+            let mut errors = Vec::new();
+
+            // For sorting the subdirectories on recursion
+            let mut new_subdirectories = Vec::new();
+
+            for dir_entry in fs::read_dir(&dir)? {
+                // Helper closure to easily catch the `io::Error` for printing
+                let process_dir_entry = || -> io::Result<()> {
+                    let dir_entry = dir_entry?;
+
+                    let mut path = dir_entry.path();
+                    let path_str = ls_from_utf8_lossy(path.as_os_str().as_bytes());
+
+                    let mut metadata = dir_entry.metadata().map_err(|e| {
+                        io::Error::other(format!("{} '{path_str}': {e}", gettext("cannot access")))
+                    })?;
+
+                    let file_name_raw = path
+                        .file_name()
+                        .map(|s| s.to_os_string())
+                        .unwrap_or(OsString::from(".."));
+                    let entry = Entry::new(&path, file_name_raw, &metadata, config, false)
+                        .map_err(|e| io::Error::other(format!("'{path_str}': {e}")))?;
+
+                    let mut include_entry = false;
+
+                    // Check if file starts with `.`
+                    let is_hidden_file = {
+                        let byte = dir_entry.file_name().as_bytes()[0];
+                        byte == b'.'
+                    };
+
+                    if is_hidden_file {
+                        match &config.file_inclusion {
+                            FileInclusion::IncludeHidden | FileInclusion::All => {
+                                include_entry = true;
+                            }
+                            FileInclusion::Default => (), // Do nothing
+                        }
+                    } else {
+                        include_entry = true;
+                    }
+
+                    if include_entry {
+                        entries.push(entry);
+
+                        if config.recursive {
+                            if metadata.is_symlink() {
+                                // -L only. On the description for the -R flag:
+                                //
+                                // When a symbolic link to a directory is
+                                // encountered, the directory shall not be
+                                // recursively listed unless the -L option is
+                                // specified
+                                if let DereferenceSymbolicLink::All =
+                                    config.dereference_symbolic_link
+                                {
+                                    path = fs::read_link(&path)?;
+                                    metadata = path.metadata()?;
+                                }
+                            }
+
+                            if metadata.is_dir() {
+                                new_subdirectories.push(path);
+                            }
+                        }
+                    }
+
+                    Ok(())
+                };
+
+                if let Err(e) = process_dir_entry() {
+                    errors.push(e);
+                }
+            }
+
+            new_subdirectories.sort();
+            while let Some(subdir) = new_subdirectories.pop() {
+                subdirectories.push(subdir);
+            }
+
+            // `.` and `..` are excluded from `fs::read_dir` so it's guaranteed
+            // we haven't added them yet.
+            if let FileInclusion::All = &config.file_inclusion {
+                for s in [".", ".."] {
+                    let mut process_dot_dirs = || -> io::Result<()> {
+                        let mut path = dir.clone();
+                        path.push(s);
+
+                        let metadata = fs::symlink_metadata(&path)?;
+                        let entry = Entry::new(&path, OsString::from(s), &metadata, config, false)?;
+
+                        entries.push(entry);
+
+                        Ok(())
+                    };
+
+                    if let Err(e) = process_dot_dirs() {
+                        errors.push(e);
+                    }
+                }
+            }
+
+            // If more than one directory, or a combination of non-directory
+            // files and directories are written, either as a result of
+            // specifying multiple operands, or the -R option
+            let display_directory_header = num_args > 1 || config.recursive;
+
+            let dir_path = ls_from_utf8_lossy(dir.as_os_str().as_bytes());
+            if display_directory_header {
+                if is_first_dir_arg && num_file_args == 0 {
+                    // Trimming the newline on the first directory isn't
+                    // strictly required by the specification
+                    println!("{}:", dir_path);
+                    is_first_dir_arg = false;
+                } else {
+                    println!("\n{}:", dir_path);
+                }
+            }
+
+            for e in errors {
+                eprintln!("ls: {e}");
+                exit_code = exit_code.max(1);
+            }
+
+            if !entries.is_empty() {
+                display_entries(&mut entries, config, Some(&dir_path));
+            }
+        }
+    }
+    Ok(exit_code)
+}
+
+fn main() -> ExitCode {
+    textdomain(PROJECT_NAME).unwrap();
+    bind_textdomain_codeset(PROJECT_NAME, "UTF-8").unwrap();
+
+    let (config, paths) = Config::new();
+
+    match ls(paths, &config) {
+        Ok(exit_code) => {
+            if exit_code == 0 {
+                ExitCode::SUCCESS
+            } else {
+                ExitCode::from(exit_code)
+            }
+        }
+        Err(e) => {
+            eprintln!("ls: {e}");
+            ExitCode::FAILURE
+        }
+    }
+}

--- a/tree/src/ls_util/entry.rs
+++ b/tree/src/ls_util/entry.rs
@@ -1,0 +1,805 @@
+//
+// Copyright (c) 2024 Hemi Labs, Inc.
+//
+// This file is part of the posixutils-rs project covered under
+// the MIT License.  For the full license text, please see the LICENSE
+// file in the root directory of this project.
+// SPDX-License-Identifier: MIT
+//
+
+use super::ls_from_utf8_lossy;
+use crate::{
+    ClassifyFiles, Config, DereferenceSymbolicLink, FileTimeOption, LongFormatOptions,
+    OutputFormat, DATE_TIME_FORMAT_OLD_OR_FUTURE, DATE_TIME_FORMAT_RECENT,
+};
+use chrono::{DateTime, Local};
+use std::cmp::Ordering;
+use std::ffi::{CStr, OsStr, OsString};
+use std::fs;
+use std::io;
+use std::os::unix::ffi::OsStrExt;
+use std::os::unix::fs::{FileTypeExt, MetadataExt};
+use std::path::Path;
+use std::time::{Duration, SystemTime};
+
+enum FileInfo {
+    Size(u64),
+    DeviceInfo((u32, u32)),
+}
+
+// A file in the file system.
+pub struct Entry {
+    file_info: FileInfo,
+    blocks: u64,
+    time: SystemTime,
+    time_string: String,
+
+    file_name_raw: OsString,   // Actual file name, might not be valid UTF-8
+    file_name_display: String, // File name to be displayed
+
+    blocks_str: Option<String>,
+    inode_str: Option<String>,
+    suffix: Option<char>,
+    target_path: Option<String>,
+
+    multi_column_padding: MultiColumnPadding,
+
+    terminal_width: usize,
+
+    long_format_data: Option<LongFormatData>,
+}
+
+impl Entry {
+    pub fn new(
+        path: &Path,
+        file_name_raw: OsString,
+        file_metadata: &fs::Metadata,
+        config: &Config,
+        is_commandline_arg: bool,
+    ) -> io::Result<Self> {
+        let dereference_symlink = match config.dereference_symbolic_link {
+            DereferenceSymbolicLink::CommandLine => is_commandline_arg,
+            DereferenceSymbolicLink::All => true,
+            DereferenceSymbolicLink::None => false,
+        };
+
+        // Rust doesn't seem to understand that this is being used in the
+        // `metadata` if/else below.
+        #[allow(unused_assignments)]
+        let mut dereferenced_metadata = None;
+
+        // If -H or -L are enabled, the metadata to be reported is from the file
+        // that the symbolic link points to.
+        let metadata = if file_metadata.is_symlink() && dereference_symlink {
+            dereferenced_metadata = Some(fs::metadata(path)?);
+            dereferenced_metadata.as_ref().unwrap() // `unwrap` here will never fail
+        } else {
+            file_metadata
+        };
+
+        let mut target_path = None;
+        if metadata.is_symlink() && !dereference_symlink {
+            if let OutputFormat::LongFormat(_) = &config.output_format {
+                let target = fs::read_link(path)?;
+                let os_str = target.as_os_str();
+                target_path = Some(ls_from_utf8_lossy(os_str.as_bytes()));
+            }
+        }
+
+        let file_info = get_file_info(metadata);
+
+        // This `SystemTime` *is* affected by -c or -u
+        let (time, time_string) = get_time_and_time_string(metadata, &config.file_time_option)?;
+
+        let blocks = metadata.blocks();
+        let blocks_str = if config.display_size {
+            // The 2 is because `crate::BLOCK_SIZE_KIBIBYTES` is double that of
+            // `crate::BLOCK_SIZE`
+            let b = if config.kibibytes { blocks / 2 } else { blocks };
+            Some(format!("{}", b))
+        } else {
+            None
+        };
+
+        let inode_str = if config.inode {
+            Some(format!("{}", metadata.ino()))
+        } else {
+            None
+        };
+
+        let long_format_data =
+            if let OutputFormat::LongFormat(long_format_options) = &config.output_format {
+                Some(LongFormatData::new(metadata, long_format_options)?)
+            } else {
+                None
+            };
+
+        let suffix = match config.classify_files {
+            ClassifyFiles::Complete => {
+                if metadata.is_dir() {
+                    Some('/')
+                } else if metadata.is_symlink() {
+                    Some('@')
+                } else {
+                    let file_type = metadata.file_type();
+                    if file_type.is_fifo() {
+                        Some('|')
+                    } else {
+                        let mode = metadata.mode();
+                        if mode & (libc::S_IXUSR | libc::S_IXGRP | libc::S_IXOTH) != 0 {
+                            Some('*')
+                        } else {
+                            None
+                        }
+                    }
+                }
+            }
+            ClassifyFiles::DirectoryOrNotDirectory => {
+                if metadata.is_dir() {
+                    Some('/')
+                } else {
+                    None
+                }
+            }
+            ClassifyFiles::None => None,
+        };
+
+        // let file_name_raw = if is_dot {
+        //     // Because `OsStr::file_name` would return the name of the directory
+        //     // instead of "."
+        //     OsString::from(".")
+        // } else {
+        //     // Returns `None` if `path` ends in ".."
+        //     let file_name = path.file_name();
+
+        //     file_name
+        //         .map(|s| s.to_os_string())
+        //         .unwrap_or(OsString::from(".."))
+        // };
+        let file_name_display = {
+            let tmp = ls_from_utf8_lossy(file_name_raw.as_bytes());
+
+            // -q
+            if config.hide_control_chars {
+                tmp.chars()
+                    .map(|c| if c.is_control() || c == '\t' { '?' } else { c })
+                    .collect()
+            } else {
+                tmp
+            }
+        };
+
+        let mut file_name_width = file_name_display.chars().count();
+        if suffix.is_some() {
+            file_name_width += 1;
+        }
+
+        let mut total_width = file_name_width;
+
+        let inode_str_width = if let Some(inode_str) = &inode_str {
+            let n = inode_str.chars().count();
+            total_width += 1 + n; // Add 1 for the space
+            n
+        } else {
+            0
+        };
+
+        let blocks_str_width = if let Some(blocks_str) = &blocks_str {
+            let n = blocks_str.chars().count();
+            total_width += 1 + n; // Also adding 1 for the space
+            n
+        } else {
+            0
+        };
+
+        let multi_column_padding = MultiColumnPadding {
+            total_width,
+            inode_str_width,
+            blocks_str_width,
+            file_name_width,
+        };
+
+        Ok(Self {
+            file_info,
+            blocks,
+            time,
+            time_string,
+            file_name_raw,
+            file_name_display,
+            blocks_str,
+            inode_str,
+            suffix,
+            target_path,
+            multi_column_padding,
+            terminal_width: config.terminal_width,
+            long_format_data,
+        })
+    }
+
+    /// Return the number of 512-byte blocks allocated to this file.
+    pub fn blocks(&self) -> u64 {
+        self.blocks
+    }
+
+    pub fn file_name_os_str(&self) -> &OsStr {
+        &self.file_name_raw
+    }
+
+    pub fn file_name_str(&self) -> &str {
+        &self.file_name_display
+    }
+
+    /// Sets the width of the inode and blocks to be equal to of the `padding`.
+    ///
+    /// This is for coreutils compatibility. coreutils sets the column widths
+    /// for inode to be all equal, and the same for blocks.
+    pub fn recalculate_widths(&mut self, padding: &MultiColumnPadding) {
+        assert!(padding.inode_str_width >= self.multi_column_padding.inode_str_width);
+        assert!(padding.blocks_str_width >= self.multi_column_padding.blocks_str_width);
+
+        let mut delta = 0;
+        delta += padding.inode_str_width - self.multi_column_padding.inode_str_width;
+        delta += padding.blocks_str_width - self.multi_column_padding.blocks_str_width;
+
+        self.multi_column_padding.inode_str_width = padding.inode_str_width;
+        self.multi_column_padding.blocks_str_width = padding.blocks_str_width;
+
+        self.multi_column_padding.total_width += delta;
+    }
+
+    /// Return the `[inode] [blocks] filename` string.
+    pub fn build_stream_mode_string(&self) -> String {
+        let mut output = String::new();
+
+        if let Some(inode_str) = &self.inode_str {
+            output.push_str(inode_str);
+            output.push(' ');
+        }
+
+        if let Some(blocks_str) = &self.blocks_str {
+            output.push_str(blocks_str);
+            output.push(' ');
+        }
+
+        output.push_str(self.file_name_str());
+
+        if let Some(suffix) = &self.suffix {
+            output.push(*suffix);
+        }
+
+        output
+    }
+
+    /// Print a single grid cell in multi-column format.
+    pub fn print_multi_column(&self, padding: &MultiColumnPadding) {
+        let MultiColumnPadding {
+            total_width,
+            inode_str_width,
+            blocks_str_width,
+            file_name_width,
+        } = padding;
+
+        let inode_str = if let Some(inode_str) = &self.inode_str {
+            format!("{:>inode_str_width$} ", inode_str)
+        } else {
+            String::from("")
+        };
+
+        let blocks_str = if let Some(blocks_str) = &self.blocks_str {
+            format!("{:>blocks_str_width$} ", blocks_str)
+        } else {
+            String::from("")
+        };
+
+        let mut file_name = self.file_name_str().to_string();
+        if let Some(suffix) = &self.suffix {
+            file_name.push(*suffix);
+        }
+
+        let mut file_name_width = *file_name_width;
+
+        // This implies that this will be printed in a single column. Don't
+        // inherit the padding for the longest string to avoid unnecessary
+        // whitespaces.
+        if *total_width > self.terminal_width {
+            file_name_width = 0;
+        }
+
+        print!("{}{}{:<file_name_width$}", inode_str, blocks_str, file_name,);
+    }
+
+    /// Print one row in long format (-l).
+    pub fn println_long_format(&self, padding: &LongFormatPadding) {
+        // Destructure to get the individual fields
+        let LongFormatPadding {
+            blocks_str_width,
+            inode_str_width,
+            num_links_width,
+            owner_name_width,
+            group_name_width,
+            file_size_width,
+            device_id_major_width,
+            device_id_minor_width,
+            time_width,
+        } = padding;
+
+        let Some(long_format_data) = &self.long_format_data else {
+            return;
+        };
+
+        let inode_str = if let Some(inode_str) = &self.inode_str {
+            format!("{:>inode_str_width$} ", inode_str)
+        } else {
+            String::from("")
+        };
+
+        let blocks_str = if let Some(blocks_str) = &self.blocks_str {
+            format!("{:>blocks_str_width$} ", blocks_str)
+        } else {
+            String::from("")
+        };
+
+        // Owner and group names are optional and can be disabled
+        let owner_name = if let Some(owner_name) = &long_format_data.owner_name {
+            format!(" {:<owner_name_width$}", owner_name)
+        } else {
+            String::from("")
+        };
+        let group_name = if let Some(group_name) = &long_format_data.group_name {
+            format!(" {:<group_name_width$}", group_name)
+        } else {
+            String::from("")
+        };
+
+        let file_info = match &self.file_info {
+            FileInfo::Size(size) => size.to_string(),
+            FileInfo::DeviceInfo((major, minor)) => {
+                format!(
+                    "{:>device_id_major_width$}, {:>device_id_minor_width$}",
+                    major, minor
+                )
+            }
+        };
+
+        let mut file_name = self.file_name_str().to_string();
+        if let Some(suffix) = &self.suffix {
+            file_name.push(*suffix);
+        }
+        if let Some(target_path) = &self.target_path {
+            file_name.push_str(" -> ");
+            file_name.push_str(target_path);
+        }
+
+        // Alignment and padding is not mentioned in the specification however
+        // the example given there does have alignment and padding.
+        //
+        // The padding/width is calculated by looping through the directory
+        // contents and using the length of the longest string for each column.
+        //
+        // As for the alignment, <number of links>, <size> or <device info>,
+        // <date and time> are right-aligned and the rest are left-aligned.
+        println!(
+            "{}{}{} {:>num_links_width$}{}{} {:>file_size_width$} {:>time_width$} {}",
+            inode_str,
+            blocks_str,
+            long_format_data.file_mode,
+            long_format_data.num_links,
+            owner_name,
+            group_name,
+            file_info,
+            self.time_string,
+            file_name
+        );
+    }
+
+    /// Comparison key for sorting based on just the file name.
+    pub fn sorting_cmp_lexicographic(&self, other: &Self) -> Ordering {
+        self.file_name_raw.cmp(&other.file_name_raw)
+    }
+
+    // Returns (is_device, size, file_name). The `bool` is to have devices
+    // sorted after normal files.
+    fn sorting_key_size(&self) -> (bool, u64, &OsStr) {
+        match self.file_info {
+            FileInfo::Size(size) => (false, size, &self.file_name_raw),
+            FileInfo::DeviceInfo(_) => (true, 0, &self.file_name_raw),
+        }
+    }
+
+    /// Comparison key for sorting where the primary key is file size and the
+    /// secondary key is the file name.
+    ///
+    /// Character and block devices that have no file size are ordered last with
+    /// only the file name being the sorting key.
+    pub fn sorting_cmp_size(&self, other: &Self) -> Ordering {
+        let self_sorting_key = self.sorting_key_size();
+        let other_sorting_key = other.sorting_key_size();
+
+        match self_sorting_key.0.cmp(&other_sorting_key.0) {
+            Ordering::Equal => {
+                match self_sorting_key.1.cmp(&other_sorting_key.1) {
+                    Ordering::Equal => self_sorting_key.2.cmp(&other_sorting_key.2),
+                    r => r.reverse(), // Default is from largest file size to smallest
+                }
+            }
+            r => r,
+        }
+    }
+
+    /// Comparison key for sorting where the primary key is time and the
+    /// secondary key is the file name.
+    ///
+    /// The kind of time is dependent on the flags -t, -c, -u.
+    pub fn sorting_cmp_time(&self, other: &Self) -> Ordering {
+        match self.time.cmp(&other.time) {
+            Ordering::Equal => self.file_name_raw.cmp(&other.file_name_raw),
+            r => r.reverse(), // Default is newest to oldest
+        }
+    }
+
+    pub fn get_multi_column_padding(&self) -> &MultiColumnPadding {
+        &self.multi_column_padding
+    }
+
+    /// Return the minimum required padding for each column of this `Entry` in
+    /// long format mode.
+    pub fn get_long_format_padding(&self) -> LongFormatPadding {
+        // Calculate the length of the resulting string when `v` is converted.
+        fn decimal_str_len(v: u64) -> usize {
+            if v == 0 {
+                1
+            } else {
+                v.ilog10() as usize + 1
+            }
+        }
+
+        let blocks_str_width = self.multi_column_padding.blocks_str_width;
+
+        let inode_str_width = self.multi_column_padding.inode_str_width;
+
+        let (num_links_width, owner_name_width, group_name_width) = self
+            .long_format_data
+            .as_ref()
+            .map(|d| {
+                let num_links_width = d.num_links.chars().count();
+                let owner_name_width = d
+                    .owner_name
+                    .as_ref()
+                    .map(|s| s.chars().count())
+                    .unwrap_or(0);
+                let group_name_width = d
+                    .group_name
+                    .as_ref()
+                    .map(|s| s.chars().count())
+                    .unwrap_or(0);
+                (num_links_width, owner_name_width, group_name_width)
+            })
+            .unwrap_or((0, 0, 0));
+
+        let file_size_width = match &self.file_info {
+            FileInfo::Size(s) => decimal_str_len(*s),
+            FileInfo::DeviceInfo(_) => 0,
+        };
+
+        let (device_id_major_width, device_id_minor_width) = match &self.file_info {
+            FileInfo::Size(_) => (0, 0),
+            FileInfo::DeviceInfo((major, minor)) => (
+                decimal_str_len(*major as u64),
+                decimal_str_len(*minor as u64),
+            ),
+        };
+
+        let time_width = self.time_string.chars().count();
+
+        LongFormatPadding {
+            blocks_str_width,
+            inode_str_width,
+            num_links_width,
+            owner_name_width,
+            group_name_width,
+            file_size_width,
+            device_id_major_width,
+            device_id_minor_width,
+            time_width,
+        }
+    }
+}
+
+// Used for padding in long format
+pub struct LongFormatPadding {
+    pub blocks_str_width: usize,
+    pub inode_str_width: usize,
+    pub num_links_width: usize,
+    pub owner_name_width: usize,
+    pub group_name_width: usize,
+    pub file_size_width: usize,
+    pub device_id_major_width: usize,
+    pub device_id_minor_width: usize,
+    pub time_width: usize,
+}
+
+impl Default for LongFormatPadding {
+    fn default() -> Self {
+        Self {
+            blocks_str_width: 0,
+            inode_str_width: 0,
+            num_links_width: 0,
+            owner_name_width: 0,
+            group_name_width: 0,
+            file_size_width: 0,
+            device_id_major_width: 0,
+            device_id_minor_width: 0,
+            time_width: 0,
+        }
+    }
+}
+
+impl LongFormatPadding {
+    /// Get the maximum padding for each field.
+    pub fn update_maximum(&mut self, other: &LongFormatPadding) {
+        self.blocks_str_width = usize::max(self.blocks_str_width, other.blocks_str_width);
+        self.inode_str_width = usize::max(self.inode_str_width, other.inode_str_width);
+        self.num_links_width = usize::max(self.num_links_width, other.num_links_width);
+        self.owner_name_width = usize::max(self.owner_name_width, other.owner_name_width);
+        self.group_name_width = usize::max(self.group_name_width, other.group_name_width);
+        self.file_size_width = usize::max(self.file_size_width, other.file_size_width);
+        self.device_id_major_width =
+            usize::max(self.device_id_major_width, other.device_id_major_width);
+        self.device_id_minor_width =
+            usize::max(self.device_id_minor_width, other.device_id_minor_width);
+        self.time_width = usize::max(self.time_width, other.time_width);
+    }
+
+    /// Compare the width of the file size string with the width of the device
+    /// ID string and use the largest.
+    ///
+    /// This needs to be called after looping through all the entries to get the
+    /// maximum width for both file size and device ID.
+    pub fn update_file_info_padding(&mut self) {
+        let mut device_id_width = self.device_id_major_width + self.device_id_minor_width;
+        if device_id_width > 0 {
+            // +2 for the ", " separator
+            device_id_width += 2;
+        }
+
+        self.file_size_width = usize::max(self.file_size_width, device_id_width);
+    }
+}
+
+// Used for padding in multi-column format
+pub struct MultiColumnPadding {
+    pub total_width: usize,
+    pub inode_str_width: usize,
+    pub blocks_str_width: usize,
+    pub file_name_width: usize,
+}
+
+impl Default for MultiColumnPadding {
+    fn default() -> Self {
+        Self {
+            total_width: 0,
+            inode_str_width: 0,
+            blocks_str_width: 0,
+            file_name_width: 0,
+        }
+    }
+}
+
+impl MultiColumnPadding {
+    pub fn update_maximum(&mut self, other: &MultiColumnPadding) {
+        self.total_width = usize::max(self.total_width, other.total_width);
+        self.inode_str_width = usize::max(self.inode_str_width, other.inode_str_width);
+        self.blocks_str_width = usize::max(self.blocks_str_width, other.blocks_str_width);
+        self.file_name_width = usize::max(self.file_name_width, other.file_name_width);
+    }
+}
+
+// Data that is only needed in long format mode.
+struct LongFormatData {
+    file_mode: String,
+    num_links: String,
+    owner_name: Option<String>,
+    group_name: Option<String>,
+}
+
+impl LongFormatData {
+    pub fn new(
+        metadata: &fs::Metadata,
+        long_format_options: &LongFormatOptions,
+    ) -> io::Result<Self> {
+        let file_mode = get_file_mode_string(metadata);
+
+        let num_links = metadata.nlink().to_string();
+
+        let owner_name = if long_format_options.without_owner {
+            None
+        } else {
+            Some(get_owner_name(
+                metadata,
+                long_format_options.numeric_uid_gid,
+            )?)
+        };
+
+        let group_name = if long_format_options.without_group {
+            None
+        } else {
+            Some(get_group_name(
+                metadata,
+                long_format_options.numeric_uid_gid,
+            )?)
+        };
+
+        Ok(Self {
+            file_mode,
+            num_links,
+            owner_name,
+            group_name,
+        })
+    }
+}
+
+fn get_file_mode_string(metadata: &fs::Metadata) -> String {
+    let mut file_mode = String::with_capacity(10);
+
+    let file_type = metadata.file_type();
+
+    // Entry type
+    file_mode.push(if file_type.is_dir() {
+        'd'
+    } else if file_type.is_block_device() {
+        'b'
+    } else if file_type.is_char_device() {
+        'c'
+    } else if file_type.is_symlink() {
+        'l'
+    } else if file_type.is_fifo() {
+        'p'
+    } else {
+        '-'
+    });
+
+    let mode = metadata.mode();
+
+    // Owner permissions
+    file_mode.push(if mode & libc::S_IRUSR != 0 { 'r' } else { '-' });
+    file_mode.push(if mode & libc::S_IWUSR != 0 { 'w' } else { '-' });
+    file_mode.push({
+        let executable = mode & libc::S_IXUSR != 0;
+        let set_user_id = mode & libc::S_ISUID != 0;
+        match (executable, set_user_id) {
+            (true, true) => 's',
+            (true, false) => 'x',
+            (false, true) => 'S',
+            (false, false) => '-',
+        }
+    });
+
+    // Group permissions
+    file_mode.push(if mode & libc::S_IRGRP != 0 { 'r' } else { '-' });
+    file_mode.push(if mode & libc::S_IWGRP != 0 { 'w' } else { '-' });
+    file_mode.push(if mode & libc::S_IXGRP != 0 { 'x' } else { '-' });
+
+    // Other permissions
+    file_mode.push(if mode & libc::S_IROTH != 0 { 'r' } else { '-' });
+    file_mode.push(if mode & libc::S_IWOTH != 0 { 'w' } else { '-' });
+    file_mode.push({
+        if file_type.is_dir() {
+            let searchable = mode & libc::S_IXOTH != 0;
+            let restricted_deletion = mode & libc::S_ISVTX != 0;
+            match (searchable, restricted_deletion) {
+                (true, true) => 't',
+                (true, false) => 'x',
+                (false, true) => 'T',
+                (false, false) => '-',
+            }
+        } else {
+            if mode & libc::S_IXOTH != 0 {
+                'x'
+            } else {
+                '-'
+            }
+        }
+    });
+
+    file_mode
+}
+
+fn get_owner_name(metadata: &fs::Metadata, numeric: bool) -> io::Result<String> {
+    let uid = metadata.uid();
+    if numeric {
+        Ok(uid.to_string())
+    } else {
+        unsafe {
+            let passwd = libc::getpwuid(uid);
+            if passwd.is_null() {
+                return Err(io::Error::last_os_error());
+            }
+            let passwd_ref = &*passwd;
+            let name = CStr::from_ptr(passwd_ref.pw_name);
+            Ok(ls_from_utf8_lossy(name.to_bytes()))
+        }
+    }
+}
+
+fn get_group_name(metadata: &fs::Metadata, numeric: bool) -> io::Result<String> {
+    let gid = metadata.gid();
+    if numeric {
+        Ok(gid.to_string())
+    } else {
+        unsafe {
+            let group = libc::getgrgid(gid);
+            if group.is_null() {
+                return Err(io::Error::last_os_error());
+            }
+            let group_ref = &*group;
+            let name = CStr::from_ptr(group_ref.gr_name);
+            Ok(ls_from_utf8_lossy(name.to_bytes()))
+        }
+    }
+}
+
+fn get_file_info(metadata: &fs::Metadata) -> FileInfo {
+    let file_type = metadata.file_type();
+    if file_type.is_char_device() || file_type.is_block_device() {
+        let device_id = metadata.rdev();
+
+        // major ID - class of the device
+        // minor ID - specific instance of a device
+        let (major, minor) = unsafe { (libc::major(device_id), libc::minor(device_id)) };
+
+        FileInfo::DeviceInfo((major, minor))
+    } else {
+        FileInfo::Size(metadata.size())
+    }
+}
+
+fn get_system_time(
+    metadata: &fs::Metadata,
+    file_time_option: &FileTimeOption,
+) -> io::Result<SystemTime> {
+    let time = match file_time_option {
+        FileTimeOption::LastModificationTime => metadata.modified()?,
+        FileTimeOption::LastAcessTime => metadata.accessed()?,
+        FileTimeOption::LastStatusChangeTime => {
+            let seconds_since_epoch =
+                u64::try_from(metadata.ctime()).map_err(|_| io::Error::other("negative ctime"))?;
+            SystemTime::UNIX_EPOCH
+                .checked_add(Duration::from_secs(seconds_since_epoch))
+                .ok_or(io::Error::other("`SystemTime` overflow"))?
+        }
+    };
+    Ok(time)
+}
+
+fn get_time_and_time_string(
+    metadata: &fs::Metadata,
+    file_time_option: &FileTimeOption,
+) -> io::Result<(SystemTime, String)> {
+    let time = get_system_time(metadata, file_time_option)?;
+
+    let dt_format = {
+        // The specification says to base it of "last modification time"
+        // without any mention of -c or -u
+        let last_modified_time = get_system_time(metadata, &FileTimeOption::LastModificationTime)?;
+        let now = SystemTime::now();
+
+        match now.duration_since(last_modified_time) {
+            Ok(duration) => {
+                const SIX_MONTHS: Duration = Duration::from_secs(3600 * 24 * 30 * 6);
+                if duration > SIX_MONTHS {
+                    DATE_TIME_FORMAT_OLD_OR_FUTURE // Old
+                } else {
+                    DATE_TIME_FORMAT_RECENT
+                }
+            }
+            Err(_) => DATE_TIME_FORMAT_OLD_OR_FUTURE, // Future
+        }
+    };
+
+    let time_string = {
+        // chrono parses the TZ environment variable in this conversion
+        let dt: DateTime<Local> = time.into();
+        dt.format(dt_format).to_string()
+    };
+    Ok((time, time_string))
+}

--- a/tree/src/ls_util/mod.rs
+++ b/tree/src/ls_util/mod.rs
@@ -1,0 +1,14 @@
+//
+// Copyright (c) 2024 Hemi Labs, Inc.
+//
+// This file is part of the posixutils-rs project covered under
+// the MIT License.  For the full license text, please see the LICENSE
+// file in the root directory of this project.
+// SPDX-License-Identifier: MIT
+//
+
+mod entry;
+mod utf8_lossy;
+
+pub use entry::{Entry, LongFormatPadding, MultiColumnPadding};
+pub use utf8_lossy::ls_from_utf8_lossy;

--- a/tree/src/ls_util/utf8_lossy.rs
+++ b/tree/src/ls_util/utf8_lossy.rs
@@ -1,0 +1,189 @@
+//
+// Copyright (c) 2024 Hemi Labs, Inc.
+//
+// This file is part of the posixutils-rs project covered under
+// the MIT License.  For the full license text, please see the LICENSE
+// file in the root directory of this project.
+// SPDX-License-Identifier: MIT
+//
+
+//! Straight copy of experimental API `std::str::Utf8Chunks` for usage in stable
+//! Rust.
+//!
+//! https://doc.rust-lang.org/std/str/struct.Utf8Chunks.html
+//!
+//! Alternative is to use the `bstr` crate:
+//!
+//! https://docs.rs/bstr/latest/bstr/struct.Utf8Chunks.html
+
+const UTF8_CHAR_WIDTH: &[u8; 256] = &[
+    // 1  2  3  4  5  6  7  8  9  A  B  C  D  E  F
+    1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, // 0
+    1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, // 1
+    1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, // 2
+    1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, // 3
+    1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, // 4
+    1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, // 5
+    1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, // 6
+    1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, // 7
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, // 8
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, // 9
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, // A
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, // B
+    0, 0, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, // C
+    2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, // D
+    3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, // E
+    4, 4, 4, 4, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, // F
+];
+
+const fn utf8_char_width(b: u8) -> usize {
+    UTF8_CHAR_WIDTH[b as usize] as usize
+}
+
+pub struct Utf8Chunk<'a> {
+    valid: &'a str,
+    invalid: &'a [u8],
+}
+
+impl<'a> Utf8Chunk<'a> {
+    pub fn valid(&self) -> &'a str {
+        self.valid
+    }
+
+    pub fn invalid(&self) -> &'a [u8] {
+        self.invalid
+    }
+}
+
+#[derive(Clone)]
+pub struct Utf8Chunks<'a> {
+    source: &'a [u8],
+}
+
+impl<'a> Utf8Chunks<'a> {
+    pub fn new(bytes: &'a [u8]) -> Self {
+        Self { source: bytes }
+    }
+}
+
+impl<'a> Iterator for Utf8Chunks<'a> {
+    type Item = Utf8Chunk<'a>;
+
+    fn next(&mut self) -> Option<Utf8Chunk<'a>> {
+        if self.source.is_empty() {
+            return None;
+        }
+
+        const TAG_CONT_U8: u8 = 128;
+        fn safe_get(xs: &[u8], i: usize) -> u8 {
+            *xs.get(i).unwrap_or(&0)
+        }
+
+        let mut i = 0;
+        let mut valid_up_to = 0;
+        while i < self.source.len() {
+            // SAFETY: `i < self.source.len()` per previous line.
+            // For some reason the following are both significantly slower:
+            // while let Some(&byte) = self.source.get(i) {
+            // while let Some(byte) = self.source.get(i).copied() {
+            let byte = unsafe { *self.source.get_unchecked(i) };
+            i += 1;
+
+            if byte < 128 {
+                // This could be a `1 => ...` case in the match below, but for
+                // the common case of all-ASCII inputs, we bypass loading the
+                // sizeable UTF8_CHAR_WIDTH table into cache.
+            } else {
+                let w = utf8_char_width(byte);
+
+                match w {
+                    2 => {
+                        if safe_get(self.source, i) & 192 != TAG_CONT_U8 {
+                            break;
+                        }
+                        i += 1;
+                    }
+                    3 => {
+                        match (byte, safe_get(self.source, i)) {
+                            (0xE0, 0xA0..=0xBF) => (),
+                            (0xE1..=0xEC, 0x80..=0xBF) => (),
+                            (0xED, 0x80..=0x9F) => (),
+                            (0xEE..=0xEF, 0x80..=0xBF) => (),
+                            _ => break,
+                        }
+                        i += 1;
+                        if safe_get(self.source, i) & 192 != TAG_CONT_U8 {
+                            break;
+                        }
+                        i += 1;
+                    }
+                    4 => {
+                        match (byte, safe_get(self.source, i)) {
+                            (0xF0, 0x90..=0xBF) => (),
+                            (0xF1..=0xF3, 0x80..=0xBF) => (),
+                            (0xF4, 0x80..=0x8F) => (),
+                            _ => break,
+                        }
+                        i += 1;
+                        if safe_get(self.source, i) & 192 != TAG_CONT_U8 {
+                            break;
+                        }
+                        i += 1;
+                        if safe_get(self.source, i) & 192 != TAG_CONT_U8 {
+                            break;
+                        }
+                        i += 1;
+                    }
+                    _ => break,
+                }
+            }
+
+            valid_up_to = i;
+        }
+
+        let (inspected, remaining) = self.source.split_at(i);
+        self.source = remaining;
+
+        let (valid, invalid) = inspected.split_at(valid_up_to);
+
+        Some(Utf8Chunk {
+            // SAFETY: All bytes up to `valid_up_to` are valid UTF-8.
+            valid: unsafe { std::str::from_utf8_unchecked(valid) },
+            invalid,
+        })
+    }
+}
+
+/// `String::from_utf8_lossy` modified to use "?" as the replacement character.
+///
+/// This only replaces invalid UTF-8 characters with "?". -q still needs to be
+/// enabled to replace other non-printable characters and <tab>.
+pub fn ls_from_utf8_lossy(v: &[u8]) -> String {
+    let mut iter = Utf8Chunks::new(v);
+
+    let first_valid = if let Some(chunk) = iter.next() {
+        let valid = chunk.valid();
+        if chunk.invalid().is_empty() {
+            debug_assert_eq!(valid.len(), v.len());
+            return valid.to_string();
+        }
+        valid
+    } else {
+        return String::from("");
+    };
+
+    const REPLACEMENT: &str = "?";
+
+    let mut res = String::with_capacity(v.len());
+    res.push_str(first_valid);
+    res.push_str(REPLACEMENT);
+
+    for chunk in iter {
+        res.push_str(chunk.valid());
+        if !chunk.invalid().is_empty() {
+            res.push_str(REPLACEMENT);
+        }
+    }
+
+    res
+}

--- a/tree/tests/integration.rs
+++ b/tree/tests/integration.rs
@@ -1,0 +1,686 @@
+//
+// Copyright (c) 2024 Hemi Labs, Inc.
+//
+// This file is part of the posixutils-rs project covered under
+// the MIT License.  For the full license text, please see the LICENSE
+// file in the root directory of this project.
+// SPDX-License-Identifier: MIT
+//
+
+use plib::{run_test, run_test_with_checker, TestPlan};
+use regex::Regex;
+use std::ffi::CString;
+use std::fs;
+use std::io::{self, Write};
+use std::os::unix::fs::MetadataExt;
+use std::path::Path;
+use std::thread;
+use std::time::Duration;
+
+fn get_errno() -> i32 {
+    io::Error::last_os_error().raw_os_error().unwrap()
+}
+
+fn create_dir_if_not_exists(path: &str) -> io::Result<()> {
+    match fs::create_dir(path) {
+        Ok(_) => Ok(()),
+        Err(e) => {
+            if e.kind() == io::ErrorKind::AlreadyExists {
+                Ok(())
+            } else {
+                Err(e)
+            }
+        }
+    }
+}
+
+fn create_file_if_not_exists(path: &str) -> io::Result<()> {
+    match fs::File::create(path) {
+        Ok(_) => Ok(()),
+        Err(e) => {
+            if e.kind() == io::ErrorKind::AlreadyExists {
+                Ok(())
+            } else {
+                Err(e)
+            }
+        }
+    }
+}
+
+fn create_symlink_if_not_exists(original: &str, link: &str) -> io::Result<()> {
+    // `fs::canonicalize` is important here. If it's left out then the
+    // symbolic link cannot be followed with -L.
+    match std::os::unix::fs::symlink(fs::canonicalize(original).unwrap(), link) {
+        Ok(_) => Ok(()),
+        Err(e) => {
+            if e.kind() == io::ErrorKind::AlreadyExists {
+                Ok(())
+            } else {
+                Err(e)
+            }
+        }
+    }
+}
+
+enum TimeToChange<'a> {
+    Accessed(&'a str),
+    Modified(&'a str),
+    Both(&'a str),
+}
+
+fn change_file_time(path: &str, time: TimeToChange) {
+    let s = match &time {
+        TimeToChange::Accessed(s) => s,
+        TimeToChange::Modified(s) => s,
+        TimeToChange::Both(s) => s,
+    };
+    let dt =
+        chrono::DateTime::parse_from_str(&format!("{s} +0000"), "%Y-%m-%d %H:%M:%S %z").unwrap();
+    let tv_sec = dt.timestamp();
+    let tv_usec = dt.timestamp_subsec_micros() as i64;
+
+    unsafe {
+        let filename = CString::new(path).unwrap();
+        let mut times = [libc::timeval { tv_sec, tv_usec }; 2];
+        match &time {
+            TimeToChange::Both(_) => (),
+            other => {
+                let metadata = Path::new(path).metadata().unwrap();
+
+                match other {
+                    TimeToChange::Accessed(_) => {
+                        let modified_dt: chrono::DateTime<chrono::Utc> =
+                            metadata.modified().unwrap().into();
+                        let tv_sec = modified_dt.timestamp();
+                        let tv_usec = modified_dt.timestamp_subsec_micros() as i64;
+                        times[1] = libc::timeval { tv_sec, tv_usec }
+                    }
+                    TimeToChange::Modified(_) => {
+                        let accessed_dt: chrono::DateTime<chrono::Utc> =
+                            metadata.accessed().unwrap().into();
+                        let tv_sec = accessed_dt.timestamp();
+                        let tv_usec = accessed_dt.timestamp_subsec_micros() as i64;
+                        times[0] = libc::timeval { tv_sec, tv_usec }
+                    }
+                    _ => unreachable!(),
+                }
+            }
+        }
+        let ret = libc::utimes(filename.as_ptr(), times.as_ptr());
+        if ret != 0 {
+            panic!("{}", io::Error::last_os_error());
+        }
+    }
+}
+
+fn ls_test(args: &[&str], expected_output: &str, expected_error: &str, expected_exit_code: i32) {
+    let str_args: Vec<String> = args.iter().map(|s| String::from(*s)).collect();
+
+    run_test(TestPlan {
+        cmd: String::from("ls"),
+        args: str_args,
+        stdin_data: String::new(),
+        expected_out: String::from(expected_output),
+        expected_err: String::from(expected_error),
+        expected_exit_code: expected_exit_code,
+    });
+}
+
+fn ls_test_with_checker<F: FnMut(&TestPlan, &std::process::Output)>(args: &[&str], checker: F) {
+    let str_args: Vec<String> = args.iter().map(|s| String::from(*s)).collect();
+
+    let test_plan = TestPlan {
+        cmd: String::from("ls"),
+        args: str_args,
+        stdin_data: String::new(),
+        expected_out: String::new(),
+        expected_err: String::new(),
+        expected_exit_code: 0,
+    };
+
+    run_test_with_checker(test_plan, checker);
+}
+
+// Port of coreutils/tests/ls/a-option.sh
+#[test]
+fn test_ls_empty_directory() {
+    let test_dir = "tests/ls/tmp/empty_directory";
+    create_dir_if_not_exists(test_dir).unwrap();
+    ls_test(&["-aA", test_dir], "", "", 0);
+}
+
+// Partial port of coreutils/tests/ls/dangle.sh
+// Not including substituting missing metadata with "?" which is non-standard
+#[test]
+fn test_ls_dangle() {
+    let test_dir = "tests/ls/tmp/dangle";
+    let dangle = "tests/ls/tmp/dangle/dangle";
+    let dir = "tests/ls/tmp/dangle/dir";
+    let dir_sub = "tests/ls/tmp/dangle/dir/sub";
+    let slink_to_dir = "tests/ls/tmp/dangle/slink-to-dir";
+
+    create_dir_if_not_exists(test_dir).unwrap();
+    create_dir_if_not_exists(dir).unwrap();
+    create_dir_if_not_exists(dir_sub).unwrap();
+
+    if let Err(e) = std::os::unix::fs::symlink("no-such-file", dangle) {
+        if e.kind() != io::ErrorKind::AlreadyExists {
+            panic!("{}", e);
+        }
+    }
+
+    create_symlink_if_not_exists(dir, slink_to_dir).unwrap();
+
+    // Must fail to dereference the symlink
+    ls_test(
+        &["-L", dangle],
+        "",
+        "ls: No such file or directory (os error 2)\n",
+        1,
+    );
+    ls_test(
+        &["-H", dangle],
+        "",
+        "ls: No such file or directory (os error 2)\n",
+        1,
+    );
+
+    // Not using -H or -L should cause it to succeed
+    ls_test(&[dangle], &format!("{dangle}\n"), "", 0);
+
+    // slink_to_dir is a proper symlink so these three should all succeed
+    ls_test(&[slink_to_dir], "sub\n", "", 0);
+    ls_test(&["-H", slink_to_dir], "sub\n", "", 0);
+    ls_test(&["-L", slink_to_dir], "sub\n", "", 0);
+}
+
+// Partial port of coreutils/tests/ls/file-type.sh
+// --indicator-style and --color non-standard so are not included.
+//
+// This test will skip the block/character devices if not run with sudo:
+// `sudo -E cargo test`
+#[test]
+fn test_ls_file_type() {
+    let test_dir = "tests/ls/tmp/file_type";
+    let sub = "tests/ls/tmp/file_type/sub";
+    let dir = "tests/ls/tmp/file_type/sub/dir";
+    let regular = "tests/ls/tmp/file_type/sub/regular";
+    let executable = "tests/ls/tmp/file_type/sub/executable";
+    let slink_reg = "tests/ls/tmp/file_type/sub/slink-reg";
+    let slink_dir = "tests/ls/tmp/file_type/sub/slink-dir";
+    let slink_dangle = "tests/ls/tmp/file_type/sub/slink-dangle";
+    let block = "tests/ls/tmp/file_type/sub/block";
+    let char = "tests/ls/tmp/file_type/sub/char";
+    let fifo = "tests/ls/tmp/file_type/sub/fifo";
+    let block_cstr = CString::new(block).unwrap();
+    let char_cstr = CString::new(char).unwrap();
+    let fifo_cstr = CString::new(fifo).unwrap();
+
+    create_dir_if_not_exists(test_dir).unwrap();
+    create_dir_if_not_exists(sub).unwrap();
+    create_dir_if_not_exists(dir).unwrap();
+
+    create_file_if_not_exists(regular).unwrap();
+
+    unsafe {
+        // `create_file_if_not_exists` would get permission denied if used here
+        if !Path::new(executable).exists() {
+            fs::File::create(executable).unwrap();
+        }
+
+        let executable_cstr = CString::new(executable).unwrap();
+
+        // Executable for all
+        let mode = libc::S_IXUSR | libc::S_IXGRP | libc::S_IXOTH;
+
+        let ret = libc::chmod(executable_cstr.as_ptr(), mode);
+        if ret != 0 {
+            panic!("{}", io::Error::last_os_error());
+        }
+    }
+
+    create_symlink_if_not_exists(regular, slink_reg).unwrap();
+    create_symlink_if_not_exists(dir, slink_dir).unwrap();
+
+    if let Err(e) = std::os::unix::fs::symlink("nowhere", slink_dangle) {
+        if e.kind() != io::ErrorKind::AlreadyExists {
+            panic!("{}", e);
+        }
+    }
+
+    let mut skip_device_files = false;
+
+    unsafe {
+        // Creating files with S_IFBLK or S_IFCHR requires superuser.
+        let ret = libc::mknod(block_cstr.as_ptr(), libc::S_IFBLK, libc::makedev(20, 20));
+        if ret != 0 {
+            match get_errno() {
+                libc::EEXIST => (),
+                libc::EPERM => skip_device_files = true,
+                _ => panic!("{}", io::Error::last_os_error()),
+            }
+        }
+        let ret = libc::mknod(char_cstr.as_ptr(), libc::S_IFCHR, libc::makedev(10, 10));
+        if ret != 0 {
+            match get_errno() {
+                libc::EEXIST => (),
+                libc::EPERM => skip_device_files = true,
+                _ => panic!("{}", io::Error::last_os_error()),
+            }
+        }
+
+        // rw-r--r--
+        let mode = libc::S_IRUSR | libc::S_IWUSR | libc::S_IRGRP | libc::S_IROTH;
+        let ret = libc::mkfifo(fifo_cstr.as_ptr(), mode);
+        if ret != 0 {
+            if get_errno() != libc::EEXIST {
+                panic!("{}", io::Error::last_os_error());
+            }
+        }
+    }
+
+    let ls_f_result = "dir/\nexecutable*\nfifo|\nregular\nslink-dangle@\nslink-dir@\nslink-reg@\n";
+    if !skip_device_files {
+        ls_test(&["-F", sub], &format!("block\nchar\n{ls_f_result}"), "", 0);
+    } else {
+        ls_test(&["-F", sub], ls_f_result, "", 0);
+    }
+
+    let ls_p_result = "dir/\nexecutable\nfifo\nregular\nslink-dangle\nslink-dir\nslink-reg\n";
+    if !skip_device_files {
+        ls_test(&["-p", sub], &format!("block\nchar\n{ls_p_result}"), "", 0);
+    } else {
+        ls_test(&["-p", sub], ls_p_result, "", 0);
+    }
+}
+
+// Port of coreutils/tests/ls/infloop.sh
+#[test]
+fn test_ls_infloop() {
+    let test_dir = "tests/ls/tmp/infloop";
+    let loop_dir = "tests/ls/tmp/infloop/loop";
+    let loop_sub = "tests/ls/tmp/infloop/loop/sub";
+
+    create_dir_if_not_exists(test_dir).unwrap();
+    create_dir_if_not_exists(loop_dir).unwrap();
+    create_symlink_if_not_exists(loop_dir, loop_sub).unwrap();
+
+    ls_test(
+        &["-RL", loop_sub],
+        &format!("{loop_sub}:\nsub\n"),
+        &format!("ls: {loop_sub}: not listing already-listed directory\n"),
+        2,
+    );
+}
+
+// Port of coreutils/tests/ls/inode.sh
+#[test]
+fn test_ls_inode() {
+    let test_dir = "tests/ls/tmp/inode";
+    let original = "tests/ls/tmp/inode/f";
+    let link = "tests/ls/tmp/inode/slink";
+
+    let re = Regex::new(r"(\d+) .*f\s+(\d+) .*slink").unwrap();
+
+    create_dir_if_not_exists(test_dir).unwrap();
+    create_file_if_not_exists(original).unwrap();
+    create_symlink_if_not_exists(original, link).unwrap();
+
+    // Args passed in command line
+    // Different inode numbers without -H or -L
+    ls_test_with_checker(&["-Ci", original, link], |_, output| {
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let captures = re.captures(&stdout).unwrap();
+        let inode_f: u64 = captures.get(1).unwrap().as_str().parse().unwrap();
+        let inode_slink: u64 = captures.get(2).unwrap().as_str().parse().unwrap();
+        assert_ne!(inode_f, inode_slink);
+        assert_eq!(output.status.code(), Some(0));
+    });
+
+    // Args passed in command line
+    // Same inode numbers with -L
+    ls_test_with_checker(&["-CLi", original, link], |_, output| {
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let captures = re.captures(&stdout).unwrap();
+        let inode_f: u64 = captures.get(1).unwrap().as_str().parse().unwrap();
+        let inode_slink: u64 = captures.get(2).unwrap().as_str().parse().unwrap();
+        assert_eq!(inode_f, inode_slink);
+        assert_eq!(output.status.code(), Some(0));
+    });
+
+    // Args passed in command line
+    // Same inode numbers with -H
+    ls_test_with_checker(&["-CHi", original, link], |_, output| {
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let captures = re.captures(&stdout).unwrap();
+        let inode_f: u64 = captures.get(1).unwrap().as_str().parse().unwrap();
+        let inode_slink: u64 = captures.get(2).unwrap().as_str().parse().unwrap();
+        assert_eq!(inode_f, inode_slink);
+        assert_eq!(output.status.code(), Some(0));
+    });
+
+    // Files in directory
+    // Different inode numbers without -L
+    ls_test_with_checker(&["-Ci", test_dir], |_, output| {
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let captures = re.captures(&stdout).unwrap();
+        let inode_f: u64 = captures.get(1).unwrap().as_str().parse().unwrap();
+        let inode_slink: u64 = captures.get(2).unwrap().as_str().parse().unwrap();
+        assert_ne!(inode_f, inode_slink);
+        assert_eq!(output.status.code(), Some(0));
+    });
+
+    // Files in directory
+    // Same inode numbers with -L
+    ls_test_with_checker(&["-CLi", test_dir], |_, output| {
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let captures = re.captures(&stdout).unwrap();
+        let inode_f: u64 = captures.get(1).unwrap().as_str().parse().unwrap();
+        let inode_slink: u64 = captures.get(2).unwrap().as_str().parse().unwrap();
+        assert_eq!(inode_f, inode_slink);
+        assert_eq!(output.status.code(), Some(0));
+    });
+
+    // Files in directory
+    // Different inode numbers even with -H
+    ls_test_with_checker(&["-CHi", test_dir], |_, output| {
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let captures = re.captures(&stdout).unwrap();
+        let inode_f: u64 = captures.get(1).unwrap().as_str().parse().unwrap();
+        let inode_slink: u64 = captures.get(2).unwrap().as_str().parse().unwrap();
+        assert_ne!(inode_f, inode_slink);
+        assert_eq!(output.status.code(), Some(0));
+    });
+}
+
+// Partial port of coreutils/tests/ls/m-option.sh
+// The -w argument is non-POSIX.
+#[test]
+fn test_ls_m_option() {
+    let test_dir = "tests/ls/tmp/m_option";
+    let a = "tests/ls/tmp/m_option/a";
+    let b = "tests/ls/tmp/m_option/b";
+
+    create_dir_if_not_exists(test_dir).unwrap();
+    create_file_if_not_exists(a).unwrap();
+    if !Path::new(b).exists() {
+        let mut file = fs::File::create(b).unwrap();
+
+        for i in 1..=2000 {
+            let s = format!("{i}\n");
+            file.write_all(s.as_bytes()).unwrap();
+        }
+    }
+
+    // Original test is using -w2 here
+    ls_test(&["-m", a, b], &format!("{a}, {b}\n"), "", 0);
+
+    // -k for 1024-byte block sizes which is the default for coreutils. Default
+    // for this implementation is 512-byte blocks as mentioned in the STDOUT
+    // section of:
+    // https://pubs.opengroup.org/onlinepubs/9699919799/utilities/ls.html
+    ls_test(&["-smk", a, b], &format!("0 {a}, 12 {b}\n"), "", 0);
+}
+
+// Port of coreutils/tests/ls/no-arg.sh
+#[test]
+fn test_ls_no_arg() {
+    // `ps::run_test` but sets the working directory for the child process
+    fn ls_run_test(test_dir: &str, args: &[&str], expected_out: &str) {
+        let ls_path = std::env::current_dir()
+            .unwrap()
+            .parent()
+            .unwrap()
+            .join("target/release/ls");
+
+        let mut command = std::process::Command::new(ls_path);
+        let child = command
+            .current_dir(test_dir)
+            .args(args)
+            .stdout(std::process::Stdio::piped())
+            .spawn()
+            .unwrap();
+
+        let output = child.wait_with_output().unwrap();
+
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        assert_eq!(stdout, expected_out);
+
+        assert_eq!(output.status.code(), Some(0));
+    }
+
+    let test_dir = "tests/ls/tmp/no_arg";
+    let dir = "tests/ls/tmp/no_arg/dir";
+    let subdir = "tests/ls/tmp/no_arg/dir/subdir";
+    let file2 = "tests/ls/tmp/no_arg/dir/subdir/file2";
+    let symlink = "tests/ls/tmp/no_arg/symlink";
+    let out = "tests/ls/tmp/no_arg/out";
+    let exp = "tests/ls/tmp/no_arg/exp";
+
+    create_dir_if_not_exists(test_dir).unwrap();
+    create_dir_if_not_exists(dir).unwrap();
+    create_dir_if_not_exists(subdir).unwrap();
+    create_file_if_not_exists(file2).unwrap();
+
+    if let Err(e) = std::os::unix::fs::symlink("f", symlink) {
+        if e.kind() != io::ErrorKind::AlreadyExists {
+            panic!("{}", e);
+        }
+    }
+
+    // Not really using this to write the output unlike in the original test
+    create_file_if_not_exists(out).unwrap();
+
+    let exp_str = "dir\n\
+                   exp\n\
+                   out\n\
+                   symlink\n";
+
+    if !Path::new(exp).exists() {
+        let mut file = fs::File::create(exp).unwrap();
+
+        file.write_all(exp_str.as_bytes()).unwrap();
+    }
+
+    ls_run_test(test_dir, &["-1"], exp_str);
+
+    let exp_str = ".:\n\
+                   dir\n\
+                   exp\n\
+                   out\n\
+                   symlink\n\
+                   \n\
+                   ./dir:\n\
+                   subdir\n\
+                   \n\
+                   ./dir/subdir:\n\
+                   file2\n";
+    ls_run_test(test_dir, &["-R1"], exp_str);
+}
+
+// Port of coreutils/tests/ls/recursive.sh
+#[test]
+fn test_ls_recursive() {
+    let test_dir = "tests/ls/tmp/recursive";
+    let x = "tests/ls/tmp/recursive/x";
+    let y = "tests/ls/tmp/recursive/y";
+    let a = "tests/ls/tmp/recursive/a";
+    let b = "tests/ls/tmp/recursive/b";
+    let c = "tests/ls/tmp/recursive/c";
+    let a1 = "tests/ls/tmp/recursive/a/1";
+    let a2 = "tests/ls/tmp/recursive/a/2";
+    let a3 = "tests/ls/tmp/recursive/a/3";
+
+    let f = "tests/ls/tmp/recursive/f";
+    let a1i = "tests/ls/tmp/recursive/a/1/I";
+    let a1ii = "tests/ls/tmp/recursive/a/1/II";
+
+    create_dir_if_not_exists(test_dir).unwrap();
+    for dir in [x, y, a, b, c] {
+        create_dir_if_not_exists(dir).unwrap();
+    }
+    for dir in [a1, a2, a3] {
+        create_dir_if_not_exists(dir).unwrap();
+    }
+    for file in [f, a1i, a1ii] {
+        create_file_if_not_exists(file).unwrap();
+    }
+
+    let result = format!(
+        "{a}:\n\
+        1\n\
+        2\n\
+        3\n\
+        \n\
+        {a1}:\n\
+        I\n\
+        II\n\
+        \n\
+        {a2}:\n\
+        \n\
+        {a3}:\n\
+        \n\
+        {b}:\n\
+        \n\
+        {c}:\n"
+    );
+    ls_test(&["-R1", a, b, c], &result, "", 0);
+
+    let result = format!(
+        "{f}\n\
+        \n\
+        {x}:\n\
+        \n\
+        {y}:\n"
+    );
+    ls_test(&["-R1", x, y, f], &result, "", 0);
+}
+
+// Port of coreutils/tests/ls/rt-1.sh
+#[test]
+fn test_ls_rt_1() {
+    let test_dir = "tests/ls/tmp/rt_1";
+    let a = "tests/ls/tmp/rt_1/a";
+    let b = "tests/ls/tmp/rt_1/b";
+    let c = "tests/ls/tmp/rt_1/c";
+    let date = "1998-01-15 00:00:00";
+
+    create_dir_if_not_exists(test_dir).unwrap();
+    create_file_if_not_exists(a).unwrap();
+    create_file_if_not_exists(b).unwrap();
+    create_file_if_not_exists(c).unwrap();
+    change_file_time(a, TimeToChange::Both(date));
+    change_file_time(b, TimeToChange::Both(date));
+    change_file_time(c, TimeToChange::Both(date));
+
+    ls_test(&["-1t", a, b, c], &format!("{a}\n{b}\n{c}\n"), "", 0);
+    ls_test(&["-1rt", a, b, c], &format!("{c}\n{b}\n{a}\n"), "", 0);
+}
+
+// Port of coreutils/tests/ls/size-align.sh
+#[test]
+fn test_ls_size_align() {
+    let test_dir = "tests/ls/tmp/size_align";
+    let small = "tests/ls/tmp/size_align/small";
+    let alloc = "tests/ls/tmp/size_align/alloc";
+    let large = "tests/ls/tmp/size_align/large";
+
+    create_dir_if_not_exists(test_dir).unwrap();
+    create_file_if_not_exists(small).unwrap();
+    if !Path::new(alloc).exists() {
+        let mut file = fs::File::create(alloc).unwrap();
+        file.write_all(b"\n").unwrap();
+    }
+    if !Path::new(large).exists() {
+        let mut file = fs::File::create(large).unwrap();
+        let data = vec![b'\n'; 123456];
+        file.write_all(&data).unwrap();
+    }
+
+    // The rows should all have the same length
+    ls_test_with_checker(&["-s", "-l", small, alloc, large], |_, output| {
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let lengths: Vec<_> = stdout.lines().map(|x| x.len()).collect();
+        let length = lengths[0];
+        assert!(lengths.iter().all(|l| *l == length));
+        assert_eq!(output.status.code(), Some(0));
+    });
+}
+
+// Partial port of coreutils/tests/ls/ls-time.sh
+// --full is non-POSIX so we can only check for coarser grained timestamps
+#[test]
+fn test_ls_time() {
+    // This gets inherited by child processes
+    std::env::set_var("TZ", "UTC0");
+
+    let test_dir = "tests/ls/tmp/time";
+    let a = "tests/ls/tmp/time/a";
+    let b = "tests/ls/tmp/time/b";
+    let c = "tests/ls/tmp/time/c";
+
+    let t1 = "1998-01-15 21:00:00";
+    let t2 = "1998-01-15 22:00:00";
+    let t3 = "1998-01-15 23:00:00";
+
+    let u1 = "1998-01-14 11:00:00";
+    let u2 = "1998-01-14 12:00:00";
+    let u3 = "1998-01-14 13:00:00";
+
+    create_dir_if_not_exists(test_dir).unwrap();
+    create_file_if_not_exists(a).unwrap();
+    create_file_if_not_exists(b).unwrap();
+    create_file_if_not_exists(c).unwrap();
+
+    change_file_time(a, TimeToChange::Modified(t3));
+    change_file_time(b, TimeToChange::Modified(t2));
+    change_file_time(c, TimeToChange::Modified(t1));
+
+    change_file_time(c, TimeToChange::Accessed(u3));
+    change_file_time(b, TimeToChange::Accessed(u2));
+
+    // Change a's ctime to be after c's
+    loop {
+        thread::sleep(Duration::from_millis(100));
+        change_file_time(a, TimeToChange::Accessed(u1));
+        let metadata_a = Path::new(a).metadata().unwrap();
+        let metadata_c = Path::new(c).metadata().unwrap();
+        if metadata_a.ctime() > metadata_c.ctime() {
+            break;
+        }
+    }
+
+    // a's ctime is newer than c's
+    ls_test(&["-c", a, c], &format!("{a}\n{c}\n"), "", 0);
+
+    // Change c's ctime to be after a's.
+    // The original is using `ln` for this but `std::os::unix::fs::symlink`
+    // doesn't seem to modify the ctime so we're changing the file time instead.
+    loop {
+        thread::sleep(Duration::from_millis(100));
+        change_file_time(c, TimeToChange::Accessed(u3));
+        let metadata_a = Path::new(a).metadata().unwrap();
+        let metadata_c = Path::new(c).metadata().unwrap();
+        if metadata_c.ctime() > metadata_a.ctime() {
+            break;
+        }
+    }
+
+    ls_test_with_checker(&["-l", a], |_, output| {
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        assert!(stdout.find("Jan 15  1998").is_some());
+        assert_eq!(output.status.code(), Some(0));
+    });
+
+    ls_test_with_checker(&["-lu", a], |_, output| {
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        assert!(stdout.find("Jan 14  1998").is_some());
+        assert_eq!(output.status.code(), Some(0));
+    });
+
+    ls_test(&["-ut", a, b, c], &format!("{c}\n{b}\n{a}\n"), "", 0);
+    ls_test(&["-t", a, b, c], &format!("{a}\n{b}\n{c}\n"), "", 0);
+
+    // c's ctime is newer than a's
+    ls_test(&["-ct", a, c], &format!("{c}\n{a}\n"), "", 0);
+}

--- a/tree/tests/ls/tmp/.gitignore
+++ b/tree/tests/ls/tmp/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore


### PR DESCRIPTION
This passes all of coreutils ls' [tests](https://github.com/coreutils/coreutils/tree/master/tests/ls) excluding non-POSIX ones.

Two tests have quirks though:

- `test_ls_file_type` skips block/character devices if not run with `sudo -E cargo ...`. Those need elevated permission to create.
- `test_ls_time` will stall a bit because it needs to wait for the ctime of the file to change. This is already an improvement over the 4 second wait time of the original.

There's also the `-k` option which coreutils always has enabled. Specification says to use 512-byte blocks if `-k` isn't specified but they always have it as 1024-byte blocks with or without `-k`.