### PR TITLE
Create a mock for gettext-rs in order to fix the failing build on macos

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -105,12 +105,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
 
 [[package]]
-name = "block"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d8c1fef690941d3e7788d328517591fecc684c084084702d6ff1641e993699a"
-
-[[package]]
 name = "block-buffer"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -456,23 +450,7 @@ dependencies = [
 
 [[package]]
 name = "gettext-rs"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e49ea8a8fad198aaa1f9655a2524b64b70eb06b2f3ff37da407566c93054f364"
-dependencies = [
- "gettext-sys",
- "locale_config",
-]
-
-[[package]]
-name = "gettext-sys"
-version = "0.21.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c63ce2e00f56a206778276704bbe38564c8695249fdc8f354b4ef71c57c3839d"
-dependencies = [
- "cc",
- "temp-dir",
-]
+version = "0.1.0"
 
 [[package]]
 name = "hashbrown"
@@ -632,19 +610,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89"
 
 [[package]]
-name = "locale_config"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08d2c35b16f4483f6c26f0e4e9550717a2f6575bcd6f12a53ff0c490a94a6934"
-dependencies = [
- "lazy_static",
- "objc",
- "objc-foundation",
- "regex",
- "winapi",
-]
-
-[[package]]
 name = "lock_api"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -659,15 +624,6 @@ name = "log"
 version = "0.4.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
-
-[[package]]
-name = "malloc_buf"
-version = "0.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62bb907fe88d54d8d9ce32a3cceab4218ed2f6b7d35617cafe9adf84e43919cb"
-dependencies = [
- "libc",
-]
 
 [[package]]
 name = "match_cfg"
@@ -804,35 +760,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c7398b9c8b70908f6371f47ed36737907c87c52af34c268fed0bf0ceb92ead9"
 dependencies = [
  "libc",
-]
-
-[[package]]
-name = "objc"
-version = "0.2.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "915b1b472bc21c53464d6c8461c9d3af805ba1ef837e1cac254428f4a77177b1"
-dependencies = [
- "malloc_buf",
-]
-
-[[package]]
-name = "objc-foundation"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1add1b659e36c9607c7aab864a76c7a4c2760cd0cd2e120f3fb8b952c7e22bf9"
-dependencies = [
- "block",
- "objc",
- "objc_id",
-]
-
-[[package]]
-name = "objc_id"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c92d4ddb4bd7b50d730c215ff871754d0da6b2178849f8a2a2ab69712d0c073b"
-dependencies = [
- "objc",
 ]
 
 [[package]]
@@ -1395,12 +1322,6 @@ dependencies = [
  "log",
  "time",
 ]
-
-[[package]]
-name = "temp-dir"
-version = "0.1.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f227968ec00f0e5322f9b8173c7a0cbcff6181a0a5b28e9892491c286277231"
 
 [[package]]
 name = "tempfile"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ members = [
 	"display",
 	"file",
 	"fs",
+	"gettext-rs",
 	"misc",
 	"pathnames",
 	"plib",
@@ -25,6 +26,6 @@ members = [
 atty = "0.2"
 clap = { version = "4", default-features = false, features = ["std", "derive", "help", "usage"] }
 chrono = { version = "0.4", default-features = false, features = ["clock"] }
-gettext-rs = { version = "0.7", features = ["gettext-system"] }
 libc = "0.2"
 regex = "1.10"
+gettext-rs = { path = "./gettext-rs" }

--- a/gettext-rs/Cargo.toml
+++ b/gettext-rs/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "gettext-rs"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+name = "gettextrs"

--- a/gettext-rs/README.md
+++ b/gettext-rs/README.md
@@ -1,0 +1,3 @@
+# gettext-rs (mock)
+
+This is a mock for `gettext-rs` crate that is being used temporarily to fix the build on macos while we figure out a resolution to https://github.com/gettext-rs/gettext-rs/issues/121

--- a/gettext-rs/src/lib.rs
+++ b/gettext-rs/src/lib.rs
@@ -1,0 +1,48 @@
+pub fn setlocale<T: Into<Vec<u8>>>(_category: LocaleCategory, locale: T) -> Option<Vec<u8>> {
+    Some(locale.into())
+}
+
+pub fn bind_textdomain_codeset<T, U>(
+    _domainname: T,
+    _codeset: U,
+) -> Result<Option<String>, std::io::Error>
+where
+    T: Into<Vec<u8>>,
+    U: Into<String>,
+{
+    Ok(None)
+}
+
+pub fn textdomain<T: Into<Vec<u8>>>(domainname: T) -> Result<Vec<u8>, std::io::Error> {
+    Ok(domainname.into())
+}
+
+pub fn gettext<T: Into<String>>(msgid: T) -> String {
+    return msgid.into();
+}
+
+#[macro_export]
+macro_rules! gettext {
+    ($fmt:expr) => {
+        format!($fmt)
+    };
+    ($fmt:expr, $($arg:tt)*) => {
+        format!($fmt, $($arg)*)
+    };
+}
+
+pub enum LocaleCategory {
+    LcCType,
+    LcNumeric,
+    LcTime,
+    LcCollate,
+    LcMonetary,
+    LcMessages,
+    LcAll,
+    LcPaper,
+    LcName,
+    LcAddress,
+    LcTelephone,
+    LcMeasurement,
+    LcIdentification,
+}


### PR DESCRIPTION
A temporary fix for failing build on macos https://github.com/rustcoreutils/posixutils-rs/actions/runs/10173778299/job/28138428272 which is highly likely to be related to https://github.com/gettext-rs/gettext-rs/issues/121

A long term resolution will likely involve one of the following:

a) Wait for https://github.com/gettext-rs/gettext-rs/pull/119 to get merged, and then fix the breaking changes introduced by https://github.com/dennisschagt/gettext-rs/commit/ec1aad1cbd167f56e6915c379c59d199a54c2758
b) Use https://docs.rs/gettext/0.4.0/gettext/ instead accepting its limitations and it's apparent abandonment.
c) Fork `gettext-rs`.
d) Replace gettext entirely with a more modern localization system.  https://github.com/unicode-org/message-format-wg  is still in the works, and so something based on https://github.com/projectfluent/fluent-rs seems likely to be the best option. My biased opinion (maintainer of the project) is that https://docs.rs/i18n-embed/latest/i18n_embed/ along with https://docs.rs/i18n-embed-fl/latest/i18n_embed_fl/macro.fl.html could be a good option for doing this in an established pattern, and would be willing to put in the time to pare down any dependencies and add any small features necessary to make it work for this project.
e) Roll our own very limited localization system to keep dependencies to a minimum. If accessibility really is a priority I don't see this being a great option, it also makes external tooling around localization more limited.