### PR TITLE
fix: refactor for clippy fixes

### DIFF
--- a/awk/src/interpreter/mod.rs
+++ b/awk/src/interpreter/mod.rs
@@ -104,11 +104,7 @@ fn swap_with_default<T: Default>(value: &mut T) -> T {
 
 fn maybe_numeric_string<S: Into<AwkString>>(str: S) -> AwkString {
     let mut str = str.into();
-    let numeric_string = is_valid_number(
-        str.as_str()
-            .trim()
-            .trim_start_matches(|c| c == '+' || c == '-'),
-    );
+    let numeric_string = is_valid_number(str.as_str().trim().trim_start_matches(['+', '-']));
     str.is_numeric = numeric_string;
     str
 }

--- a/calc/bc_util/interpreter.rs
+++ b/calc/bc_util/interpreter.rs
@@ -201,7 +201,7 @@ impl Interpreter {
                     .ok_or("array index is too large")? as usize;
                 if let Some(call_frame) = self.call_frames.last_mut() {
                     if let Some(array) = &mut call_frame.array_variables[name_index(*name)] {
-                        return Ok(get_or_extend(array, index as usize));
+                        return Ok(get_or_extend(array, index));
                     }
                 }
                 Ok(get_or_extend(

--- a/calc/expr.rs
+++ b/calc/expr.rs
@@ -67,11 +67,7 @@ fn token_display(t: &Token) -> String {
 
 // is token an lval?
 fn token_is_lval(t: &Token) -> bool {
-    match t {
-        Token::Integer(_) => true,
-        Token::Str(_) => true,
-        _ => false,
-    }
+    matches!(t, Token::Integer(_) | Token::Str(_))
 }
 
 // is token zero?
@@ -228,14 +224,12 @@ fn logop(lhs: &Token, rhs: &Token, is_and: bool) -> Token {
         } else {
             Token::Integer(0)
         }
+    } else if !lhs_zero {
+        lhs.clone()
+    } else if !rhs_zero {
+        rhs.clone()
     } else {
-        if !lhs_zero {
-            lhs.clone()
-        } else if !rhs_zero {
-            rhs.clone()
-        } else {
-            Token::Integer(0)
-        }
+        Token::Integer(0)
     }
 }
 

--- a/datetime/cal.rs
+++ b/datetime/cal.rs
@@ -97,7 +97,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // If no arguments are provided, display the current month
     if args.month.is_none() && args.year.is_none() {
         let now = chrono::Local::now();
-        args.month = Some(now.month() as u32);
+        args.month = Some(now.month());
         args.year = Some(now.year() as u32);
 
     // If only one argument is provided, assume it is the entire year

--- a/display/echo.rs
+++ b/display/echo.rs
@@ -80,7 +80,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     args.remove(0);
 
     let skip_nl = {
-        if args.len() > 0 && (args[0] == "-n") {
+        if !args.is_empty() && (args[0] == "-n") {
             args.remove(0);
             true
         } else {

--- a/file/dd.rs
+++ b/file/dd.rs
@@ -151,7 +151,7 @@ fn convert_swab(data: &mut [u8]) {
 fn convert_lcase(data: &mut [u8]) {
     for byte in data.iter_mut() {
         if *byte >= b'A' && *byte <= b'Z' {
-            *byte = *byte + 32;
+            *byte += 32;
         }
     }
 }
@@ -159,7 +159,7 @@ fn convert_lcase(data: &mut [u8]) {
 fn convert_ucase(data: &mut [u8]) {
     for byte in data.iter_mut() {
         if *byte >= b'a' && *byte <= b'z' {
-            *byte = *byte - 32;
+            *byte -= 32;
         }
     }
 }

--- a/file/find.rs
+++ b/file/find.rs
@@ -388,7 +388,7 @@ fn evaluate_expression(
                 Expr::Newer(f) => {
                     if let Ok(metadata) = fs::metadata(f) {
                         if let Ok(file_metadata) = file.metadata() {
-                            if !(file_metadata.modified().unwrap() > metadata.modified().unwrap()) {
+                            if file_metadata.modified().unwrap() <= metadata.modified().unwrap() {
                                 c_files.remove(file.path());
                             }
                         }

--- a/file/od.rs
+++ b/file/od.rs
@@ -259,12 +259,12 @@ fn parse_offset(offset: &str) -> Result<u64, Box<dyn std::error::Error>> {
     let mut multiplier = 1;
 
     // Handle special suffixes
-    let offset = if offset.ends_with('b') {
+    let offset = if let Some(stripped) = offset.strip_suffix('b') {
         multiplier = 512;
-        &offset[..offset.len() - 1]
-    } else if offset.ends_with('.') {
+        stripped
+    } else if let Some(stripped) = offset.strip_suffix('.') {
         base = 10;
-        &offset[..offset.len() - 1]
+        stripped
     } else {
         offset
     };

--- a/file/split.rs
+++ b/file/split.rs
@@ -90,7 +90,7 @@ impl OutputState {
             if i == 0 {
                 break;
             }
-            i = i - 1;
+            i -= 1;
         }
 
         Err("maximum suffix reached")
@@ -126,7 +126,7 @@ impl OutputState {
     }
 
     fn incr_output(&mut self, n: u64) {
-        self.count = self.count + n;
+        self.count += n;
         assert!(self.count <= self.boundary);
 
         if self.count == self.boundary {
@@ -137,8 +137,7 @@ impl OutputState {
     fn write(&mut self, buf: &[u8]) -> io::Result<()> {
         match &mut self.outf {
             None => {
-                assert!(false);
-                Ok(())
+                unreachable!()
             }
             Some(ref mut f) => f.write_all(buf),
         }
@@ -155,7 +154,7 @@ impl OutputState {
             let slice = &buf[consumed..consumed + wlen];
             self.write(slice)?;
 
-            consumed = consumed + wlen;
+            consumed += wlen;
 
             self.incr_output(wlen as u64);
         }

--- a/fs/df.rs
+++ b/fs/df.rs
@@ -14,7 +14,7 @@ use std::ffi::{CStr, CString};
 use std::io;
 
 #[cfg(target_os = "linux")]
-const _PATH_MOUNTED: &'static str = "/etc/mtab";
+const _PATH_MOUNTED: &str = "/etc/mtab";
 
 /// df - report free storage space
 #[derive(Parser, Debug)]

--- a/ftw/tests/integration.rs
+++ b/ftw/tests/integration.rs
@@ -124,7 +124,9 @@ fn test_ftw_deep() {
             panic!("{}", io::Error::last_os_error());
         }
 
-        fd = ftw::FileDescriptor::open_at(&fd, filename.as_ptr(), libc::O_RDONLY).unwrap();
+        fd = unsafe {
+            ftw::FileDescriptor::open_at(&fd, filename.as_ptr(), libc::O_RDONLY).unwrap()
+        };
     }
 
     let mut count = 0;
@@ -295,7 +297,9 @@ fn test_ftw_long_filename() {
             panic!("{}", io::Error::last_os_error());
         }
 
-        fd = ftw::FileDescriptor::open_at(&fd, filename.as_ptr(), libc::O_RDONLY).unwrap();
+        fd = unsafe {
+            ftw::FileDescriptor::open_at(&fd, filename.as_ptr(), libc::O_RDONLY).unwrap()
+        };
 
         // If at the last index, add dummy directories
         if i == DIR_HIERARCHY_DEPTH - 1 {

--- a/ftw/tests/integration2.rs
+++ b/ftw/tests/integration2.rs
@@ -85,7 +85,9 @@ fn test_ftw_too_many_open_files() {
                 panic!("{}", io::Error::last_os_error());
             }
 
-            fd = ftw::FileDescriptor::open_at(&fd, filename.as_ptr(), libc::O_RDONLY).unwrap();
+            fd = unsafe {
+                ftw::FileDescriptor::open_at(&fd, filename.as_ptr(), libc::O_RDONLY).unwrap()
+            };
         }
     }
 
@@ -120,7 +122,9 @@ fn test_ftw_too_many_open_files() {
         // Open the penultimate directory
         for i in 0..DIR_HIERARCHY_DEPTH - 1 {
             let filename = if i == 0 { &test_dir_name } else { &dir_name };
-            fd = ftw::FileDescriptor::open_at(&fd, filename.as_ptr(), libc::O_RDONLY).unwrap();
+            fd = unsafe {
+                ftw::FileDescriptor::open_at(&fd, filename.as_ptr(), libc::O_RDONLY).unwrap()
+            };
         }
 
         // Remove the directories starting from the deepest
@@ -137,7 +141,9 @@ fn test_ftw_too_many_open_files() {
             }
 
             // Go up a level in the tree
-            fd = ftw::FileDescriptor::open_at(&fd, c"..".as_ptr(), libc::O_RDONLY).unwrap();
+            fd = unsafe {
+                ftw::FileDescriptor::open_at(&fd, c"..".as_ptr(), libc::O_RDONLY).unwrap()
+            };
         }
 
         assert!(!Path::new(test_dir).exists());

--- a/i18n/gencat.rs
+++ b/i18n/gencat.rs
@@ -486,7 +486,7 @@ impl MessageCatalog {
         let mut act_size = 1 + self.cat.total_messages() / 5;
 
         while act_size <= best_total {
-            let mut deep = vec![0; act_size as usize];
+            let mut deep = vec![0; act_size];
             let mut act_depth = 1;
 
             for set in self.cat.all_sets() {
@@ -501,7 +501,7 @@ impl MessageCatalog {
                     if deep[idx] > act_depth {
                         act_depth = deep[idx];
 
-                        if act_depth * act_size > best_total as usize {
+                        if act_depth * act_size > best_total {
                             break;
                         }
                     }
@@ -540,7 +540,7 @@ impl MessageCatalog {
                     idx += best_size * 3;
                 }
 
-                array[idx] = (set.set_id + 1) as u32;
+                array[idx] = set.set_id + 1;
                 array[idx + 1] = msg.msg_id as u32;
                 array[idx + 2] = string_pool.len() as u32;
 
@@ -580,14 +580,14 @@ impl MessageCatalog {
         // little-endian array
         let array_size = (plane_size * plane_depth * 3) as usize;
         let mut le_array = vec![0u32; array_size];
-        for i in 0..array_size {
-            le_array[i] = LittleEndian::read_u32(&buf[ptr..(ptr + 4)]);
+        for elem in le_array.iter_mut().take(array_size) {
+            *elem = LittleEndian::read_u32(&buf[ptr..(ptr + 4)]);
             ptr += 4;
         }
 
         let mut be_array = vec![0u32; array_size];
-        for i in 0..array_size {
-            be_array[i] = BigEndian::read_u32(&buf[ptr..(ptr + 4)]);
+        for elem in be_array.iter_mut().take(array_size) {
+            *elem = BigEndian::read_u32(&buf[ptr..(ptr + 4)]);
             ptr += 4;
         }
 
@@ -611,10 +611,7 @@ impl MessageCatalog {
                     + string_offset;
 
                 let msg = String::from_utf8_lossy(&string_pool[string_offset..msg_end]).to_string();
-                set_msg
-                    .entry(set_id)
-                    .or_insert_with(BTreeMap::new)
-                    .insert(msg_id, msg);
+                set_msg.entry(set_id).or_default().insert(msg_id, msg);
             }
         }
 

--- a/m4/test-manager/src/main.rs
+++ b/m4/test-manager/src/main.rs
@@ -59,11 +59,10 @@ fn update_snapshots(args: &Args, update: &UpdateSnapshots) {
     dir.map(|result| result.unwrap())
         .filter(|entry| {
             if !(entry.path().is_file()
-                && match entry.path().extension().map(|e| e.as_bytes()) {
-                    Some(b"m4") => true,
-                    Some(b"args") => true,
-                    _ => false,
-                })
+                && matches!(
+                    entry.path().extension().map(|e| e.as_bytes()),
+                    Some(b"m4") | Some(b"args")
+                ))
             {
                 return false;
             }
@@ -155,7 +154,7 @@ fn update_snapshots(args: &Args, update: &UpdateSnapshots) {
             }
             let mut f = std::fs::OpenOptions::new()
                 .write(true)
-                .create(true)
+                .truncate(true)
                 .open(snapshot_file)
                 .unwrap();
             snapshot.serialize(&mut f);

--- a/misc/test.rs
+++ b/misc/test.rs
@@ -82,10 +82,10 @@ fn parse_unary_op(s: &str) -> Option<UnaryOp> {
 }
 
 fn want_metadata(op: &UnaryOp) -> bool {
-    match op {
-        UnaryOp::Terminal | UnaryOp::StrNonZero | UnaryOp::StrZero => false,
-        _ => true,
-    }
+    !matches!(
+        op,
+        UnaryOp::Terminal | UnaryOp::StrNonZero | UnaryOp::StrZero
+    )
 }
 
 fn eval_str(s: &str) -> bool {
@@ -183,10 +183,7 @@ fn parse_binary_op(s: &str) -> Option<BinOp> {
 }
 
 fn parse_int(s: &str) -> i64 {
-    match s.parse::<i64>() {
-        Ok(i) => i,
-        Err(_) => 0,
-    }
+    s.parse::<i64>().unwrap_or_default()
 }
 
 fn eval_binary_int(op: &BinOp, s1: &str, s2: &str) -> bool {

--- a/pathnames/pathchk.rs
+++ b/pathnames/pathchk.rs
@@ -40,13 +40,10 @@ fn check_path_basic(pathname: &str) -> Result<(), &'static str> {
     }
 
     for component in Path::new(pathname).components() {
-        match component {
-            Component::Normal(filename) => {
-                if filename.to_string_lossy().starts_with("-") {
-                    return Err("filename begins with -");
-                }
+        if let Component::Normal(filename) = component {
+            if filename.to_string_lossy().starts_with("-") {
+                return Err("filename begins with -");
             }
-            _ => {}
         }
     }
 
@@ -64,16 +61,13 @@ fn check_path_limits(
     }
 
     for component in Path::new(pathname).components() {
-        match component {
-            Component::Normal(filename) => {
-                if filename.len() > max_name {
-                    return Err("filename too long");
-                }
-                if check_ascii && !filename.is_ascii() {
-                    return Err("filename contains non-portable characters");
-                }
+        if let Component::Normal(filename) = component {
+            if filename.len() > max_name {
+                return Err("filename too long");
             }
-            _ => {}
+            if check_ascii && !filename.is_ascii() {
+                return Err("filename contains non-portable characters");
+            }
         }
     }
 

--- a/plib/src/lib.rs
+++ b/plib/src/lib.rs
@@ -18,7 +18,7 @@ pub mod sccsfile;
 pub mod testing;
 pub mod utmpx;
 
-pub const PROJECT_NAME: &'static str = "posixutils-rs";
+pub const PROJECT_NAME: &str = "posixutils-rs";
 
 pub const BUFSZ: usize = 8 * 1024;
 

--- a/plib/src/modestr.rs
+++ b/plib/src/modestr.rs
@@ -55,6 +55,12 @@ impl ChmodAction {
     }
 }
 
+impl Default for ChmodAction {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 #[derive(Debug)]
 pub struct ChmodClause {
     // wholist
@@ -80,6 +86,12 @@ impl ChmodClause {
     }
 }
 
+impl Default for ChmodClause {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 #[derive(Debug)]
 pub struct ChmodSymbolic {
     pub clauses: Vec<ChmodClause>,
@@ -90,6 +102,12 @@ impl ChmodSymbolic {
         ChmodSymbolic {
             clauses: Vec::new(),
         }
+    }
+}
+
+impl Default for ChmodSymbolic {
+    fn default() -> Self {
+        Self::new()
     }
 }
 
@@ -227,9 +245,9 @@ pub fn parse(mode: &str) -> Result<ChmodMode, String> {
 // apply symbolic mutations to the given file at path
 pub fn mutate(cur_mode: u32, symbolic: &ChmodSymbolic) -> u32 {
     let mut new_mode = cur_mode;
-    let mut user = cur_mode & S_IRWXU as u32;
-    let mut group = cur_mode & S_IRWXG as u32;
-    let mut others = cur_mode & S_IRWXO as u32;
+    let mut user = cur_mode & S_IRWXU;
+    let mut group = cur_mode & S_IRWXG;
+    let mut others = cur_mode & S_IRWXO;
 
     // apply each clause
     for clause in &symbolic.clauses {
@@ -239,123 +257,123 @@ pub fn mutate(cur_mode: u32, symbolic: &ChmodSymbolic) -> u32 {
                 // add bits to the mode
                 ChmodActionOp::Add => {
                     if action.copy_user {
-                        user |= cur_mode & S_IRWXU as u32;
+                        user |= cur_mode & S_IRWXU;
                     }
                     if action.copy_group {
-                        group |= cur_mode & S_IRWXG as u32;
+                        group |= cur_mode & S_IRWXG;
                     }
                     if action.copy_others {
-                        others |= cur_mode & S_IRWXO as u32;
+                        others |= cur_mode & S_IRWXO;
                     }
                     if action.read {
-                        user |= S_IRUSR as u32;
-                        group |= S_IRGRP as u32;
-                        others |= S_IROTH as u32;
+                        user |= S_IRUSR;
+                        group |= S_IRGRP;
+                        others |= S_IROTH;
                     }
                     if action.write {
-                        user |= S_IWUSR as u32;
-                        group |= S_IWGRP as u32;
-                        others |= S_IWOTH as u32;
+                        user |= S_IWUSR;
+                        group |= S_IWGRP;
+                        others |= S_IWOTH;
                     }
                     if action.execute {
-                        user |= S_IXUSR as u32;
-                        group |= S_IXGRP as u32;
-                        others |= S_IXOTH as u32;
+                        user |= S_IXUSR;
+                        group |= S_IXGRP;
+                        others |= S_IXOTH;
                     }
                     if action.execute_dir {
-                        user |= S_IXUSR as u32;
-                        group |= S_IXGRP as u32;
-                        others |= S_IXOTH as u32;
+                        user |= S_IXUSR;
+                        group |= S_IXGRP;
+                        others |= S_IXOTH;
                     }
                     if action.setuid {
-                        user |= S_ISUID as u32;
+                        user |= S_ISUID;
                     }
                     if action.sticky {
-                        others |= S_ISVTX as u32;
+                        others |= S_ISVTX;
                     }
                 }
 
                 // remove bits from the mode
                 ChmodActionOp::Remove => {
                     if action.copy_user {
-                        user &= !(cur_mode & S_IRWXU as u32);
+                        user &= !(cur_mode & S_IRWXU);
                     }
                     if action.copy_group {
-                        group &= !(cur_mode & S_IRWXG as u32);
+                        group &= !(cur_mode & S_IRWXG);
                     }
                     if action.copy_others {
-                        others &= !(cur_mode & S_IRWXO as u32);
+                        others &= !(cur_mode & S_IRWXO);
                     }
                     if action.read {
-                        user &= !S_IRUSR as u32;
-                        group &= !S_IRGRP as u32;
-                        others &= !S_IROTH as u32;
+                        user &= !S_IRUSR;
+                        group &= !S_IRGRP;
+                        others &= !S_IROTH;
                     }
                     if action.write {
-                        user &= !S_IWUSR as u32;
-                        group &= !S_IWGRP as u32;
-                        others &= !S_IWOTH as u32;
+                        user &= !S_IWUSR;
+                        group &= !S_IWGRP;
+                        others &= !S_IWOTH;
                     }
                     if action.execute {
-                        user &= !S_IXUSR as u32;
-                        group &= !S_IXGRP as u32;
-                        others &= !S_IXOTH as u32;
+                        user &= !S_IXUSR;
+                        group &= !S_IXGRP;
+                        others &= !S_IXOTH;
                     }
                     if action.execute_dir {
-                        user &= !S_IXUSR as u32;
-                        group &= !S_IXGRP as u32;
-                        others &= !S_IXOTH as u32;
+                        user &= !S_IXUSR;
+                        group &= !S_IXGRP;
+                        others &= !S_IXOTH;
                     }
                     if action.setuid {
-                        user &= !S_ISUID as u32;
+                        user &= !S_ISUID;
                     }
                     if action.sticky {
-                        others &= !S_ISVTX as u32;
+                        others &= !S_ISVTX;
                     }
                 }
 
                 // set the mode bits
                 ChmodActionOp::Set => {
                     if action.copy_user {
-                        user = cur_mode & S_IRWXU as u32;
+                        user = cur_mode & S_IRWXU;
                     } else {
                         user = 0;
                     }
                     if action.copy_group {
-                        group = cur_mode & S_IRWXG as u32;
+                        group = cur_mode & S_IRWXG;
                     } else {
                         group = 0;
                     }
                     if action.copy_others {
-                        others = cur_mode & S_IRWXO as u32;
+                        others = cur_mode & S_IRWXO;
                     } else {
                         others = 0;
                     }
                     if action.read {
-                        user |= S_IRUSR as u32;
-                        group |= S_IRGRP as u32;
-                        others |= S_IROTH as u32;
+                        user |= S_IRUSR;
+                        group |= S_IRGRP;
+                        others |= S_IROTH;
                     }
                     if action.write {
-                        user |= S_IWUSR as u32;
-                        group |= S_IWGRP as u32;
-                        others |= S_IWOTH as u32;
+                        user |= S_IWUSR;
+                        group |= S_IWGRP;
+                        others |= S_IWOTH;
                     }
                     if action.execute {
-                        user |= S_IXUSR as u32;
-                        group |= S_IXGRP as u32;
-                        others |= S_IXOTH as u32;
+                        user |= S_IXUSR;
+                        group |= S_IXGRP;
+                        others |= S_IXOTH;
                     }
                     if action.execute_dir {
-                        user |= S_IXUSR as u32;
-                        group |= S_IXGRP as u32;
-                        others |= S_IXOTH as u32;
+                        user |= S_IXUSR;
+                        group |= S_IXGRP;
+                        others |= S_IXOTH;
                     }
                     if action.setuid {
-                        user |= S_ISUID as u32;
+                        user |= S_ISUID;
                     }
                     if action.sticky {
-                        others |= S_ISVTX as u32;
+                        others |= S_ISVTX;
                     }
                 }
             }
@@ -363,13 +381,13 @@ pub fn mutate(cur_mode: u32, symbolic: &ChmodSymbolic) -> u32 {
 
         // apply the clause
         if clause.user {
-            new_mode = (new_mode & !S_IRWXU as u32) | user;
+            new_mode = (new_mode & !S_IRWXU) | user;
         }
         if clause.group {
-            new_mode = (new_mode & !S_IRWXG as u32) | group;
+            new_mode = (new_mode & !S_IRWXG) | group;
         }
         if clause.others {
-            new_mode = (new_mode & !S_IRWXO as u32) | others;
+            new_mode = (new_mode & !S_IRWXO) | others;
         }
     }
 

--- a/plib/src/testing.rs
+++ b/plib/src/testing.rs
@@ -49,7 +49,7 @@ fn run_test_base(cmd: &str, args: &Vec<String>, stdin_data: &[u8]) -> Output {
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
         .spawn()
-        .expect(format!("failed to spawn command {}", cmd).as_str());
+        .unwrap_or_else(|_| panic!("failed to spawn command {}", cmd));
 
     // Separate the mutable borrow of stdin from the child process
     if let Some(mut stdin) = child.stdin.take() {
@@ -74,8 +74,7 @@ fn run_test_base(cmd: &str, args: &Vec<String>, stdin_data: &[u8]) -> Output {
     }
 
     // Ensure we wait for the process to complete after writing to stdin
-    let output = child.wait_with_output().expect("failed to wait for child");
-    output
+    child.wait_with_output().expect("failed to wait for child")
 }
 
 pub fn run_test(plan: TestPlan) {

--- a/process/fuser.rs
+++ b/process/fuser.rs
@@ -199,9 +199,8 @@ mod linux {
         type Item = &'a IpConnections;
 
         fn next(&mut self) -> Option<Self::Item> {
-            self.current.map(|node| {
+            self.current.inspect(|node| {
                 self.current = node.next.as_deref();
-                node
             })
         }
     }
@@ -241,9 +240,8 @@ mod linux {
         type Item = &'a UnixSocketList;
 
         fn next(&mut self) -> Option<Self::Item> {
-            self.current.map(|node| {
+            self.current.inspect(|node| {
                 self.current = node.next.as_deref();
-                node
             })
         }
     }
@@ -279,9 +277,8 @@ mod linux {
         type Item = &'a InodeList;
 
         fn next(&mut self) -> Option<Self::Item> {
-            self.current.map(|node| {
+            self.current.inspect(|node| {
                 self.current = node.next.as_deref();
-                node
             })
         }
     }
@@ -321,9 +318,8 @@ mod linux {
         type Item = &'a DeviceList;
 
         fn next(&mut self) -> Option<Self::Item> {
-            self.current.map(|node| {
+            self.current.inspect(|node| {
                 self.current = node.next.as_deref();
-                node
             })
         }
     }
@@ -1053,7 +1049,7 @@ mod linux {
                     None
                 }
             })
-            .unwrap_or_else(NameSpace::default)
+            .unwrap_or_default()
     }
 
     /// Processes file namespaces by expanding paths and updating lists based on the mount flag.

--- a/process/renice.rs
+++ b/process/renice.rs
@@ -58,7 +58,7 @@ fn parse_id(which: u32, input: &str) -> Result<u32, &'static str> {
         Ok(0) => Err("Invalid ID"),
         Ok(n) => Ok(n),
         Err(e) => {
-            if which != libc::PRIO_USER as u32 {
+            if which != libc::PRIO_USER {
                 eprintln!("{}", e);
                 Err("Invalid ID")
             } else {
@@ -85,11 +85,11 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // which class of priority to modify
     let which: u32 = {
         if args.pgrp {
-            libc::PRIO_PGRP as u32
+            libc::PRIO_PGRP
         } else if args.user {
-            libc::PRIO_USER as u32
+            libc::PRIO_USER
         } else {
-            libc::PRIO_PROCESS as u32
+            libc::PRIO_PROCESS
         }
     };
 

--- a/sys/ipcs.rs
+++ b/sys/ipcs.rs
@@ -241,7 +241,7 @@ fn get_current_date() -> String {
 }
 
 fn display_ipc_status(args: &Args) {
-    println!("IPC status from {} as of {}", "source", get_current_date());
+    println!("IPC status from source as of {}", get_current_date());
 
     if args.message_queues {
         display_message_queues(args);

--- a/sys/ps.rs
+++ b/sys/ps.rs
@@ -81,8 +81,8 @@ fn main() {
     };
 
     println!(
-        "{:<5} {:<5} {:<5} {:<5} {}",
-        "PID", "PPID", "UID", "GID", "COMMAND"
+        "{:<5} {:<5} {:<5} {:<5} COMMAND",
+        "PID", "PPID", "UID", "GID",
     );
     for proc in filtered_processes {
         println!(

--- a/sys/who.rs
+++ b/sys/who.rs
@@ -171,7 +171,7 @@ fn show_utmpx_summary() {
     let mut count = 0;
     let entries = plib::utmpx::load();
     for entry in &entries {
-        if entry.user.len() > 0 {
+        if !entry.user.is_empty() {
             println!("{}", entry.user);
             count += 1;
         }

--- a/text/asa.rs
+++ b/text/asa.rs
@@ -72,7 +72,7 @@ fn asa_file(pathname: &PathBuf) -> io::Result<()> {
     let mut state = AsaState::new();
 
     loop {
-        line_no = line_no + 1;
+        line_no += 1;
 
         let mut raw_line = String::new();
         let n_read = reader.read_line(&mut raw_line)?;
@@ -90,7 +90,7 @@ fn asa_file(pathname: &PathBuf) -> io::Result<()> {
         // exclude first char, and trailing newline
         let mut line_len = raw_line.len() - 1;
         if raw_line.ends_with('\n') {
-            line_len = line_len - 1;
+            line_len -= 1;
         }
         let line = &raw_line[1..line_len];
 

--- a/text/comm.rs
+++ b/text/comm.rs
@@ -93,15 +93,12 @@ fn comm_file(
     let mut want2 = true;
 
     loop {
-        if want1 && buf1.is_empty() {
-            if rdr1.read_line(&mut buf1)? == 0 {
-                want1 = false;
-            }
+        if want1 && buf1.is_empty() && rdr1.read_line(&mut buf1)? == 0 {
+            want1 = false;
         }
-        if want2 && buf2.is_empty() {
-            if rdr2.read_line(&mut buf2)? == 0 {
-                want2 = false;
-            }
+
+        if want2 && buf2.is_empty() && rdr2.read_line(&mut buf2)? == 0 {
+            want2 = false;
         }
 
         if buf1.is_empty() && buf2.is_empty() {

--- a/text/diff.rs
+++ b/text/diff.rs
@@ -131,20 +131,15 @@ fn check_difference(args: Args) -> io::Result<DiffExitStatus> {
         ignore_trailing_white_spaces: args.ignore_eol_space,
         label1: args.label,
         label2: args.label2,
-        output_format: output_format,
+        output_format,
     };
 
     if path1_is_file && path2_is_file {
-        return FileDiff::file_diff(path1, path2, &format_options, None);
+        FileDiff::file_diff(path1, path2, &format_options, None)
     } else if !path1_is_file && !path2_is_file {
-        return DirDiff::dir_diff(
-            PathBuf::from(path1),
-            PathBuf::from(path2),
-            &format_options,
-            args.recurse,
-        );
+        DirDiff::dir_diff(path1, path2, &format_options, args.recurse)
     } else {
-        return FileDiff::file_dir_diff(path1, path2, &format_options);
+        FileDiff::file_dir_diff(path1, path2, &format_options)
     }
 }
 

--- a/text/diff_util/change.rs
+++ b/text/diff_util/change.rs
@@ -84,13 +84,13 @@ impl Change {
 
 impl PartialEq for Change {
     fn eq(&self, other: &Self) -> bool {
-        match (self, other) {
-            (Self::None, Self::None) => true,
-            (Self::Unchanged(_), Self::Unchanged(_)) => true,
-            (Self::Insert(_), Self::Insert(_)) => true,
-            (Self::Delete(_), Self::Delete(_)) => true,
-            (Self::Substitute(_), Self::Substitute(_)) => true,
-            _ => false,
-        }
+        matches!(
+            (self, other),
+            (Self::None, Self::None)
+                | (Self::Unchanged(_), Self::Unchanged(_))
+                | (Self::Insert(_), Self::Insert(_))
+                | (Self::Delete(_), Self::Delete(_))
+                | (Self::Substitute(_), Self::Substitute(_))
+        )
     }
 }

--- a/text/diff_util/constants.rs
+++ b/text/diff_util/constants.rs
@@ -3,8 +3,8 @@
 pub const EXIT_STATUS_NO_DIFFERENCE: u8 = 0;
 pub const EXIT_STATUS_DIFFERENCE: u8 = 1;
 pub const EXIT_STATUS_TROUBLE: u8 = 2;
-pub const NO_NEW_LINE_AT_END_OF_FILE: &'static str = "\\ No newline at end of file";
-pub const COULD_NOT_UNWRAP_FILENAME: &'static str = "Could not unwrap filename!";
+pub const NO_NEW_LINE_AT_END_OF_FILE: &str = "\\ No newline at end of file";
+pub const COULD_NOT_UNWRAP_FILENAME: &str = "Could not unwrap filename!";
 pub const UTF8_NOT_ALLOWED_BYTES: [u8; 26] = [
     0, 1, 2, 3, 4, 5, 6, 11, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 28, 29, 30, 31,
     127,

--- a/text/diff_util/dir_data.rs
+++ b/text/diff_util/dir_data.rs
@@ -16,7 +16,7 @@ pub struct DirData {
 impl DirData {
     pub fn load(path: PathBuf) -> io::Result<DirData> {
         let mut dir_data = DirData {
-            path: path,
+            path,
             files: Default::default(),
         };
         let entries = fs::read_dir(&dir_data.path)?;
@@ -39,6 +39,6 @@ impl DirData {
     }
 
     pub fn path_str(&self) -> &str {
-        &self.path.to_str().unwrap_or(COULD_NOT_UNWRAP_FILENAME)
+        self.path.to_str().unwrap_or(COULD_NOT_UNWRAP_FILENAME)
     }
 }

--- a/text/diff_util/dir_diff.rs
+++ b/text/diff_util/dir_diff.rs
@@ -34,11 +34,11 @@ impl<'a> DirDiff<'a> {
         format_options: &FormatOptions,
         recursive: bool,
     ) -> io::Result<DiffExitStatus> {
-        let mut dir1: DirData = DirData::load(PathBuf::from(path1))?;
-        let mut dir2: DirData = DirData::load(PathBuf::from(path2))?;
+        let mut dir1: DirData = DirData::load(path1)?;
+        let mut dir2: DirData = DirData::load(path2)?;
 
-        let mut dir_diff = DirDiff::new(&mut dir1, &mut dir2, &format_options, recursive);
-        return dir_diff.analyze();
+        let mut dir_diff = DirDiff::new(&mut dir1, &mut dir2, format_options, recursive);
+        dir_diff.analyze()
     }
 
     fn analyze(&mut self) -> io::Result<DiffExitStatus> {
@@ -48,16 +48,15 @@ impl<'a> DirDiff<'a> {
             let is_file = dir_data
                 .files()
                 .get_key_value(file_name)
-                .expect(
-                    format!(
+                .unwrap_or_else(|| {
+                    panic!(
                         "Could not find file in {}",
                         dir_data
                             .path()
                             .to_str()
                             .unwrap_or(COULD_NOT_UNWRAP_FILENAME)
                     )
-                    .as_str(),
-                )
+                })
                 .1
                 .file_type()?
                 .is_file();
@@ -177,13 +176,13 @@ impl<'a> DirDiff<'a> {
                     } else {
                         let (file, dir) = if in_dir1_is_file && !in_dir2_is_file {
                             (
-                                path1.to_str().unwrap_or(&COULD_NOT_UNWRAP_FILENAME),
-                                path2.to_str().unwrap_or(&COULD_NOT_UNWRAP_FILENAME),
+                                path1.to_str().unwrap_or(COULD_NOT_UNWRAP_FILENAME),
+                                path2.to_str().unwrap_or(COULD_NOT_UNWRAP_FILENAME),
                             )
                         } else {
                             (
-                                path2.to_str().unwrap_or(&COULD_NOT_UNWRAP_FILENAME),
-                                path1.to_str().unwrap_or(&COULD_NOT_UNWRAP_FILENAME),
+                                path2.to_str().unwrap_or(COULD_NOT_UNWRAP_FILENAME),
+                                path1.to_str().unwrap_or(COULD_NOT_UNWRAP_FILENAME),
                             )
                         };
 
@@ -217,6 +216,6 @@ impl<'a> DirDiff<'a> {
             }
         }
 
-        return Ok(exit_status);
+        Ok(exit_status)
     }
 }

--- a/text/diff_util/file_data.rs
+++ b/text/diff_util/file_data.rs
@@ -81,7 +81,7 @@ impl FileData {
             }
         }
 
-        return COULD_NOT_UNWRAP_FILENAME;
+        COULD_NOT_UNWRAP_FILENAME
     }
 
     pub fn set_change(&mut self, change: Change, index: usize) {
@@ -102,7 +102,7 @@ impl FileData {
             }
         }
 
-        return false;
+        false
     }
 
     pub fn change(&self, index: usize) -> &Change {
@@ -110,6 +110,6 @@ impl FileData {
     }
 
     pub fn path(&self) -> &str {
-        self.path.to_str().unwrap_or(&COULD_NOT_UNWRAP_FILENAME)
+        self.path.to_str().unwrap_or(COULD_NOT_UNWRAP_FILENAME)
     }
 }

--- a/text/diff_util/functions.rs
+++ b/text/diff_util/functions.rs
@@ -3,7 +3,7 @@ use std::{
     fs::File,
     hash::{DefaultHasher, Hash, Hasher},
     io::{self, Read},
-    path::PathBuf,
+    path::{Path, PathBuf},
     time::SystemTime,
 };
 
@@ -35,7 +35,7 @@ pub fn vec_min(nums: &[usize]) -> usize {
         }
     }
 
-    return result;
+    result
 }
 
 pub fn is_binary(file_path: &PathBuf) -> io::Result<bool> {
@@ -43,8 +43,8 @@ pub fn is_binary(file_path: &PathBuf) -> io::Result<bool> {
     let mut buffer = [0; 1024];
 
     if let Ok(count) = file.read(&mut buffer) {
-        for i in 0..count {
-            if UTF8_NOT_ALLOWED_BYTES.contains(&buffer[i]) {
+        for buf in buffer.iter().take(count) {
+            if UTF8_NOT_ALLOWED_BYTES.contains(buf) {
                 return Ok(true);
             }
         }
@@ -53,8 +53,8 @@ pub fn is_binary(file_path: &PathBuf) -> io::Result<bool> {
     Ok(false)
 }
 
-pub fn check_existance(path_buf: &PathBuf) -> io::Result<bool> {
-    if path_buf.exists() == false {
+pub fn check_existance(path_buf: &Path) -> io::Result<bool> {
+    if !path_buf.exists() {
         println!(
             "diff: {}: No such file or directory",
             path_buf.to_str().unwrap_or(COULD_NOT_UNWRAP_FILENAME)

--- a/text/diff_util/hunks.rs
+++ b/text/diff_util/hunks.rs
@@ -34,7 +34,7 @@ impl Hunk {
         let (ln1, ln2) = change.get_lns();
 
         Self {
-            kind: change.clone(),
+            kind: change,
             changes: vec![change; 1],
             ln1_start: ln1,
             ln1_end: ln1,
@@ -107,7 +107,7 @@ impl Hunk {
     }
 
     pub fn change_sequence_acceptable(&self, change: &Change) -> bool {
-        let sequence_is_allowed = if let Some(_) = self.changes.last() {
+        let sequence_is_allowed = if self.changes.last().is_some() {
             change.get_ln1().abs_diff(self.ln1_start) == 1
                 || change.get_ln1().abs_diff(self.ln1_end) == 1
                 || change.get_ln2().abs_diff(self.ln2_start) == 1
@@ -139,7 +139,7 @@ impl Hunk {
                     println!("< {}", file1.line(change.get_ln1() - 1));
                 }
 
-                if is_last && file1.ends_with_newline() == false {
+                if is_last && !file1.ends_with_newline() {
                     println!("{}", NO_NEW_LINE_AT_END_OF_FILE);
                 }
             }
@@ -159,7 +159,7 @@ impl Hunk {
                     println!("< {}", old);
                 }
 
-                if is_last && file1.ends_with_newline() == false {
+                if is_last && !file1.ends_with_newline() {
                     println!("{}", NO_NEW_LINE_AT_END_OF_FILE);
                 }
 
@@ -169,7 +169,7 @@ impl Hunk {
                     println!("> {}", new);
                 }
 
-                if is_last && file2.ends_with_newline() == false {
+                if is_last && !file2.ends_with_newline() {
                     println!("{}", NO_NEW_LINE_AT_END_OF_FILE);
                 }
             }
@@ -254,7 +254,7 @@ impl Hunk {
             }
         }
 
-        if is_last && file1.ends_with_newline() == false {
+        if is_last && !file1.ends_with_newline() {
             println!(
                 "diff: {}:{}\n",
                 file1.name(),
@@ -262,7 +262,7 @@ impl Hunk {
             );
         }
 
-        if is_last && file2.ends_with_newline() == false {
+        if is_last && !file2.ends_with_newline() {
             println!(
                 "diff: {}:{}\n",
                 file2.name(),
@@ -300,7 +300,7 @@ impl Hunk {
             }
         }
 
-        if is_last && file1.ends_with_newline() == false {
+        if is_last && !file1.ends_with_newline() {
             println!(
                 "diff: {}:{}\n",
                 file1.name(),
@@ -308,7 +308,7 @@ impl Hunk {
             );
         }
 
-        if is_last && file2.ends_with_newline() == false {
+        if is_last && !file2.ends_with_newline() {
             println!(
                 "diff: {}:{}\n",
                 file2.name(),
@@ -326,7 +326,7 @@ pub struct Hunks {
 impl Hunks {
     pub fn new() -> Self {
         Self {
-            hunks: vec![Hunk::new(); 0],
+            hunks: vec![] as Vec<Hunk>,
         }
     }
 

--- a/text/expand.rs
+++ b/text/expand.rs
@@ -57,7 +57,7 @@ fn parse_tablist(tablist: &str) -> Result<TabList, &'static str> {
 }
 
 fn space_out(column: &mut usize, writer: &mut BufWriter<dyn Write>) -> io::Result<()> {
-    *column = *column + 1;
+    *column += 1;
 
     writer.write_all(b" ")?;
 
@@ -89,14 +89,14 @@ fn expand_file(tablist: &TabList, pathname: &PathBuf) -> io::Result<()> {
                 // backspace
                 writer.write_all(&[byte])?;
                 if column > 1 {
-                    column = column - 1;
+                    column -= 1;
                 }
             } else if byte == b'\r' || byte == b'\n' {
                 writer.write_all(&[byte])?;
                 column = 1;
             } else if byte != b'\t' {
                 writer.write_all(&[byte])?;
-                column = column + 1;
+                column += 1;
             } else {
                 match tablist {
                     TabList::UniStop(n) => {
@@ -115,7 +115,7 @@ fn expand_file(tablist: &TabList, pathname: &PathBuf) -> io::Result<()> {
                             while column < next_tab {
                                 space_out(&mut column, &mut writer)?;
                             }
-                            cur_stop = cur_stop + 1;
+                            cur_stop += 1;
                             space_out(&mut column, &mut writer)?;
                         }
                     }

--- a/text/head.rs
+++ b/text/head.rs
@@ -56,10 +56,10 @@ fn head_file(args: &Args, pathname: &PathBuf, first: bool, want_header: bool) ->
         for chv in buf {
             // LF character encountered
             if *chv == 10 {
-                nl = nl + 1;
+                nl += 1;
             }
 
-            pos = pos + 1;
+            pos += 1;
 
             // if user-specified limit reached, stop
             if nl >= args.n {

--- a/text/join.rs
+++ b/text/join.rs
@@ -104,7 +104,7 @@ fn process_files2(
                     for num in order {
                         let f_num: Vec<&str> = num.split('.').collect();
                         if f_num[0] == "1" {
-                            if fields1.len() <= f_num[1].parse::<usize>()? - 1 {
+                            if fields1.len() < f_num[1].parse::<usize>()? {
                                 if let Some(e) = &e {
                                     res.push(e.to_string());
                                 }
@@ -112,7 +112,7 @@ fn process_files2(
                                 res.push(fields1[f_num[1].parse::<usize>()? - 1].clone());
                             }
                         } else if f_num[0] == "2" {
-                            if fields2.len() <= f_num[1].parse::<usize>()? - 1 {
+                            if fields2.len() < f_num[1].parse::<usize>()? {
                                 if let Some(e) = &e {
                                     res.push(e.to_string());
                                 }
@@ -124,10 +124,8 @@ fn process_files2(
                     if v == 0 {
                         println!("{}", res.join(" "));
                     }
-                } else {
-                    if v == 0 {
-                        println!("{} {}", fields1.join(" "), fields2[1..].join(" "));
-                    }
+                } else if v == 0 {
+                    println!("{} {}", fields1.join(" "), fields2[1..].join(" "));
                 }
             }
         }

--- a/text/pr.rs
+++ b/text/pr.rs
@@ -463,11 +463,9 @@ fn pr_merged(paths: &[PathBuf], params: &Parameters) -> io::Result<()> {
         }
 
         let mut required_rows = 0;
-        for page in pages.iter() {
-            if let Some(p) = page {
-                if p.num_nonpadding_lines > required_rows {
-                    required_rows = p.num_nonpadding_lines;
-                }
+        for p in pages.iter().flatten() {
+            if p.num_nonpadding_lines > required_rows {
+                required_rows = p.num_nonpadding_lines;
             }
         }
 

--- a/text/pr_util/args.rs
+++ b/text/pr_util/args.rs
@@ -187,17 +187,17 @@ impl Args {
         let page_column_regex = Regex::new(r"^\+\d+(?::\d+)?|-\d+\b").unwrap();
 
         let mut env_args: Vec<_> = std::env::args()
-            .filter_map(|s| {
+            .map(|s| {
                 // Map the arguments +FIRST_PAGE[:LAST_PAGE] and -COLUMN
                 // to something that `clap` can parse
                 if page_column_regex.is_match(&s) {
                     if s.starts_with('+') {
-                        Some(format!("--pages={}", s.strip_prefix('+').unwrap()))
+                        format!("--pages={}", s.strip_prefix('+').unwrap())
                     } else {
-                        Some(format!("--columns={}", s.strip_prefix('-').unwrap()))
+                        format!("--columns={}", s.strip_prefix('-').unwrap())
                     }
                 } else {
-                    Some(s)
+                    s
                 }
             })
             .collect();
@@ -358,10 +358,8 @@ impl Parameters {
         let num_columns = {
             if args.merge {
                 args.file.len()
-            } else if let Some(n) = args.columns {
-                n
             } else {
-                1
+                args.columns.unwrap_or(1)
             }
         };
 

--- a/text/sort.rs
+++ b/text/sort.rs
@@ -223,12 +223,10 @@ fn update_range_field(mut field1: RangeField, mut field2: RangeField) -> (RangeF
 /// the second RangeField object based on their field numbers and first characters.
 ///
 fn compare_range_fields(field1: &RangeField, field2: &RangeField) -> bool {
-    if field1.field_number < field2.field_number {
-        true
-    } else if field1.field_number == field2.field_number {
-        field1.first_character <= field2.first_character
-    } else {
-        false
+    match field1.field_number.cmp(&field2.field_number) {
+        Ordering::Less => true,
+        Ordering::Equal => field1.first_character <= field2.first_character,
+        Ordering::Greater => false,
     }
 }
 
@@ -951,15 +949,15 @@ fn merge_empty_lines(vec: Vec<&str>) -> Vec<String> {
     let mut empty_count = 0;
     let mut result = vec![];
 
-    for i in 0..vec.len() {
-        if vec[i].is_empty() {
+    for str in &vec {
+        if str.is_empty() {
             empty_count += 1;
         } else if empty_count > 0 {
             let spaces = " ".repeat(empty_count);
-            result.push(format!("{}{}", spaces, vec[i]));
+            result.push(format!("{}{}", spaces, str));
             empty_count = 0;
         } else {
-            result.push(vec[i].to_string());
+            result.push(str.to_string());
         }
     }
 

--- a/text/uniq.rs
+++ b/text/uniq.rs
@@ -180,11 +180,10 @@ fn output_result<W: Write>(
 ) -> Result<(), io::Error> {
     if args.count {
         writeln!(output, "{} {}", count, line)?;
-    } else if args.repeated && count > 1 {
-        writeln!(output, "{}", line)?;
-    } else if args.unique && count == 1 {
-        writeln!(output, "{}", line)?;
-    } else if !args.repeated && !args.unique {
+    } else if args.repeated && count > 1
+        || args.unique && count == 1
+        || !args.repeated && !args.unique
+    {
         writeln!(output, "{}", line)?;
     }
     Ok(())

--- a/text/wc.rs
+++ b/text/wc.rs
@@ -54,9 +54,9 @@ impl CountInfo {
     }
 
     fn accum(&mut self, count: &CountInfo) {
-        self.words = self.words + count.words;
-        self.chars = self.chars + count.chars;
-        self.nl = self.nl + count.nl;
+        self.words += count.words;
+        self.chars += count.chars;
+        self.nl += count.nl;
     }
 }
 
@@ -64,9 +64,9 @@ fn build_display_str(args: &Args, count: &CountInfo, filename: &OsStr) -> String
     let mut output = String::with_capacity(filename.len() + (3 * 10));
 
     let multi_file = args.files.len() > 1;
-    let only_lines = (args.words == false) && (args.bytes == false) && (args.chars == false);
-    let only_words = (args.lines == false) && (args.bytes == false) && (args.chars == false);
-    let only_bytechars = (args.lines == false) && (args.words == false);
+    let only_lines = (!args.words) && (!args.bytes) && (!args.chars);
+    let only_words = (!args.lines) && (!args.bytes) && (!args.chars);
+    let only_bytechars = (!args.lines) && (!args.words);
 
     if args.lines {
         let numstr = match only_lines {
@@ -76,7 +76,7 @@ fn build_display_str(args: &Args, count: &CountInfo, filename: &OsStr) -> String
         output.push_str(&numstr);
     }
     if args.words {
-        if output.len() > 0 {
+        if !output.is_empty() {
             output.push(' ');
         }
         let numstr = match only_words {
@@ -86,7 +86,7 @@ fn build_display_str(args: &Args, count: &CountInfo, filename: &OsStr) -> String
         output.push_str(&numstr);
     }
     if args.bytes || args.chars {
-        if output.len() > 0 {
+        if !output.is_empty() {
             output.push(' ');
         }
         let numstr = match only_bytechars {
@@ -121,7 +121,7 @@ fn wc_file_bytes(count: &mut CountInfo, pathname: &PathBuf) -> io::Result<()> {
             break;
         }
 
-        count.chars = count.chars + n_read;
+        count.chars += n_read;
 
         let bufslice = &buffer[0..n_read];
 
@@ -129,26 +129,24 @@ fn wc_file_bytes(count: &mut CountInfo, pathname: &PathBuf) -> io::Result<()> {
             let ch = *ch_u8 as char;
 
             if ch == '\n' {
-                count.nl = count.nl + 1;
+                count.nl += 1;
                 if in_word {
                     in_word = false;
-                    count.words = count.words + 1;
+                    count.words += 1;
                 }
             } else if ch.is_whitespace() {
                 if in_word {
                     in_word = false;
-                    count.words = count.words + 1;
+                    count.words += 1;
                 }
-            } else {
-                if !in_word {
-                    in_word = true;
-                }
+            } else if !in_word {
+                in_word = true;
             }
         }
     }
 
     if in_word {
-        count.words = count.words + 1;
+        count.words += 1;
     }
 
     Ok(())
@@ -164,8 +162,8 @@ fn wc_file_chars(args: &Args, count: &mut CountInfo, pathname: &PathBuf) -> io::
             break;
         }
 
-        count.nl = count.nl + 1;
-        count.chars = count.chars + n_read;
+        count.nl += 1;
+        count.chars += n_read;
 
         if args.words {
             let mut in_word = false;
@@ -174,16 +172,14 @@ fn wc_file_chars(args: &Args, count: &mut CountInfo, pathname: &PathBuf) -> io::
                 if ch.is_whitespace() {
                     if in_word {
                         in_word = false;
-                        count.words = count.words + 1;
+                        count.words += 1;
                     }
-                } else {
-                    if !in_word {
-                        in_word = true;
-                    }
+                } else if !in_word {
+                    in_word = true;
                 }
             }
             if in_word {
-                count.words = count.words + 1;
+                count.words += 1;
             }
         }
     }

--- a/tree/ls.rs
+++ b/tree/ls.rs
@@ -417,20 +417,18 @@ impl Config {
                 MULTI_COLUMN | STREAM_OUTPUT_FORMAT | MUTI_COLUMN_ACROSS => {
                     long_format_state.push(false);
                 }
-                ONE_ENTRY_PER_LINE => loop {
-                    // Remove any `false` that was added by -C, -m or -x until
-                    // a `true` is reached or the vec is empty
-                    match long_format_state.last().copied() {
-                        Some(enabled) => {
-                            if enabled {
-                                break;
-                            } else {
-                                long_format_state.pop();
-                            }
+                ONE_ENTRY_PER_LINE => {
+                    while let Some(enabled) = long_format_state.last().copied() {
+                        // Remove any `false` that was added by -C, -m or -x until
+                        // a `true` is reached or the vec is empty
+
+                        if enabled {
+                            break;
+                        } else {
+                            long_format_state.pop();
                         }
-                        None => break,
                     }
-                },
+                }
                 _ => unreachable!(),
             }
         }
@@ -517,9 +515,8 @@ impl Config {
             args.reverse_sorting = false;
 
             // -A is also ignored
-            match file_inclusion {
-                FileInclusion::Default => file_inclusion = FileInclusion::All,
-                _ => (),
+            if let FileInclusion::Default = file_inclusion {
+                file_inclusion = FileInclusion::All
             }
         }
 

--- a/tree/mv.rs
+++ b/tree/mv.rs
@@ -107,17 +107,18 @@ fn move_file(
     let source_filename = CString::new(source.as_os_str().as_bytes()).unwrap();
     let target_filename = CString::new(target.as_os_str().as_bytes()).unwrap();
 
-    let target_md = match ftw::Metadata::new(libc::AT_FDCWD, target_filename.as_ptr(), true) {
-        Ok(md) => Some(md),
-        Err(e) => {
-            if e.kind() == io::ErrorKind::NotFound {
-                None
-            } else {
-                let err_str = format!("{}: {}", target.display(), error_string(&e));
-                return Err(io::Error::other(err_str));
+    let target_md =
+        match unsafe { ftw::Metadata::new(libc::AT_FDCWD, target_filename.as_ptr(), true) } {
+            Ok(md) => Some(md),
+            Err(e) => {
+                if e.kind() == io::ErrorKind::NotFound {
+                    None
+                } else {
+                    let err_str = format!("{}: {}", target.display(), error_string(&e));
+                    return Err(io::Error::other(err_str));
+                }
             }
-        }
-    };
+        };
     let target_exists = target_md.is_some();
     let target_is_dir = match &target_md {
         Some(md) => md.file_type() == ftw::FileType::Directory,
@@ -125,17 +126,18 @@ fn move_file(
     };
     let target_is_writable = target_md.map(|md| md.is_writable()).unwrap_or(false);
 
-    let source_md = match ftw::Metadata::new(libc::AT_FDCWD, source_filename.as_ptr(), true) {
-        Ok(md) => Some(md),
-        Err(e) => {
-            if e.kind() == io::ErrorKind::NotFound {
-                None
-            } else {
-                let err_str = format!("{}: {}", source.display(), error_string(&e));
-                return Err(io::Error::other(err_str));
+    let source_md =
+        match unsafe { ftw::Metadata::new(libc::AT_FDCWD, source_filename.as_ptr(), true) } {
+            Ok(md) => Some(md),
+            Err(e) => {
+                if e.kind() == io::ErrorKind::NotFound {
+                    None
+                } else {
+                    let err_str = format!("{}: {}", source.display(), error_string(&e));
+                    return Err(io::Error::other(err_str));
+                }
             }
-        }
-    };
+        };
     let source_exists = source_md.is_some();
     let source_is_dir = match &source_md {
         Some(md) => md.file_type() == ftw::FileType::Directory,
@@ -153,8 +155,8 @@ fn move_file(
 
     // 2. source and target are same dirent
     if let (Ok(smd), Ok(tmd), Some(deref_smd)) = (
-        ftw::Metadata::new(libc::AT_FDCWD, source_filename.as_ptr(), false),
-        ftw::Metadata::new(libc::AT_FDCWD, target_filename.as_ptr(), false),
+        unsafe { ftw::Metadata::new(libc::AT_FDCWD, source_filename.as_ptr(), false) },
+        unsafe { ftw::Metadata::new(libc::AT_FDCWD, target_filename.as_ptr(), false) },
         &source_md,
     ) {
         // `true` for hard links to the same file and when `source == target`

--- a/tree/touch.rs
+++ b/tree/touch.rs
@@ -55,12 +55,9 @@ fn parse_tm_posix(time: &str) -> Result<DateTime<Utc>, Box<dyn std::error::Error
 
     // split into YYYYMMDDhhmm and [.SS] components
     let mut tmp_time = String::new();
-    match time.split_once('.') {
-        Some((t, secs)) => {
-            tmp_time = t.to_string();
-            seconds = secs.to_string();
-        }
-        None => {}
+    if let Some((t, secs)) = time.split_once('.') {
+        tmp_time = t.to_string();
+        seconds = secs.to_string();
     }
     if !tmp_time.is_empty() {
         time = tmp_time;

--- a/users/mesg.rs
+++ b/users/mesg.rs
@@ -107,7 +107,7 @@ fn set_mesg(fd: i32, st: libc::stat, setting: &str) -> io::Result<()> {
             return Ok(());
         }
 
-        mode = mode & !(libc::S_IWGRP | libc::S_IWOTH);
+        mode &= !(libc::S_IWGRP | libc::S_IWOTH);
     }
 
     let chres = unsafe { libc::fchmod(fd, mode) };

--- a/users/pwd.rs
+++ b/users/pwd.rs
@@ -16,7 +16,7 @@ use plib::PROJECT_NAME;
 use std::ffi::OsStr;
 use std::path::{Component, Path};
 
-const PWD_ENV: &'static str = "PWD";
+const PWD_ENV: &str = "PWD";
 
 /// pwd - return working directory name
 #[derive(Parser, Debug)]
@@ -42,10 +42,8 @@ fn dirname_valid(name: &OsStr) -> bool {
             if component != Component::RootDir {
                 return false;
             }
-        } else {
-            if component == Component::CurDir || component == Component::ParentDir {
-                return false;
-            }
+        } else if component == Component::CurDir || component == Component::ParentDir {
+            return false;
         }
     }
 

--- a/xform/cksum.rs
+++ b/xform/cksum.rs
@@ -44,7 +44,7 @@ fn cksum_file(filename: &PathBuf) -> io::Result<()> {
             break;
         }
 
-        n_bytes = n_bytes + n_read as u64;
+        n_bytes += n_read as u64;
         crc = crc32::update(crc, &buffer[0..n_read]);
     }
 

--- a/xform/crc32.rs
+++ b/xform/crc32.rs
@@ -64,7 +64,7 @@ pub fn finalize(crc_in: u32, n_in: usize) -> u32 {
 
     while n != 0 {
         let c = (n & 0o377) as u32;
-        n = n >> 8;
+        n >>= 8;
         s = (s << 8) ^ CRCTAB[(((s >> 24) ^ c) & 0xff) as usize];
     }
 


### PR DESCRIPTION
API change: two functions became `unsafe` because they perform dereference of raw pointer, which could be an undefined behavior. not all lints are fixed as they require huge refactor/doc changes