### PR TITLE
feat: use `std::io::IsTerminal` instead of `atty` crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -109,17 +109,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d67af77d68a931ecd5cbd8a3b5987d63a1d1d1278f7f6a60ae33db485cdebb69"
 
 [[package]]
-name = "atty"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
-dependencies = [
- "hermit-abi 0.1.19",
- "libc",
- "winapi",
-]
-
-[[package]]
 name = "autocfg"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -684,15 +673,6 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermit-abi"
-version = "0.1.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "hermit-abi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
@@ -1012,7 +992,7 @@ version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "80e04d1dcff3aae0704555fe5fee3bcfaf3d1fdf8a7e521d5b9d2b42acb52cec"
 dependencies = [
- "hermit-abi 0.3.9",
+ "hermit-abi",
  "libc",
  "wasi",
  "windows-sys 0.52.0",
@@ -1338,7 +1318,6 @@ dependencies = [
 name = "posixutils-file"
 version = "0.2.1"
 dependencies = [
- "atty",
  "clap",
  "gettext-rs",
  "libc",
@@ -1391,7 +1370,6 @@ dependencies = [
 name = "posixutils-misc"
 version = "0.2.1"
 dependencies = [
- "atty",
  "clap",
  "gettext-rs",
  "libc",
@@ -1412,7 +1390,6 @@ dependencies = [
 name = "posixutils-process"
 version = "0.2.1"
 dependencies = [
- "atty",
  "bindgen",
  "clap",
  "dirs 5.0.1",
@@ -1459,7 +1436,6 @@ dependencies = [
 name = "posixutils-text"
 version = "0.2.1"
 dependencies = [
- "atty",
  "chrono",
  "clap",
  "ctor",
@@ -1479,7 +1455,6 @@ dependencies = [
 name = "posixutils-tree"
 version = "0.2.1"
 dependencies = [
- "atty",
  "chrono",
  "clap",
  "errno",
@@ -1495,7 +1470,6 @@ dependencies = [
 name = "posixutils-users"
 version = "0.2.1"
 dependencies = [
- "atty",
  "chrono",
  "clap",
  "gettext-rs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,6 @@ members = [
 ]
 
 [workspace.dependencies]
-atty = "0.2"
 clap = { version = "4", default-features = false, features = ["std", "derive", "help", "usage", "error-context", "cargo"] }
 chrono = { version = "0.4", default-features = false, features = ["clock"] }
 libc = "0.2"

--- a/file/Cargo.toml
+++ b/file/Cargo.toml
@@ -11,7 +11,6 @@ plib = { path = "../plib" }
 clap.workspace = true
 gettext-rs.workspace = true
 libc.workspace = true
-atty.workspace = true
 regex.workspace = true
 walkdir = "2"
 users = "0.11"

--- a/misc/Cargo.toml
+++ b/misc/Cargo.toml
@@ -8,7 +8,6 @@ repository = "https://github.com/rustcoreutils/posixutils-rs.git"
 
 [dependencies]
 plib = { path = "../plib" }
-atty.workspace = true
 clap.workspace = true
 libc.workspace = true
 gettext-rs.workspace = true

--- a/process/Cargo.toml
+++ b/process/Cargo.toml
@@ -11,7 +11,6 @@ plib = { path = "../plib" }
 clap.workspace = true
 gettext-rs.workspace = true
 libc.workspace = true
-atty.workspace = true
 dirs = "5.0"
 
 [dev-dependencies]

--- a/process/nohup.rs
+++ b/process/nohup.rs
@@ -13,7 +13,7 @@ use libc::{dup, dup2, SIGHUP, SIG_IGN};
 use plib::PROJECT_NAME;
 use std::env;
 use std::fs::{File, OpenOptions};
-use std::io;
+use std::io::{self, IsTerminal};
 use std::os::unix::io::AsRawFd;
 use std::process::{self, Command};
 
@@ -45,11 +45,11 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     };
 
     // Redirecting stdout and stderr to the nohup.out file if they are connected to a terminal
-    if atty::is(atty::Stream::Stdout) || atty::is(atty::Stream::Stderr) {
+    if io::stdout().is_terminal() || io::stderr().is_terminal() {
         let nohup_out_file =
             get_nohup_out_file().expect("Failed to open nohup.out in current or home directory");
 
-        if atty::is(atty::Stream::Stdout) {
+        if io::stdout().is_terminal() {
             let fd = nohup_out_file.0.as_raw_fd();
 
             if unsafe { dup2(fd, libc::STDOUT_FILENO) } == -1 {
@@ -71,7 +71,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             }
         }
 
-        if atty::is(atty::Stream::Stderr) {
+        if io::stderr().is_terminal() {
             let fd = nohup_out_file.0.as_raw_fd();
 
             if unsafe { dup2(fd, libc::STDERR_FILENO) } == -1 {

--- a/text/Cargo.toml
+++ b/text/Cargo.toml
@@ -16,7 +16,6 @@ chrono.workspace = true
 libc.workspace = true
 notify-debouncer-full = "0.3"
 ctor = "0.2"
-atty.workspace = true
 diff = "0.1"
 dirs = "5.0"
 deunicode = "1.6"
@@ -101,4 +100,3 @@ path = "./tsort.rs"
 [[bin]]
 name = "wc"
 path = "./wc.rs"
-

--- a/tree/Cargo.toml
+++ b/tree/Cargo.toml
@@ -14,7 +14,6 @@ gettext-rs.workspace = true
 libc.workspace = true
 regex.workspace = true
 chrono.workspace = true
-atty.workspace = true
 errno.workspace = true
 
 [dev-dependencies]
@@ -87,4 +86,3 @@ path = "./touch.rs"
 [[bin]]
 name = "unlink"
 path = "./unlink.rs"
-

--- a/tree/mv.rs
+++ b/tree/mv.rs
@@ -18,9 +18,10 @@ use plib::PROJECT_NAME;
 use std::{
     collections::{HashMap, HashSet},
     ffi::CString,
+    fs,
+    io::{self, IsTerminal},
     os::unix::{ffi::OsStrExt, fs::MetadataExt},
     path::{Path, PathBuf},
-    {fs, io},
 };
 
 /// mv - move files
@@ -54,7 +55,7 @@ impl MvConfig {
         MvConfig {
             force: args.force,
             interactive: args.interactive,
-            is_terminal: atty::is(atty::Stream::Stdin),
+            is_terminal: io::stdin().is_terminal(),
         }
     }
 }

--- a/tree/rm.rs
+++ b/tree/rm.rs
@@ -16,7 +16,8 @@ use gettextrs::{bind_textdomain_codeset, gettext, setlocale, textdomain, LocaleC
 use plib::PROJECT_NAME;
 use std::{
     ffi::CString,
-    fs, io,
+    fs,
+    io::{self, IsTerminal},
     os::unix::{ffi::OsStrExt, fs::MetadataExt},
     path::{Path, PathBuf},
 };
@@ -440,7 +441,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     textdomain(PROJECT_NAME)?;
     bind_textdomain_codeset(PROJECT_NAME, "UTF-8")?;
 
-    let is_tty = atty::is(atty::Stream::Stdin);
+    let is_tty = io::stdin().is_terminal();
     let cfg = RmConfig { args, is_tty };
 
     let mut exit_code = 0;

--- a/tree/tests/mv/mod.rs
+++ b/tree/tests/mv/mod.rs
@@ -1272,7 +1272,7 @@ fn test_mv_hardlink_case() {
 #[test]
 #[cfg_attr(not(all(target_os = "linux", feature = "posixutils_test_all")), ignore)]
 fn test_mv_i_link_no() {
-    // Tricks `atty::is(atty::Stream::Stdin)` to allow showing the overwrite
+    // Tricks `io::stdin().is_terminal()` to allow showing the overwrite
     // prompt without -i
     fn mv_test_fake_tty(
         args: &[&str],

--- a/users/Cargo.toml
+++ b/users/Cargo.toml
@@ -11,7 +11,6 @@ plib = { path = "../plib" }
 clap.workspace = true
 gettext-rs.workspace = true
 libc.workspace = true
-atty.workspace = true
 chrono.workspace = true
 syslog = "6.1"
 
@@ -42,4 +41,3 @@ path = "./tty.rs"
 [[bin]]
 name = "write"
 path = "./write.rs"
-

--- a/users/mesg.rs
+++ b/users/mesg.rs
@@ -14,7 +14,7 @@
 use clap::Parser;
 use gettextrs::{bind_textdomain_codeset, gettext, setlocale, textdomain, LocaleCategory};
 use plib::PROJECT_NAME;
-use std::io::{self, Error, ErrorKind};
+use std::io::{self, Error, ErrorKind, IsTerminal};
 use std::mem;
 
 /// mesg - permit or deny messages
@@ -25,27 +25,29 @@ struct Args {
     operand: Option<String>,
 }
 
-const STREAMS: [atty::Stream; 3] = [
-    atty::Stream::Stdin,
-    atty::Stream::Stdout,
-    atty::Stream::Stderr,
-];
-
-fn find_tty() -> Option<atty::Stream> {
-    for stream in STREAMS {
-        if atty::is(stream) {
-            return Some(stream);
-        }
-    }
-
-    None
+enum Stream {
+    Stdin,
+    Stdout,
+    Stderr,
 }
 
-fn tty_to_fd(tty: atty::Stream) -> i32 {
+fn find_tty() -> Option<Stream> {
+    if io::stdin().is_terminal() {
+        Some(Stream::Stdin)
+    } else if io::stdout().is_terminal() {
+        Some(Stream::Stdout)
+    } else if io::stderr().is_terminal() {
+        Some(Stream::Stderr)
+    } else {
+        None
+    }
+}
+
+fn tty_to_fd(tty: Stream) -> i32 {
     match tty {
-        atty::Stream::Stdin => libc::STDIN_FILENO,
-        atty::Stream::Stdout => libc::STDOUT_FILENO,
-        atty::Stream::Stderr => libc::STDERR_FILENO,
+        Stream::Stdin => libc::STDIN_FILENO,
+        Stream::Stdout => libc::STDOUT_FILENO,
+        Stream::Stderr => libc::STDERR_FILENO,
     }
 }
 

--- a/users/tty.rs
+++ b/users/tty.rs
@@ -7,8 +7,10 @@
 // SPDX-License-Identifier: MIT
 //
 
+use std::io::{self, IsTerminal};
+
 fn main() {
-    let is_tty = atty::is(atty::Stream::Stdin);
+    let is_tty = io::stdin().is_terminal();
     if !is_tty {
         println!("not a tty");
         std::process::exit(1);


### PR DESCRIPTION
small code change for a trait from std. it has MSRV 1.70.0

P.S. when I run clippy I've got too much warnings and even errors. I can help with it and apply fixes for all of them