### PR TITLE
paste: allow empty -d, and stdin

### DIFF
--- a/text/tests/grep/mod.rs
+++ b/text/tests/grep/mod.rs
@@ -1116,12 +1116,12 @@ fn test_duplicate_input_files_quiet() {
 }
 
 #[test]
-fn test_muptiple_pattern_files_multiple_input_files() {
+fn test_multiple_pattern_files_multiple_input_files() {
     grep_test(&["-f", BRE_FILE_1, "-f", BRE_FILE_2, INPUT_FILE_1, INPUT_FILE_2, INPUT_FILE_3], LINES_INPUT, "tests/grep/f_1:line_{1}\ntests/grep/f_1:p_line_{2}_s\ntests/grep/f_1:  line_{3}  \ntests/grep/f_1:line_{70}\ntests/grep/f_2:#include <stdio.h>\ntests/grep/f_2:void func1() {\ntests/grep/f_2:void func2() {\n", "", 0);
 }
 
 #[test]
-fn test_muptiple_pattern_files_multiple_input_files_count() {
+fn test_multiple_pattern_files_multiple_input_files_count() {
     grep_test(
         &[
             "-c",
@@ -1141,7 +1141,7 @@ fn test_muptiple_pattern_files_multiple_input_files_count() {
 }
 
 #[test]
-fn test_muptiple_pattern_files_multiple_input_files_files_with_matches() {
+fn test_multiple_pattern_files_multiple_input_files_files_with_matches() {
     grep_test(
         &[
             "-l",
@@ -1161,7 +1161,7 @@ fn test_muptiple_pattern_files_multiple_input_files_files_with_matches() {
 }
 
 #[test]
-fn test_muptiple_pattern_files_multiple_input_files_quiet() {
+fn test_multiple_pattern_files_multiple_input_files_quiet() {
     grep_test(
         &[
             "-q",
@@ -1181,7 +1181,7 @@ fn test_muptiple_pattern_files_multiple_input_files_quiet() {
 }
 
 #[test]
-fn test_muptiple_pattern_files_multiple_input_files_line_number() {
+fn test_multiple_pattern_files_multiple_input_files_line_number() {
     grep_test(&["-n", "-f", BRE_FILE_1, "-f", BRE_FILE_2, INPUT_FILE_1, INPUT_FILE_2, INPUT_FILE_3], LINES_INPUT, "tests/grep/f_1:1:line_{1}\ntests/grep/f_1:2:p_line_{2}_s\ntests/grep/f_1:3:  line_{3}  \ntests/grep/f_1:7:line_{70}\ntests/grep/f_2:1:#include <stdio.h>\ntests/grep/f_2:8:void func1() {\ntests/grep/f_2:12:void func2() {\n", "", 0);
 }
 

--- a/text/tests/paste/mod.rs
+++ b/text/tests/paste/mod.rs
@@ -9,8 +9,7 @@
 //
 
 use plib::testing::{run_test, TestPlan};
-use std::fs::File;
-use std::io::Read;
+use std::fs;
 use std::path::PathBuf;
 
 fn get_test_file_path(filename: &str) -> PathBuf {
@@ -23,17 +22,14 @@ fn get_test_file_path(filename: &str) -> PathBuf {
 fn run_paste_test(args: Vec<&str>, expected_output_filename: &str) {
     let expected_output_file_path = get_test_file_path(expected_output_filename);
 
-    let mut expected_output = String::new();
-    File::open(expected_output_file_path)
-        .unwrap()
-        .read_to_string(&mut expected_output)
-        .unwrap();
+    let expected_out = fs::read_to_string(expected_output_file_path).unwrap();
 
-    let args: Vec<String> = args.iter().map(|s| s.to_string()).collect();
+    let args = args.into_iter().map(ToOwned::to_owned).collect();
+
     run_test(TestPlan {
         cmd: String::from("paste"),
         args,
-        expected_out: expected_output,
+        expected_out,
         expected_err: String::new(),
         stdin_data: String::new(),
         expected_exit_code: 0,
@@ -81,4 +77,31 @@ fn paste_serial_custom_delimiter() {
         ],
         "output_serial_custom_delim.txt",
     );
+}
+
+// Test case for:
+//
+// thread 'main' panicked at text/./paste.rs:133:16:
+// index out of bounds: the len is 0 but the index is 18446744073709551615
+// note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
+#[test]
+fn paste_simple_multi_line_input() {
+    let args = ["-d", "", "-s", "-"]
+        .into_iter()
+        .map(ToOwned::to_owned)
+        .collect();
+
+    run_test(TestPlan {
+        cmd: String::from("paste"),
+        args,
+        expected_out: "Line 1Line 2Line 3\n".to_owned(),
+        expected_err: String::new(),
+        stdin_data: "\
+Line 1
+Line 2
+Line 3
+"
+        .to_owned(),
+        expected_exit_code: 0,
+    });
 }


### PR DESCRIPTION
Allow an empty delimiter list, so the program can do something useful in this case, instead of just exiting. Also, some other implementations of `paste` permit this use case, and users of paste rely on this functionality. [1] Also, read from stdin if "-" is passed.

[1] https://stackoverflow.com/questions/1251999/how-can-i-replace-each-newline-n-with-a-space-using-sed/7697604#7697604