### PR TITLE
Fix #111

### DIFF
--- a/tree/tests/rm/mod.rs
+++ b/tree/tests/rm/mod.rs
@@ -158,14 +158,15 @@ fn test_rm_deep_1() {
     let test_dir = &format!("{}/test_rm_deep_1", env!("CARGO_TARGET_TMPDIR"));
     let k20 = ["/k"; 20].join("");
     let k200 = [k20.as_str(); 10].join("");
-    let t = &format!("{test_dir}/t{k200}{k200}");
+    let t = &format!("{test_dir}/t");
+    let k_deep = &format!("{t}{k200}{k200}");
 
     fs::create_dir(test_dir).unwrap();
 
     let umask_setter = super::UMASK_SETTER.lock().unwrap();
     let original_umask = umask_setter.umask(0o002);
 
-    fs::create_dir_all(t).unwrap();
+    fs::create_dir_all(k_deep).unwrap();
 
     rm_test(&["-r", t], "", "", 0);
 


### PR DESCRIPTION
The root cause here is that this test should be deleting `t` and not the deeply nested sub-directory under it.

The error is because Rust's implementation of [`remove_dir_all`](https://github.com/rust-lang/rust/blob/cdc509f7c09361466d543fc8311ce7066b10cc4f/library/std/src/sys_common/fs.rs#L33) is doing recursion which doesn't close the directory handles until it reaches the deepest subdir. The implementation of `rm` can delete `t` because it opens only one handle so it won't get the "Too many open files" error. It does comes with the tradeoff of having to cache the visited files though.