### PR TITLE
Remove unneeded extern crate declarations

### DIFF
--- a/calc/expr.rs
+++ b/calc/expr.rs
@@ -7,8 +7,6 @@
 // SPDX-License-Identifier: MIT
 //
 
-extern crate plib;
-
 use gettextrs::{bind_textdomain_codeset, setlocale, textdomain, LocaleCategory};
 use plib::PROJECT_NAME;
 use regex::Regex;

--- a/datetime/cal.rs
+++ b/datetime/cal.rs
@@ -11,9 +11,6 @@
 // - Arg help should indicate "[[month] year]" as the default
 //
 
-extern crate clap;
-extern crate plib;
-
 use chrono::Datelike;
 use clap::Parser;
 use gettextrs::{bind_textdomain_codeset, gettext, setlocale, textdomain, LocaleCategory};

--- a/datetime/date.rs
+++ b/datetime/date.rs
@@ -11,9 +11,6 @@
 // - double-check that Rust stftime() is POSIX compliant
 //
 
-extern crate clap;
-extern crate plib;
-
 use chrono::{DateTime, Datelike, Local, LocalResult, TimeZone, Utc};
 use clap::Parser;
 use gettextrs::{bind_textdomain_codeset, setlocale, textdomain, LocaleCategory};

--- a/datetime/sleep.rs
+++ b/datetime/sleep.rs
@@ -7,9 +7,6 @@
 // SPDX-License-Identifier: MIT
 //
 
-extern crate clap;
-extern crate plib;
-
 use clap::Parser;
 use gettextrs::{bind_textdomain_codeset, setlocale, textdomain, LocaleCategory};
 use plib::PROJECT_NAME;

--- a/dev/ar.rs
+++ b/dev/ar.rs
@@ -7,8 +7,6 @@
 // SPDX-License-Identifier: MIT
 //
 
-extern crate clap;
-
 use chrono::DateTime;
 use clap::{Parser, Subcommand};
 use object::{Object, ObjectSymbol, SymbolKind};

--- a/dev/nm.rs
+++ b/dev/nm.rs
@@ -11,9 +11,6 @@
 // - sort output
 //
 
-extern crate clap;
-extern crate plib;
-
 use object::{
     Object, ObjectSection, ObjectSymbol, SectionIndex, SectionKind, Symbol, SymbolKind,
     SymbolSection,

--- a/display/echo.rs
+++ b/display/echo.rs
@@ -13,8 +13,6 @@
 //	Write an 8-bit value that is the 0, 1, 2 or 3-digit octal number _num_.
 //
 
-extern crate plib;
-
 use gettextrs::{bind_textdomain_codeset, setlocale, textdomain, LocaleCategory};
 use plib::PROJECT_NAME;
 use std::io::{self, Write};

--- a/display/printf.rs
+++ b/display/printf.rs
@@ -11,8 +11,6 @@
 // - fix bug:  zero padding does not work for negative numbers
 //
 
-extern crate plib;
-
 use gettextrs::{bind_textdomain_codeset, gettext, setlocale, textdomain, LocaleCategory};
 use plib::PROJECT_NAME;
 use std::io::{self, Write};

--- a/file/cat.rs
+++ b/file/cat.rs
@@ -12,9 +12,6 @@
 // - Questionable behavior:  if write_all() produces Err, the program will
 //   continue to the next file, rather than stopping.
 
-extern crate clap;
-extern crate plib;
-
 use clap::Parser;
 use gettextrs::{bind_textdomain_codeset, setlocale, textdomain, LocaleCategory};
 use plib::PROJECT_NAME;

--- a/file/dd.rs
+++ b/file/dd.rs
@@ -7,8 +7,6 @@
 // SPDX-License-Identifier: MIT
 //
 
-extern crate plib;
-
 use gettextrs::{bind_textdomain_codeset, gettext, setlocale, textdomain, LocaleCategory};
 use plib::PROJECT_NAME;
 use std::fs;

--- a/file/split.rs
+++ b/file/split.rs
@@ -7,9 +7,6 @@
 // SPDX-License-Identifier: MIT
 //
 
-extern crate clap;
-extern crate plib;
-
 use clap::Parser;
 use gettextrs::{bind_textdomain_codeset, setlocale, textdomain, LocaleCategory};
 use plib::PROJECT_NAME;

--- a/file/tee.rs
+++ b/file/tee.rs
@@ -7,10 +7,6 @@
 // SPDX-License-Identifier: MIT
 //
 
-extern crate clap;
-extern crate libc;
-extern crate plib;
-
 use clap::Parser;
 use gettextrs::{bind_textdomain_codeset, setlocale, textdomain, LocaleCategory};
 use libc::{signal, SIGINT, SIG_IGN};

--- a/fs/df.rs
+++ b/fs/df.rs
@@ -7,10 +7,6 @@
 // SPDX-License-Identifier: MIT
 //
 
-extern crate clap;
-extern crate libc;
-extern crate plib;
-
 use clap::Parser;
 use gettextrs::{bind_textdomain_codeset, setlocale, textdomain, LocaleCategory};
 use plib::PROJECT_NAME;

--- a/misc/test.rs
+++ b/misc/test.rs
@@ -11,9 +11,6 @@
 // - fix and test unary ops
 //
 
-extern crate libc;
-extern crate plib;
-
 use gettextrs::{bind_textdomain_codeset, gettext, setlocale, textdomain, LocaleCategory};
 use plib::PROJECT_NAME;
 use std::os::unix::fs::FileTypeExt;

--- a/pathnames/basename.rs
+++ b/pathnames/basename.rs
@@ -7,9 +7,6 @@
 // SPDX-License-Identifier: MIT
 //
 
-extern crate clap;
-extern crate plib;
-
 use clap::Parser;
 use gettextrs::{bind_textdomain_codeset, setlocale, textdomain, LocaleCategory};
 use plib::PROJECT_NAME;

--- a/pathnames/dirname.rs
+++ b/pathnames/dirname.rs
@@ -7,9 +7,6 @@
 // SPDX-License-Identifier: MIT
 //
 
-extern crate clap;
-extern crate plib;
-
 use clap::Parser;
 use gettextrs::{bind_textdomain_codeset, setlocale, textdomain, LocaleCategory};
 use plib::PROJECT_NAME;

--- a/pathnames/pathchk.rs
+++ b/pathnames/pathchk.rs
@@ -7,10 +7,6 @@
 // SPDX-License-Identifier: MIT
 //
 
-extern crate clap;
-extern crate libc;
-extern crate plib;
-
 use clap::Parser;
 use gettextrs::{bind_textdomain_codeset, setlocale, textdomain, LocaleCategory};
 use plib::PROJECT_NAME;

--- a/plib/src/curuser.rs
+++ b/plib/src/curuser.rs
@@ -7,7 +7,6 @@
 // SPDX-License-Identifier: MIT
 //
 
-extern crate libc;
 use std::ffi::CStr;
 
 pub fn login_name() -> String {

--- a/plib/src/group.rs
+++ b/plib/src/group.rs
@@ -7,7 +7,6 @@
 // SPDX-License-Identifier: MIT
 //
 
-extern crate libc;
 use libc::{endgrent, getgrent, setgrent};
 use std::ffi::CStr;
 use std::ptr;

--- a/plib/src/utmpx.rs
+++ b/plib/src/utmpx.rs
@@ -7,7 +7,6 @@
 // SPDX-License-Identifier: MIT
 //
 
-extern crate libc;
 use libc::{endutxent, getutxent, setutxent};
 use std::ffi::CStr;
 

--- a/process/env.rs
+++ b/process/env.rs
@@ -7,9 +7,6 @@
 // SPDX-License-Identifier: MIT
 //
 
-extern crate clap;
-extern crate plib;
-
 use clap::Parser;
 use gettextrs::{bind_textdomain_codeset, setlocale, textdomain, LocaleCategory};
 use plib::PROJECT_NAME;

--- a/process/kill.rs
+++ b/process/kill.rs
@@ -7,10 +7,6 @@
 // SPDX-License-Identifier: MIT
 //
 
-extern crate clap;
-extern crate libc;
-extern crate plib;
-
 use gettextrs::{bind_textdomain_codeset, setlocale, textdomain, LocaleCategory};
 use plib::PROJECT_NAME;
 

--- a/process/nice.rs
+++ b/process/nice.rs
@@ -7,10 +7,6 @@
 // SPDX-License-Identifier: MIT
 //
 
-extern crate clap;
-extern crate libc;
-extern crate plib;
-
 use clap::Parser;
 use gettextrs::{bind_textdomain_codeset, setlocale, textdomain, LocaleCategory};
 use plib::PROJECT_NAME;

--- a/process/renice.rs
+++ b/process/renice.rs
@@ -7,10 +7,6 @@
 // SPDX-License-Identifier: MIT
 //
 
-extern crate clap;
-extern crate libc;
-extern crate plib;
-
 use clap::Parser;
 use errno::{errno, set_errno};
 use gettextrs::{bind_textdomain_codeset, setlocale, textdomain, LocaleCategory};

--- a/process/xargs.rs
+++ b/process/xargs.rs
@@ -14,9 +14,6 @@
 // - write tests
 //
 
-extern crate clap;
-extern crate plib;
-
 use clap::Parser;
 use gettextrs::{bind_textdomain_codeset, setlocale, textdomain, LocaleCategory};
 use plib::PROJECT_NAME;

--- a/sccs/what.rs
+++ b/sccs/what.rs
@@ -7,9 +7,6 @@
 // SPDX-License-Identifier: MIT
 //
 
-extern crate clap;
-extern crate plib;
-
 use clap::Parser;
 use gettextrs::{bind_textdomain_codeset, gettext, setlocale, textdomain, LocaleCategory};
 use plib::PROJECT_NAME;

--- a/screen/osdata.rs
+++ b/screen/osdata.rs
@@ -7,8 +7,6 @@
 // SPDX-License-Identifier: MIT
 //
 
-extern crate libc;
-
 use std::collections::HashMap;
 
 #[cfg(target_os = "macos")]

--- a/screen/stty.rs
+++ b/screen/stty.rs
@@ -10,10 +10,6 @@
 // - stty get-short display
 //
 
-extern crate clap;
-extern crate libc;
-extern crate plib;
-
 mod osdata;
 
 use clap::Parser;

--- a/screen/tabs.rs
+++ b/screen/tabs.rs
@@ -11,9 +11,6 @@
 // - Research if 100 is a POSIX-compliant limit for MAX_STOPS
 //
 
-extern crate clap;
-extern crate plib;
-
 use clap::Parser;
 use gettextrs::{bind_textdomain_codeset, gettext, setlocale, textdomain, LocaleCategory};
 use plib::PROJECT_NAME;

--- a/screen/tput.rs
+++ b/screen/tput.rs
@@ -11,9 +11,6 @@
 // - read init-file and reset-file data from filesystem
 //
 
-extern crate clap;
-extern crate plib;
-
 use clap::Parser;
 use gettextrs::{bind_textdomain_codeset, gettext, setlocale, textdomain, LocaleCategory};
 use plib::PROJECT_NAME;

--- a/sys/getconf.rs
+++ b/sys/getconf.rs
@@ -12,10 +12,6 @@
 // - Proper -v specification support.  is it even necessary?
 //
 
-extern crate clap;
-extern crate libc;
-extern crate plib;
-
 use clap::Parser;
 use gettextrs::{bind_textdomain_codeset, gettext, setlocale, textdomain, LocaleCategory};
 use libc::{pathconf, sysconf};

--- a/sys/ipcrm.rs
+++ b/sys/ipcrm.rs
@@ -7,10 +7,6 @@
 // SPDX-License-Identifier: MIT
 //
 
-extern crate clap;
-extern crate libc;
-extern crate plib;
-
 use clap::Parser;
 use gettextrs::{bind_textdomain_codeset, setlocale, textdomain, LocaleCategory};
 #[cfg(not(target_os = "macos"))]

--- a/sys/ipcs.rs
+++ b/sys/ipcs.rs
@@ -7,10 +7,6 @@
 // SPDX-License-Identifier: MIT
 //
 
-extern crate clap;
-extern crate gettextrs;
-extern crate plib;
-
 use chrono::Local;
 use clap::Parser;
 use gettextrs::{bind_textdomain_codeset, gettext, setlocale, textdomain, LocaleCategory};

--- a/sys/uname.rs
+++ b/sys/uname.rs
@@ -7,10 +7,6 @@
 // SPDX-License-Identifier: MIT
 //
 
-extern crate clap;
-extern crate plib;
-extern crate uname;
-
 use clap::Parser;
 use gettextrs::{bind_textdomain_codeset, setlocale, textdomain, LocaleCategory};
 use plib::PROJECT_NAME;

--- a/sys/who.rs
+++ b/sys/who.rs
@@ -11,10 +11,6 @@
 // - implement -T, -u options
 //
 
-extern crate chrono;
-extern crate clap;
-extern crate plib;
-
 use clap::Parser;
 use gettextrs::{bind_textdomain_codeset, gettext, setlocale, textdomain, LocaleCategory};
 use plib::PROJECT_NAME;

--- a/text/asa.rs
+++ b/text/asa.rs
@@ -11,9 +11,6 @@
 // - add tests
 //
 
-extern crate clap;
-extern crate plib;
-
 use clap::Parser;
 use gettextrs::{bind_textdomain_codeset, gettext, setlocale, textdomain, LocaleCategory};
 use plib::PROJECT_NAME;

--- a/text/comm.rs
+++ b/text/comm.rs
@@ -7,9 +7,6 @@
 // SPDX-License-Identifier: MIT
 //
 
-extern crate clap;
-extern crate plib;
-
 use clap::Parser;
 use gettextrs::{bind_textdomain_codeset, setlocale, textdomain, LocaleCategory};
 use plib::PROJECT_NAME;

--- a/text/csplit.rs
+++ b/text/csplit.rs
@@ -10,9 +10,6 @@
 // - err on line num == 0
 //
 
-extern crate clap;
-extern crate plib;
-
 use clap::Parser;
 use gettextrs::{bind_textdomain_codeset, setlocale, textdomain, LocaleCategory};
 use plib::PROJECT_NAME;

--- a/text/cut.rs
+++ b/text/cut.rs
@@ -7,8 +7,6 @@
 // SPDX-License-Identifier: MIT
 //
 
-extern crate clap;
-extern crate plib;
 use std::io::{self, BufRead, Error, ErrorKind, Read};
 
 use clap::Parser;

--- a/text/diff.rs
+++ b/text/diff.rs
@@ -14,10 +14,6 @@
 
 mod diff_util;
 
-extern crate clap;
-extern crate diff;
-extern crate plib;
-
 use std::{fs, io, path::PathBuf};
 
 use clap::Parser;

--- a/text/expand.rs
+++ b/text/expand.rs
@@ -7,9 +7,6 @@
 // SPDX-License-Identifier: MIT
 //
 
-extern crate clap;
-extern crate plib;
-
 use clap::Parser;
 use gettextrs::{bind_textdomain_codeset, setlocale, textdomain, LocaleCategory};
 use plib::PROJECT_NAME;

--- a/text/fold.rs
+++ b/text/fold.rs
@@ -7,9 +7,6 @@
 // SPDX-License-Identifier: MIT
 //
 
-extern crate clap;
-extern crate plib;
-
 use clap::Parser;
 use gettextrs::{bind_textdomain_codeset, setlocale, textdomain, LocaleCategory};
 use plib::PROJECT_NAME;

--- a/text/grep.rs
+++ b/text/grep.rs
@@ -7,10 +7,6 @@
 // SPDX-License-Identifier: MIT
 //
 
-extern crate clap;
-extern crate libc;
-extern crate plib;
-
 use clap::Parser;
 use gettextrs::{bind_textdomain_codeset, textdomain};
 use libc::{regcomp, regex_t, regexec, regfree, REG_EXTENDED, REG_ICASE, REG_NOMATCH};

--- a/text/head.rs
+++ b/text/head.rs
@@ -7,9 +7,6 @@
 // SPDX-License-Identifier: MIT
 //
 
-extern crate clap;
-extern crate plib;
-
 use clap::Parser;
 use gettextrs::{bind_textdomain_codeset, setlocale, textdomain, LocaleCategory};
 use plib::PROJECT_NAME;

--- a/text/join.rs
+++ b/text/join.rs
@@ -7,10 +7,6 @@
 // SPDX-License-Identifier: MIT
 //
 
-extern crate clap;
-extern crate gettextrs;
-extern crate walkdir;
-
 use clap::Parser;
 use gettextrs::{bind_textdomain_codeset, setlocale, textdomain, LocaleCategory};
 use plib::PROJECT_NAME;

--- a/text/paste.rs
+++ b/text/paste.rs
@@ -12,9 +12,6 @@
 // - improve:  don't open all files at once in --serial mode
 //
 
-extern crate clap;
-extern crate plib;
-
 use clap::Parser;
 use gettextrs::{bind_textdomain_codeset, setlocale, textdomain, LocaleCategory};
 use plib::PROJECT_NAME;

--- a/text/sort.rs
+++ b/text/sort.rs
@@ -7,8 +7,6 @@
 // SPDX-License-Identifier: MIT
 //
 
-extern crate clap;
-extern crate plib;
 use std::cmp::Ordering;
 
 use std::io::{ErrorKind, Read};

--- a/text/tsort.rs
+++ b/text/tsort.rs
@@ -7,9 +7,6 @@
 // SPDX-License-Identifier: MIT
 //
 
-extern crate clap;
-extern crate plib;
-
 use clap::Parser;
 use gettextrs::{bind_textdomain_codeset, setlocale, textdomain, LocaleCategory};
 use plib::PROJECT_NAME;

--- a/text/wc.rs
+++ b/text/wc.rs
@@ -7,9 +7,6 @@
 // SPDX-License-Identifier: MIT
 //
 
-extern crate clap;
-extern crate plib;
-
 use clap::Parser;
 use gettextrs::{bind_textdomain_codeset, setlocale, textdomain, LocaleCategory};
 use plib::PROJECT_NAME;

--- a/tree/chgrp.rs
+++ b/tree/chgrp.rs
@@ -10,10 +10,6 @@
 // - implement -h, -H, -L, -P
 //
 
-extern crate clap;
-extern crate libc;
-extern crate plib;
-
 use clap::Parser;
 use gettextrs::{bind_textdomain_codeset, setlocale, textdomain, LocaleCategory};
 use plib::PROJECT_NAME;

--- a/tree/chmod.rs
+++ b/tree/chmod.rs
@@ -7,9 +7,6 @@
 // SPDX-License-Identifier: MIT
 //
 
-extern crate clap;
-extern crate plib;
-
 use clap::Parser;
 use gettextrs::{bind_textdomain_codeset, setlocale, textdomain, LocaleCategory};
 use modestr::{ChmodMode, ChmodSymbolic};

--- a/tree/chown.rs
+++ b/tree/chown.rs
@@ -10,10 +10,6 @@
 // - implement -h, -H, -L, -P
 //
 
-extern crate clap;
-extern crate libc;
-extern crate plib;
-
 use clap::Parser;
 use gettextrs::{bind_textdomain_codeset, setlocale, textdomain, LocaleCategory};
 use plib::PROJECT_NAME;

--- a/tree/cp.rs
+++ b/tree/cp.rs
@@ -7,10 +7,6 @@
 // SPDX-License-Identifier: MIT
 //
 
-extern crate atty;
-extern crate clap;
-extern crate plib;
-
 mod common;
 
 use self::common::{copy_file, copy_files, error_string, CopyConfig};

--- a/tree/du.rs
+++ b/tree/du.rs
@@ -10,9 +10,6 @@
 // - implement -H, -L, -x
 //
 
-extern crate clap;
-extern crate plib;
-
 use clap::Parser;
 use gettextrs::{bind_textdomain_codeset, setlocale, textdomain, LocaleCategory};
 use plib::PROJECT_NAME;

--- a/tree/link.rs
+++ b/tree/link.rs
@@ -7,9 +7,6 @@
 // SPDX-License-Identifier: MIT
 //
 
-extern crate clap;
-extern crate plib;
-
 use clap::Parser;
 use gettextrs::{bind_textdomain_codeset, setlocale, textdomain, LocaleCategory};
 use plib::PROJECT_NAME;

--- a/tree/ln.rs
+++ b/tree/ln.rs
@@ -7,9 +7,6 @@
 // SPDX-License-Identifier: MIT
 //
 
-extern crate clap;
-extern crate plib;
-
 use clap::Parser;
 use gettextrs::{bind_textdomain_codeset, gettext, setlocale, textdomain, LocaleCategory};
 use plib::PROJECT_NAME;

--- a/tree/mkdir.rs
+++ b/tree/mkdir.rs
@@ -7,10 +7,6 @@
 // SPDX-License-Identifier: MIT
 //
 
-extern crate clap;
-extern crate libc;
-extern crate plib;
-
 use clap::Parser;
 use gettextrs::{bind_textdomain_codeset, setlocale, textdomain, LocaleCategory};
 use modestr::ChmodMode;

--- a/tree/mkfifo.rs
+++ b/tree/mkfifo.rs
@@ -7,10 +7,6 @@
 // SPDX-License-Identifier: MIT
 //
 
-extern crate clap;
-extern crate libc;
-extern crate plib;
-
 use clap::Parser;
 use gettextrs::{bind_textdomain_codeset, setlocale, textdomain, LocaleCategory};
 use modestr::ChmodMode;

--- a/tree/mv.rs
+++ b/tree/mv.rs
@@ -8,11 +8,6 @@
 //
 //
 
-extern crate atty;
-extern crate clap;
-extern crate libc;
-extern crate plib;
-
 mod common;
 
 use self::common::{copy_file, error_string};

--- a/tree/readlink.rs
+++ b/tree/readlink.rs
@@ -7,9 +7,6 @@
 // SPDX-License-Identifier: MIT
 //
 
-extern crate clap;
-extern crate plib;
-
 use clap::Parser;
 use gettextrs::{bind_textdomain_codeset, setlocale, textdomain, LocaleCategory};
 use plib::PROJECT_NAME;

--- a/tree/rm.rs
+++ b/tree/rm.rs
@@ -7,10 +7,6 @@
 // SPDX-License-Identifier: MIT
 //
 
-extern crate atty;
-extern crate clap;
-extern crate plib;
-
 mod common;
 
 use self::common::error_string;

--- a/tree/rmdir.rs
+++ b/tree/rmdir.rs
@@ -7,9 +7,6 @@
 // SPDX-License-Identifier: MIT
 //
 
-extern crate clap;
-extern crate plib;
-
 use clap::Parser;
 use gettextrs::{bind_textdomain_codeset, gettext, setlocale, textdomain, LocaleCategory};
 use plib::PROJECT_NAME;

--- a/tree/tests/readlink/mod.rs
+++ b/tree/tests/readlink/mod.rs
@@ -7,8 +7,6 @@
 // SPDX-License-Identifier: MIT
 //
 
-extern crate tempfile;
-
 use plib::{run_test, TestPlan};
 use std::fs::File;
 use std::io::Write;

--- a/tree/touch.rs
+++ b/tree/touch.rs
@@ -7,10 +7,6 @@
 // SPDX-License-Identifier: MIT
 //
 
-extern crate clap;
-extern crate libc;
-extern crate plib;
-
 use chrono::{DateTime, Datelike, LocalResult, TimeZone, Utc};
 use clap::Parser;
 use gettextrs::{bind_textdomain_codeset, setlocale, textdomain, LocaleCategory};

--- a/tree/unlink.rs
+++ b/tree/unlink.rs
@@ -7,9 +7,6 @@
 // SPDX-License-Identifier: MIT
 //
 
-extern crate clap;
-extern crate plib;
-
 use clap::Parser;
 use gettextrs::{bind_textdomain_codeset, setlocale, textdomain, LocaleCategory};
 use plib::PROJECT_NAME;

--- a/users/id.rs
+++ b/users/id.rs
@@ -10,10 +10,6 @@
 // - bug: only one group is returned, in group list (MacOS-only?)
 //
 
-extern crate clap;
-extern crate libc;
-extern crate plib;
-
 use clap::Parser;
 use gettextrs::{bind_textdomain_codeset, setlocale, textdomain, LocaleCategory};
 use plib::PROJECT_NAME;

--- a/users/logger.rs
+++ b/users/logger.rs
@@ -7,8 +7,6 @@
 // SPDX-License-Identifier: MIT
 //
 
-extern crate plib;
-
 use gettextrs::{bind_textdomain_codeset, setlocale, textdomain, LocaleCategory};
 use plib::PROJECT_NAME;
 use syslog::{Facility, Formatter3164};

--- a/users/logname.rs
+++ b/users/logname.rs
@@ -7,8 +7,6 @@
 // SPDX-License-Identifier: MIT
 //
 
-extern crate plib;
-
 fn main() {
     let username = plib::curuser::login_name();
 

--- a/users/mesg.rs
+++ b/users/mesg.rs
@@ -11,10 +11,6 @@
 // - set process exit code according to spec
 //
 
-extern crate clap;
-extern crate libc;
-extern crate plib;
-
 use clap::Parser;
 use gettextrs::{bind_textdomain_codeset, gettext, setlocale, textdomain, LocaleCategory};
 use plib::PROJECT_NAME;

--- a/users/pwd.rs
+++ b/users/pwd.rs
@@ -10,9 +10,6 @@
 // - compliance:  for -L mode, Rust performs unwanted normalization for "."
 //
 
-extern crate clap;
-extern crate plib;
-
 use clap::Parser;
 use gettextrs::{bind_textdomain_codeset, setlocale, textdomain, LocaleCategory};
 use plib::PROJECT_NAME;

--- a/users/tty.rs
+++ b/users/tty.rs
@@ -7,9 +7,6 @@
 // SPDX-License-Identifier: MIT
 //
 
-extern crate atty;
-extern crate plib;
-
 fn main() {
     let is_tty = atty::is(atty::Stream::Stdin);
     if !is_tty {

--- a/users/write.rs
+++ b/users/write.rs
@@ -7,9 +7,6 @@
 // SPDX-License-Identifier: MIT
 //
 
-extern crate clap;
-extern crate plib;
-
 use chrono::Local;
 use clap::Parser;
 use gettextrs::{bind_textdomain_codeset, gettext, setlocale, textdomain, LocaleCategory};

--- a/xform/cksum.rs
+++ b/xform/cksum.rs
@@ -15,9 +15,6 @@
 //   a Rust crate + our finalize() function.
 //
 
-extern crate clap;
-extern crate plib;
-
 mod crc32;
 
 use clap::Parser;

--- a/xform/uncompress.rs
+++ b/xform/uncompress.rs
@@ -11,9 +11,6 @@
 // - support options -f, -v
 //
 
-extern crate clap;
-extern crate plib;
-
 use clap::Parser;
 use gettextrs::{bind_textdomain_codeset, setlocale, textdomain, LocaleCategory};
 use plib::lzw::UnixLZWReader;

--- a/xform/uudecode.rs
+++ b/xform/uudecode.rs
@@ -7,9 +7,6 @@
 // SPDX-License-Identifier: MIT
 //
 
-extern crate clap;
-extern crate plib;
-
 use base64::prelude::*;
 use clap::Parser;
 use gettextrs::{bind_textdomain_codeset, setlocale, textdomain, LocaleCategory};

--- a/xform/uuencode.rs
+++ b/xform/uuencode.rs
@@ -7,9 +7,6 @@
 // SPDX-License-Identifier: MIT
 //
 
-extern crate clap;
-extern crate plib;
-
 use base64::prelude::*;
 use clap::Parser;
 use gettextrs::{bind_textdomain_codeset, setlocale, textdomain, LocaleCategory};


### PR DESCRIPTION
These declarations have not been needed since the 2018 edition.

https://doc.rust-lang.org/edition-guide/rust-2018/path-changes.html