### PR TITLE
Fix possible race condition in cp

### DIFF
--- a/tree/tests/integration.rs
+++ b/tree/tests/integration.rs
@@ -10,3 +10,22 @@
 mod cp;
 mod ls;
 mod mv;
+
+use std::sync::Mutex;
+
+static UMASK_SETTER: Mutex<UmaskSetter> = Mutex::new(UmaskSetter);
+
+// Used to serialize changes to the process' umask
+struct UmaskSetter;
+
+impl UmaskSetter {
+    fn umask(&self, mask: libc::mode_t) -> libc::mode_t {
+        let original = unsafe { libc::umask(mask) };
+
+        // Pessimistically makes sure that the umask is applied before
+        // continuing execution
+        unsafe { while libc::umask(mask) != mask {} }
+
+        original
+    }
+}


### PR DESCRIPTION
Hopefully fixes #101.

~~I'm assuming it's related to [this](https://www.mail-archive.com/bug-cpio@gnu.org/msg00128.html). Solution was to work with the fd directly instead of passing the path to the chmod, et al.~~

I was able to replicate #101 by removing the `libc::umask` call in `test_cp_perm`. That implies it was not being set properly perhaps due to `test_cp_existing_perm_dir` running its own umask call at the same time. This PR prevents `test_cp_perm` and `test_cp_existing_perm_dir` from running simultaneously.