### PR TITLE
paste: fix multiple bugs

### DIFF
--- a/file/tests/od/mod.rs
+++ b/file/tests/od/mod.rs
@@ -278,8 +278,8 @@ fn test_od_22() {
 // Given that most other implementations of `od` print one or more leading spaces, for compatibility, one
 // leading space will be printed.
 //
-// Busybox, GNU Core Utilities, uutils's coreutils: 1 leading space
-// Toybox: 2 leading spaces
+// BusyBox, GNU Core Utilities, uutils's coreutils: 1 leading space
+// toybox: 2 leading spaces
 //
 // Also, none of these implementations print trailing spaces
 #[test]

--- a/text/paste.rs
+++ b/text/paste.rs
@@ -8,53 +8,85 @@
 //
 // TODO:
 // - stdin ("-")
-// -- Probably fixed
+// -- Fixed
 // - fix:  empty-string delimiters \0
-// -- Probably fixed
+// -- Fixed
 // - improve:  don't open all files at once in --serial mode
 //
 
 use clap::Parser;
 use gettextrs::{bind_textdomain_codeset, setlocale, textdomain, LocaleCategory};
 use plib::PROJECT_NAME;
-use std::cell::Cell;
-use std::collections::hash_map::Entry;
-use std::collections::HashMap;
+use std::cell::{LazyCell, RefCell};
 use std::error::Error;
 use std::fs::File;
-use std::io::{self, BufRead, BufReader, Write};
+use std::io::{self, BufRead, BufReader, Stdin, Write};
+use std::iter::Cycle;
 use std::rc::Rc;
+use std::slice::Iter;
 
 /// paste - merge corresponding or subsequent lines of files
 #[derive(Parser)]
 #[command(version, about)]
 struct Args {
-    /// Concatenate all of the lines from each input file into one line of output per file, in command line order.
+    /// Concatenate all of the lines from each input file into one line of output per file, in command line order
     #[arg(short, long)]
     serial: bool,
 
     /// Delimiter list
-    #[arg(short, long)]
+    // Other implementations use "delimiters"
+    #[arg(alias = "delimiters", short, long)]
     delims: Option<String>,
 
-    /// One or more input files.
+    /// One or more input files
     files: Vec<String>,
 }
 
+enum Source {
+    File {
+        buf_reader: BufReader<File>,
+        file_description: String,
+    },
+    StandardInput(Rc<RefCell<Stdin>>),
+}
+
+impl Source {
+    fn read_until_new_line(&mut self, vec: &mut Vec<u8>) -> Result<usize, Box<dyn Error>> {
+        const READ_UNTIL_BYTE: u8 = b'\n';
+
+        let (source_description, result) = match self {
+            Self::File {
+                buf_reader,
+                file_description,
+            } => (
+                file_description.as_str(),
+                buf_reader.read_until(READ_UNTIL_BYTE, vec),
+            ),
+            Self::StandardInput(st) => (
+                "Pipe: standard input",
+                st.try_borrow()?.lock().read_until(READ_UNTIL_BYTE, vec),
+            ),
+        };
+
+        match result {
+            Ok(us) => Ok(us),
+            Err(er) => Err(Box::from(format!("{source_description}: {er}"))),
+        }
+    }
+}
+
 struct PasteFile {
-    filename: String,
-    rdr: Rc<Cell<Option<Box<dyn BufRead>>>>,
     eof: bool,
     last: bool,
+    source: Source,
 }
 
 impl PasteFile {
-    fn new(filename: String, rdr: Rc<Cell<Option<Box<dyn BufRead>>>>) -> PasteFile {
+    fn new(source: Source) -> PasteFile {
         PasteFile {
-            filename,
-            rdr,
             eof: false,
             last: false,
+            source,
         }
     }
 }
@@ -63,78 +95,62 @@ struct PasteInfo {
     pub inputs: Vec<PasteFile>,
 }
 
-// TODO
-// Use an iterator instead of an index
-enum DelimInfo {
+enum DelimsInfo<'a> {
     NoDelimiters,
-    SingleDelimiter(char),
+    SingleDelimiter(&'a [u8]),
     MultipleDelimiters {
-        cur_delim: usize,
-        delims: Box<[char]>,
-        number_of_delims: usize,
+        delimiters: &'a [Box<[u8]>],
+        delimiters_iterator: Cycle<Iter<'a, Box<[u8]>>>,
     },
 }
 
-impl DelimInfo {
-    fn new(delims: Box<[char]>) -> DelimInfo {
-        let mut iter = delims.iter();
-
-        let Some(first_delimiter) = iter.next() else {
-            // Otherwise there are no delimiters
-            return Self::NoDelimiters;
-        };
-
-        let Some(_) = iter.next() else {
-            // There is only one delimiter
-            return Self::SingleDelimiter(first_delimiter.to_owned());
-        };
-
-        // Otherwise there are more than one delimiters
-        let number_of_delims = delims.len();
-
-        Self::MultipleDelimiters {
-            delims,
-            cur_delim: 0,
-            number_of_delims,
+impl<'a> DelimsInfo<'a> {
+    fn new(parsed_delims_argument_ref: &'a [Box<[u8]>]) -> DelimsInfo<'a> {
+        match parsed_delims_argument_ref {
+            [] => Self::NoDelimiters,
+            [only_delimiter] => {
+                // -d '\0' has the same effect as -d ''
+                if only_delimiter.is_empty() {
+                    Self::NoDelimiters
+                } else {
+                    Self::SingleDelimiter(only_delimiter)
+                }
+            }
+            _ => Self::MultipleDelimiters {
+                delimiters: parsed_delims_argument_ref,
+                delimiters_iterator: parsed_delims_argument_ref.iter().cycle(),
+            },
         }
     }
 
-    fn delim(&mut self) -> Option<char> {
+    fn write(&mut self, write: &mut impl io::Write) -> io::Result<()> {
         match *self {
-            DelimInfo::NoDelimiters => None,
-            DelimInfo::SingleDelimiter(ch) => Some(ch.to_owned()),
-            DelimInfo::MultipleDelimiters {
-                ref mut cur_delim,
-                ref delims,
-                number_of_delims,
-            } => {
-                let cur_delim_to_owned = cur_delim.to_owned();
-
-                // Advance function
-                {
-                    let cur_delim_to_owned_plus_one = cur_delim_to_owned + 1;
-
-                    let new_cur_delim = if cur_delim_to_owned_plus_one >= number_of_delims {
-                        0
-                    } else {
-                        cur_delim_to_owned_plus_one
-                    };
-
-                    *cur_delim = new_cur_delim;
-                }
-
-                // Unwrap because indexing here should never fail
-                Some(delims.get(cur_delim_to_owned).unwrap().to_owned())
+            DelimsInfo::SingleDelimiter(sl) => {
+                write.write_all(sl)?;
             }
+            DelimsInfo::MultipleDelimiters {
+                ref mut delimiters_iterator,
+                ..
+            } => {
+                // Unwrap because advancing here should never fail
+                let bo = delimiters_iterator.next().unwrap();
+
+                write.write_all(bo)?;
+            }
+            _ => {}
         }
+
+        Ok(())
     }
 
     fn reset(&mut self) {
-        match *self {
-            DelimInfo::MultipleDelimiters {
-                ref mut cur_delim, ..
+        match self {
+            DelimsInfo::MultipleDelimiters {
+                delimiters,
+                ref mut delimiters_iterator,
+                ..
             } => {
-                *cur_delim = 0;
+                *delimiters_iterator = delimiters.iter().cycle();
             }
             _ => {
                 // Nothing to do for these cases
@@ -143,39 +159,87 @@ impl DelimInfo {
     }
 }
 
-fn xlat_delim_str(s: &str) -> Box<[char]> {
-    // Plus 10?
-    let mut output = Vec::<char>::with_capacity(s.len() + 10);
+/// `delims`: Delimiters parsed from "-d"/"--delims" argument
+// Support for empty delimiter list:
+//
+// bsdutils: no, supports "-d" but requires the delimiter list to be non-empty
+// BusyBox: does not support "-d" at all
+// GNU Core Utilities: yes
+// toybox: yes
+// uutils's coreutils: no, supports "-d", but panics on an empty delimiter list
+//
+// POSIX seems to almost forbid this:
+// "These elements specify one or more delimiters to use, instead of the default <tab>, to replace the <newline> of the input lines."
+// https://pubs.opengroup.org/onlinepubs/9799919799/utilities/paste.html
+fn parse_delims_argument(delims: Option<String>) -> Result<Box<[Box<[u8]>]>, String> {
+    const BACKSLASH: char = '\\';
 
-    let mut in_escape = false;
-    for ch in s.chars() {
-        if in_escape {
-            let out_ch = match ch {
-                'n' => '\n',
-                't' => '\t',
-                '0' => '\0',
-                _ => ch,
-            };
+    fn add_normal_delimiter(ve: &mut Vec<Box<[u8]>>, byte: u8) {
+        ve.push(Box::new([byte]));
+    }
 
-            output.push(out_ch);
-            in_escape = false;
-        } else if ch == '\\' {
-            in_escape = true;
-        } else {
-            output.push(ch);
+    let Some(delims_string) = delims else {
+        // Default when no delimiter argument is provided
+        return Ok(Box::new([Box::new([b'\t'])]));
+    };
+
+    let mut buffer = [0_u8; 4];
+
+    let mut add_other_delimiter = |ve: &mut Vec<Box<[u8]>>, ch: char| {
+        let encoded = ch.encode_utf8(&mut buffer);
+
+        ve.push(Box::from(encoded.as_bytes()));
+    };
+
+    let mut vec = Vec::<Box<[u8]>>::with_capacity(delims_string.len());
+
+    let mut chars = delims_string.chars();
+
+    while let Some(char) = chars.next() {
+        match char {
+            BACKSLASH => match chars.next() {
+                Some('0') => {
+                    vec.push(Box::<[u8; 0]>::new([]));
+                }
+                Some(BACKSLASH) => {
+                    // '\'
+                    // U+005C
+                    add_normal_delimiter(&mut vec, b'\\');
+                }
+                Some('n') => {
+                    // U+000A
+                    add_normal_delimiter(&mut vec, b'\n');
+                }
+                Some('t') => {
+                    // U+0009
+                    add_normal_delimiter(&mut vec, b'\t');
+                }
+                Some(other_char) => {
+                    // "If any other characters follow the <backslash>, the results are unspecified."
+                    // https://pubs.opengroup.org/onlinepubs/9799919799/utilities/paste.html
+                    // GNU Core Utilities: ignores the backslash
+                    // BusyBox, toybox: includes the backslash as one of the delimiters
+                    add_other_delimiter(&mut vec, other_char);
+                }
+                None => {
+                    return Err(format!(
+                        "delimiter list ends with an unescaped backslash: {delims_string}"
+                    ));
+                }
+            },
+            not_backslash => {
+                add_other_delimiter(&mut vec, not_backslash);
+            }
         }
     }
 
-    output.into_boxed_slice()
+    Ok(vec.into_boxed_slice())
 }
 
 fn open_inputs(files: Vec<String>) -> Result<PasteInfo, Box<dyn Error>> {
-    let files_len = files.len();
+    let stdin_lazy_cell = LazyCell::new(|| Rc::new(RefCell::new(io::stdin())));
 
-    let mut inputs = Vec::<PasteFile>::with_capacity(files_len);
-
-    let mut hash_map =
-        HashMap::<String, Rc<Cell<Option<Box<dyn BufRead>>>>>::with_capacity(files_len);
+    let mut paste_file_vec = Vec::<PasteFile>::with_capacity(files.len());
 
     // open each input
     for file in files {
@@ -184,174 +248,125 @@ fn open_inputs(files: Vec<String>) -> Result<PasteInfo, Box<dyn Error>> {
         // https://pubs.opengroup.org/onlinepubs/9799919799/utilities/paste.html
         match file.as_str() {
             "-" => {
-                let filename = format!("Pipe: standard input (opened as '{file}')");
-
-                // TODO
-                // Duplication
-                let en = hash_map.entry(file);
-
-                let rdr = match en {
-                    Entry::Occupied(oc) => oc.get().clone(),
-                    Entry::Vacant(va) => {
-                        let box_buf_read: Box<dyn BufRead> = Box::new(io::stdin().lock());
-
-                        let rc = Rc::new(Cell::new(Some(box_buf_read)));
-
-                        let rc_clone = rc.clone();
-
-                        va.insert(rc_clone);
-
-                        rc
-                    }
-                };
-
-                inputs.push(PasteFile::new(filename, rdr));
+                paste_file_vec.push(PasteFile::new(Source::StandardInput(
+                    stdin_lazy_cell.clone(),
+                )));
             }
             "" => {
-                eprintln!("paste: FILE is an empty string, skipping");
+                eprintln!("FILE is an empty string, skipping");
             }
-            _ => {
-                let filename = format!("File: {file}");
+            st => {
+                let open_result = File::open(st);
 
-                // TODO
-                // Duplication
-                let en = hash_map.entry(file);
-
-                let rdr = match en {
-                    Entry::Occupied(oc) => oc.get().clone(),
-                    Entry::Vacant(va) => {
-                        let key = va.key();
-
-                        let open_result = File::open(key);
-
-                        let file = match open_result {
-                            Err(er) => {
-                                return Err(Box::from(format!("{key}: {er}")));
-                            }
-                            Ok(fi) => fi,
-                        };
-
-                        let box_buf_read: Box<dyn BufRead> = Box::new(BufReader::new(file));
-
-                        let rc = Rc::new(Cell::new(Some(box_buf_read)));
-
-                        let rc_clone = rc.clone();
-
-                        va.insert(rc_clone);
-
-                        rc
+                let buf_reader = match open_result {
+                    Err(er) => {
+                        return Err(Box::from(format!("{st}: {er}")));
                     }
+                    Ok(fi) => BufReader::new(fi),
                 };
 
-                inputs.push(PasteFile::new(filename, rdr));
+                let filename = format!("File: {st}");
+
+                paste_file_vec.push(PasteFile::new(Source::File {
+                    buf_reader,
+                    file_description: filename,
+                }));
             }
         }
     }
 
-    if inputs.is_empty() {
-        eprintln!(
-            "paste: No valid [FILES] were specified. Use '-' if you are trying to read from stdin."
-        );
-
-        return Err(Box::from("Execution failed"));
+    if paste_file_vec.is_empty() {
+        return Err(Box::from(
+            "No valid [FILES] were specified. Use '-' if you are trying to read from stdin.",
+        ));
     }
 
     // mark final input
-    if let Some(pa) = inputs.last_mut() {
+    if let Some(pa) = paste_file_vec.last_mut() {
         pa.last = true;
     }
 
-    Ok(PasteInfo { inputs })
+    Ok(PasteInfo {
+        inputs: paste_file_vec,
+    })
 }
 
 fn paste_files_serial(
     mut paste_info: PasteInfo,
-    mut delim_info: DelimInfo,
+    mut delims_info: DelimsInfo,
 ) -> Result<(), Box<dyn Error>> {
-    // loop serially for each input file
+    let mut stdout_lock = io::stdout().lock();
 
     // Re-use buffers to avoid repeated allocations
-    let mut buffer = String::new();
+    let mut buffer = Vec::new();
 
+    // loop serially for each input file
     for paste_file in &mut paste_info.inputs {
         let mut first_line = true;
 
         // for each input line
         loop {
-            // Equivalent to allocating a new String here
+            // Equivalent to allocating a new Vec here
             buffer.clear();
 
-            let rc = &paste_file.rdr;
-
-            // TODO
-            // unwrap
-            // Take the `BufRead` out to use it
-            let mut buf_read_box = rc.take().unwrap();
-
-            let read_line_result = match buf_read_box.read_line(&mut buffer) {
-                Ok(us) => us,
-                Err(er) => {
-                    let filename = &paste_file.filename;
-
-                    return Err(Box::from(format!("{filename}: {er}")));
-                }
-            };
-
-            // Put the `BufRead` back
-            rc.set(Some(buf_read_box));
+            let read_line_result = paste_file.source.read_until_new_line(&mut buffer)?;
 
             // if EOF, output line terminator and end inner loop
             if read_line_result == 0 {
-                println!();
+                stdout_lock.write_all(b"\n")?;
 
                 break;
             } else {
-                // output line segment
+                if !first_line {
+                    delims_info.write(&mut stdout_lock)?;
+                }
 
-                let mut chars = buffer.chars();
+                // output line segment
+                let mut iter = buffer.iter();
 
                 // TODO
                 // Check that the removed character is a newline?
                 // Update: checking if it was a newline in this manner fixes "paste_multiple_stdin_serial_test_two"
                 // But this seems hacky
-                let slice = match chars.next_back() {
-                    // `chars` is correct, since character that was removed was a newline character
-                    Some('\n') => chars.as_str(),
-                    // `chars` is wrong, since it is now missing the final character (which was not a newline
+                let slice = match iter.next_back() {
+                    // `iter` is correct, since the byte that was removed was a newline character
+                    Some(b'\n') => iter.as_slice(),
+                    // `iter` is wrong, since it is now missing the final character (which was not a newline
                     // character), so use `buffer`, unmodified
-                    _ => buffer.as_str(),
+                    _ => buffer.as_slice(),
                 };
 
-                if first_line {
-                    print!("{slice}");
-                } else {
-                    let delimiter = match delim_info.delim() {
-                        Some(ch) => ch.to_string(),
-                        None => String::new(),
-                    };
-
-                    print!("{delimiter}{slice}");
-                }
+                stdout_lock.write_all(slice)?;
             }
 
             if first_line {
                 first_line = false;
             }
         }
+
+        // See https://pubs.opengroup.org/onlinepubs/9799919799/utilities/paste.html:
+        //
+        //    When the -s option is specified:
+        //    The last <newline> in a file shall not be modified.
+        //    The delimiter shall be reset to the first element of list after each file operand is processed.
+        delims_info.reset();
     }
 
     Ok(())
 }
 
-fn paste_files(mut paste_info: PasteInfo, mut delim_info: DelimInfo) -> Result<(), Box<dyn Error>> {
+fn paste_files(
+    mut paste_info: PasteInfo,
+    mut delims_info: DelimsInfo,
+) -> Result<(), Box<dyn Error>> {
     // for each input line, across N files
 
     // Re-use buffers to avoid repeated allocations
-    let mut buffer = String::new();
-    let mut output = String::new();
+    let mut buffer = Vec::new();
+    let mut output = Vec::new();
 
     loop {
-        // Equivalent to allocating a new String here
+        // Equivalent to allocating a new Vec here
         output.clear();
 
         let mut have_data = false;
@@ -360,55 +375,36 @@ fn paste_files(mut paste_info: PasteInfo, mut delim_info: DelimInfo) -> Result<(
         for paste_file in &mut paste_info.inputs {
             // if not already at EOF, read and process a line
             if !paste_file.eof {
-                let rc = &paste_file.rdr;
-
-                // TODO
-                // unwrap
-                // Take the `BufRead` out to use it
-                let mut buf_read_box = rc.take().unwrap();
-
-                // Equivalent to allocating a new String here
+                // Equivalent to allocating a new Vec here
                 buffer.clear();
 
-                let read_line_result = match buf_read_box.read_line(&mut buffer) {
-                    Ok(us) => us,
-                    Err(er) => {
-                        let filename = &paste_file.filename;
+                let read_line_result = paste_file.source.read_until_new_line(&mut buffer)?;
 
-                        return Err(Box::from(format!("{filename}: {er}")));
-                    }
-                };
-
-                // Put the `BufRead` back
-                rc.set(Some(buf_read_box));
-
-                // if at EOF, note and continue
                 if read_line_result == 0 {
+                    // if at EOF, note and continue
                     paste_file.eof = true;
-
-                // otherwise add to output line, sans trailing NL
                 } else {
+                    // otherwise add to output line, sans trailing NL
                     have_data = true;
 
-                    let mut chars = buffer.chars();
+                    let mut iter = buffer.iter();
 
-                    // TODO
-                    // Check that the removed character is a newline
-                    let _: Option<char> = chars.next_back();
+                    // See note above
+                    let slice = match iter.next_back() {
+                        Some(b'\n') => iter.as_slice(),
+                        _ => buffer.as_slice(),
+                    };
 
-                    output.push_str(chars.as_str());
+                    output.extend_from_slice(slice);
                 }
             }
 
             // final record, output line end
             if paste_file.last {
-                output.push('\n');
+                output.push(b'\n');
             } else {
                 // next delimiter
-                #[allow(clippy::collapsible_else_if)]
-                if let Some(ch) = delim_info.delim() {
-                    output.push(ch);
-                }
+                delims_info.write(&mut output)?;
             }
         }
 
@@ -417,9 +413,9 @@ fn paste_files(mut paste_info: PasteInfo, mut delim_info: DelimInfo) -> Result<(
         }
 
         // output all segments to stdout at once (one write per line)
-        io::stdout().write_all(output.as_bytes())?;
+        io::stdout().write_all(output.as_slice())?;
 
-        delim_info.reset();
+        delims_info.reset();
     }
 
     Ok(())
@@ -439,35 +435,34 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         serial,
     } = args;
 
-    let paste_info = open_inputs(files)?;
+    let parsed_delims_argument = match parse_delims_argument(delims) {
+        Ok(bo) => bo,
+        Err(st) => {
+            eprintln!("paste: {st}");
 
-    let delim_state = match delims {
-        None => {
-            // Default when no delimiter argument is provided
-            DelimInfo::new(Box::new(['\t']))
-        }
-        Some(st) => {
-            // Delimiters parsed from "-d"/"--delims" argument
-            //
-            // Support for empty delimiter list:
-            //
-            // bsdutils: no, supports "-d" but requires the delimiter list to be non-empty
-            // Busybox: does not support "-d" at all
-            // GNU Core Utilities: yes
-            // toybox: yes
-            // uutils's coreutils: no, supports "-d", but panics on an empty delimiter list
-            //
-            // POSIX seems to almost forbid this:
-            // "These elements specify one or more delimiters to use, instead of the default <tab>, to replace the <newline> of the input lines."
-            // https://pubs.opengroup.org/onlinepubs/9799919799/utilities/paste.html
-            DelimInfo::new(xlat_delim_str(&st))
+            // TODO
+            // `std::process::exit` should not be used
+            std::process::exit(1);
         }
     };
 
+    let paste_info = match open_inputs(files) {
+        Ok(pa) => pa,
+        Err(bo) => {
+            eprintln!("paste: {bo}");
+
+            // TODO
+            // `std::process::exit` should not be used
+            std::process::exit(1);
+        }
+    };
+
+    let delims_info = DelimsInfo::new(&parsed_delims_argument);
+
     if serial {
-        paste_files_serial(paste_info, delim_state)?;
+        paste_files_serial(paste_info, delims_info)?;
     } else {
-        paste_files(paste_info, delim_state)?;
+        paste_files(paste_info, delims_info)?;
     }
 
     Ok(())

--- a/text/tests/paste/mod.rs
+++ b/text/tests/paste/mod.rs
@@ -9,6 +9,7 @@
 //
 
 use plib::testing::{run_test, TestPlan};
+use plib::{run_test_u8, TestPlanU8};
 use std::fs;
 use std::path::PathBuf;
 
@@ -27,7 +28,7 @@ fn run_paste_test(args: Vec<&str>, expected_output_filename: &str) {
     let args = args.into_iter().map(ToOwned::to_owned).collect();
 
     run_test(TestPlan {
-        cmd: String::from("paste"),
+        cmd: "paste".to_owned(),
         args,
         expected_out,
         expected_err: String::new(),
@@ -92,7 +93,7 @@ fn paste_simple_multi_line_input() {
         .collect();
 
     run_test(TestPlan {
-        cmd: String::from("paste"),
+        cmd: "paste".to_owned(),
         args,
         expected_out: "Line 1Line 2Line 3\n".to_owned(),
         expected_err: String::new(),
@@ -114,7 +115,7 @@ fn paste_multiple_stdin() {
         .collect();
 
     run_test(TestPlan {
-        cmd: String::from("paste"),
+        cmd: "paste".to_owned(),
         args,
         expected_out: "\
 Line 1ALine 2BLine 3CLine 4
@@ -147,7 +148,7 @@ fn paste_multiple_stdin_serial_test_one() {
         .collect();
 
     run_test(TestPlan {
-        cmd: String::from("paste"),
+        cmd: "paste".to_owned(),
         args,
         expected_out: "\
 Line 1ALine 2BLine 3CLine 4ALine 5BLine 6CLine 7ALine 8BLine 9
@@ -182,7 +183,7 @@ fn paste_multiple_stdin_serial_test_two() {
         .collect();
 
     run_test(TestPlan {
-        cmd: String::from("paste"),
+        cmd: "paste".to_owned(),
         args,
         expected_out: "\
 O!K!1!234!here
@@ -200,4 +201,133 @@ here"
             .to_owned(),
         expected_exit_code: 0,
     });
+}
+
+#[test]
+fn paste_non_utf8_input() {
+    const INPUT: &[u8] = b"String with non-UTF-8 bytes: \xFF\x00\xFF.\n";
+
+    let args = ["--", "-"]
+        .into_iter()
+        .map(ToOwned::to_owned)
+        .collect::<Vec<_>>();
+
+    run_test_u8(TestPlanU8 {
+        args,
+        cmd: "paste".to_owned(),
+        expected_err: Vec::<u8>::new(),
+        expected_exit_code: 0,
+        expected_out: INPUT.to_vec(),
+        stdin_data: INPUT.to_vec(),
+    });
+}
+
+#[test]
+fn paste_backslash_zero_delimiter() {
+    let args = ["-d", r#"\0\!\0"#, "-s", "--", "-"]
+        .into_iter()
+        .map(ToOwned::to_owned)
+        .collect::<Vec<_>>();
+
+    run_test(TestPlan {
+        args,
+        cmd: "paste".to_owned(),
+        expected_err: String::new(),
+        expected_exit_code: 0,
+        expected_out: "\
+AB!CDE!F
+"
+        .to_owned(),
+        stdin_data: "\
+A
+B
+C
+D
+E
+F
+"
+        .to_owned(),
+    });
+}
+
+#[test]
+fn paste_trailing_unescaped_backslash_delimiter() {
+    let args = ["-d", r#"\\\"#, "-s", "--", "-"]
+        .into_iter()
+        .map(ToOwned::to_owned)
+        .collect::<Vec<_>>();
+
+    run_test(TestPlan {
+        args,
+        cmd: "paste".to_owned(),
+        expected_err: r#"paste: delimiter list ends with an unescaped backslash: \\\
+"#
+        .to_owned(),
+        expected_exit_code: 1,
+        expected_out: String::new(),
+        stdin_data: String::new(),
+    });
+}
+
+#[test]
+fn paste_trailing_escaped_backslash_delimiter() {
+    let args = ["-d", r#"\\!\@\\"#, "-s", "--", "-"]
+        .into_iter()
+        .map(ToOwned::to_owned)
+        .collect::<Vec<_>>();
+
+    run_test(TestPlan {
+        args,
+        cmd: "paste".to_owned(),
+        expected_err: String::new(),
+        expected_exit_code: 0,
+        expected_out: r#"A\B!C@D\E\F!G@H\I\J
+"#
+        .to_owned(),
+        stdin_data: "\
+A
+B
+C
+D
+E
+F
+G
+H
+I
+J
+"
+        .to_owned(),
+    });
+}
+
+#[test]
+fn paste_custom_delimiters() {
+    run_paste_test(
+        vec![
+            "-d",
+            "!@#",
+            "--",
+            "tests/paste/input1.txt",
+            "tests/paste/input2.txt",
+            "tests/paste/input1.txt",
+            "tests/paste/input2.txt",
+            "tests/paste/input2.txt",
+        ],
+        "output_paste_custom_delimiters.txt",
+    );
+}
+
+#[test]
+fn paste_custom_delimiters_serial() {
+    run_paste_test(
+        vec![
+            "-d",
+            "!@#",
+            "-s",
+            "--",
+            "tests/paste/input1.txt",
+            "tests/paste/input2.txt",
+        ],
+        "output_paste_custom_delimiters_serial.txt",
+    );
 }

--- a/text/tests/paste/output_paste_custom_delimiters.txt
+++ b/text/tests/paste/output_paste_custom_delimiters.txt
@@ -1,0 +1,3 @@
+apple!1@apple#1!1
+banana!2@banana#2!2
+carrot!3@carrot#3!3

--- a/text/tests/paste/output_paste_custom_delimiters_serial.txt
+++ b/text/tests/paste/output_paste_custom_delimiters_serial.txt
@@ -1,0 +1,2 @@
+apple!banana@carrot
+1!2@3


### PR DESCRIPTION
- Implement handling of "\0" delimiter
- Process data in bytes to allow handling of non-UTF-8 data
- Forbid unescaped trailing backslash delimiter
- Fix handling of repeated input files
- In "-s" mode, reset delimiters iterator after each file