### PR TITLE
tr: add full support for ranges

### DIFF
--- a/text/tests/tr/mod.rs
+++ b/text/tests/tr/mod.rs
@@ -11,15 +11,34 @@
 use plib::{run_test, TestPlan};
 
 fn tr_test(args: &[&str], test_data: &str, expected_output: &str) {
-    let str_args: Vec<String> = args.iter().map(|s| String::from(*s)).collect();
+    let str_args = args
+        .iter()
+        .map(|st| st.to_owned().to_owned())
+        .collect::<Vec<String>>();
 
     run_test(TestPlan {
-        cmd: String::from("tr"),
+        cmd: "tr".to_owned(),
         args: str_args,
-        stdin_data: String::from(test_data),
-        expected_out: String::from(expected_output),
-        expected_err: String::from(""),
+        stdin_data: test_data.to_owned(),
+        expected_out: expected_output.to_owned(),
+        expected_err: String::new(),
         expected_exit_code: 0,
+    });
+}
+
+fn tr_bad_arguments_failure_test(args: &[&str], expected_stderr: &str) {
+    let str_args = args
+        .iter()
+        .map(|st| st.to_owned().to_owned())
+        .collect::<Vec<_>>();
+
+    run_test(TestPlan {
+        cmd: "tr".to_owned(),
+        args: str_args,
+        stdin_data: String::new(),
+        expected_out: String::new(),
+        expected_err: expected_stderr.to_owned(),
+        expected_exit_code: 1,
     });
 }
 
@@ -386,4 +405,161 @@ fn tr_left_square_bracket_literal() {
 #[test]
 fn tr_multiple_transformations() {
     tr_test(&["3[:lower:]", "![:upper:]"], "abc123", "ABC12!");
+}
+
+#[test]
+fn tr_equiv_not_one_char() {
+    tr_bad_arguments_failure_test(
+        &["-d", "[=aa=]"],
+        "tr: aa: equivalence class operand must be a single character\n",
+    );
+}
+
+#[test]
+fn tr_backwards_range_normal() {
+    tr_bad_arguments_failure_test(
+        &["-d", "b-a"],
+        "tr: range-endpoints of 'b-a' are in reverse collating sequence order\n",
+    );
+}
+
+#[test]
+fn tr_backwards_range_backslash() {
+    tr_bad_arguments_failure_test(
+        &["-d", r"\t-\b"],
+        r"tr: range-endpoints of '\t-\u{8}' are in reverse collating sequence order
+",
+    );
+}
+
+#[test]
+fn tr_backwards_range_octal() {
+    tr_bad_arguments_failure_test(
+        &["-d", r"\045-\044"],
+        "tr: range-endpoints of '%-$' are in reverse collating sequence order\n",
+    );
+}
+
+#[test]
+fn tr_backwards_range_mixed() {
+    tr_bad_arguments_failure_test(
+        &["-d", r"A-\t"],
+        r"tr: range-endpoints of 'A-\t' are in reverse collating sequence order
+",
+    );
+}
+
+#[test]
+fn tr_mixed_range() {
+    tr_test(
+        &["-d", r"\044-Z"],
+        "$123456789ABCDEFGHIabcdefghi",
+        "abcdefghi",
+    );
+}
+
+#[test]
+fn tr_two_ranges() {
+    tr_test(&["ab12", r"\044-\045Y-Z"], "21ba", "ZY%$");
+}
+
+#[test]
+fn tr_bad_octal_range() {
+    tr_bad_arguments_failure_test(
+        &["-d", r"\046-\048"],
+        r"tr: range-endpoints of '&-\u{4}' are in reverse collating sequence order
+",
+    );
+}
+
+#[test]
+fn tr_bad_x_n_construct_decimal() {
+    tr_bad_arguments_failure_test(
+        &["-d", "[a*100000000000000000000]"],
+        "tr: invalid repeat count ‘100000000000000000000’ in [c*n] construct\n",
+    );
+}
+
+#[test]
+fn tr_bad_x_n_construct_octal() {
+    tr_bad_arguments_failure_test(
+        &["-d", "[a*010000000000000000000000]"],
+        "tr: invalid repeat count ‘010000000000000000000000’ in [c*n] construct\n",
+    );
+}
+
+#[test]
+fn tr_bad_x_n_construct_non_decimal_non_octal() {
+    tr_bad_arguments_failure_test(
+        &["-d", "[a*a]"],
+        "tr: invalid repeat count ‘a’ in [c*n] construct\n",
+    );
+}
+
+#[test]
+fn tr_trailing_hyphen() {
+    tr_test(&["ab", "c-"], "abc123", "c-c123");
+}
+
+#[test]
+fn tr_backslash_range() {
+    tr_test(
+        &["1-9", r"\b-\r"],
+        r"\ 987654321 -",
+        "\\ \x0D\x0D\x0D\x0D\x0C\x0B\x0A\x09\x08 -",
+    );
+}
+
+#[test]
+fn tr_fill_with_last_char() {
+    tr_test(&["1-34-8", "A-C!"], "987654321", "9!!!!!CBA");
+}
+
+#[test]
+fn tr_octal_above_one_byte_value() {
+    let args = &["-d", r"\501"];
+
+    let str_args = args
+        .iter()
+        .map(|st| st.to_owned().to_owned())
+        .collect::<Vec<String>>();
+
+    run_test(TestPlan {
+        cmd: "tr".to_owned(),
+        args: str_args,
+        stdin_data: "(1Ł)".to_owned(),
+        expected_out: "Ł)".to_owned(),
+        expected_err: r"tr: warning: the ambiguous octal escape \501 is being interpreted as the 2-byte sequence \050, 1
+".to_owned(),
+        expected_exit_code: 0,
+    });
+}
+
+#[test]
+fn tr_short_octal_with_non_octal_digits_after() {
+    // Interpret as \004, '8', and the range from '1' through '3'
+    tr_test(&["-d", r"\0481-3"], "A 123 \x04 456 789 Z", "A   456 79 Z");
+}
+
+#[test]
+fn tr_octal_parsing_ambiguous() {
+    // "If an ordinary digit (representing itself) is to follow an octal sequence, the octal sequence must use the full three digits to avoid ambiguity."
+    // https://pubs.opengroup.org/onlinepubs/9799919799/utilities/tr.html
+    // Interpret as \123, not \012 and '3'
+    tr_test(
+        &["-d", r"\123"],
+        "321 \\ \x0A \x53 \x50 \x02 \x01 \\ CBA",
+        "321 \\ \x0A  \x50 \x02 \x01 \\ CBA",
+    );
+}
+
+#[test]
+fn tr_octal_parsing_non_ambiguous() {
+    // See above
+    // Interpret as \012 and 'A'
+    tr_test(
+        &["-d", r"\12A"],
+        "321 \\ \x0A \x53 \x50 \x02 \x01 \\ CBA",
+        "321 \\  \x53 \x50 \x02 \x01 \\ CB",
+    );
 }

--- a/text/tests/tr/mod.rs
+++ b/text/tests/tr/mod.rs
@@ -288,7 +288,13 @@ fn tr_ross_1b() {
 
 #[test]
 fn tr_ross_2() {
-    tr_test(&["-dcs", "[:lower:]", "n-rs-z"], "amzAMZ123.-+amz", "amzam");
+    // Modified expected output to match other implementations
+    // "amzam" -> "amzamz"
+    tr_test(
+        &["-dcs", "[:lower:]", "n-rs-z"],
+        "amzAMZ123.-+amz",
+        "amzamz",
+    );
 }
 
 #[test]
@@ -531,7 +537,7 @@ fn tr_octal_above_one_byte_value() {
         expected_out: "Ł)".to_owned(),
         expected_err: r"tr: warning: the ambiguous octal escape \501 is being interpreted as the 2-byte sequence \050, 1
 ".to_owned(),
-        expected_exit_code: 0,
+        expected_exit_code: 0_i32,
     });
 }
 
@@ -608,4 +614,17 @@ fn tr_ranges_with_invalid_escape_sequences() {
 
     // Similar to above
     tr_test(&["-d", r"\7-\A"], INPUT, r"abcdefBCDEF\\");
+}
+
+// Make sure state is persisted through multiple calls to `transform`
+#[test]
+fn tr_streaming_state() {
+    let a_s = "a".repeat(16_usize * 1_024_usize);
+
+    tr_test(&["-s", "a", "b"], &a_s, "b");
+}
+
+#[test]
+fn tr_minimal_d_s() {
+    tr_test(&["-d", "-s", "", "A"], "1AA", "1A");
 }

--- a/text/tests/tr/mod.rs
+++ b/text/tests/tr/mod.rs
@@ -563,3 +563,34 @@ fn tr_octal_parsing_non_ambiguous() {
         "321 \\  \x53 \x50 \x02 \x01 \\ CB",
     );
 }
+
+#[test]
+fn tr_equiv_class_and_other_deletions() {
+    tr_test(&["-d", "4[=a=]2"], "1 3 A a 2 4", "1 3 A   ");
+}
+
+#[test]
+fn tr_string2_equiv_inappropriate() {
+    tr_bad_arguments_failure_test(
+        &["1", "[=a=]"],
+        "tr: [=c=] expressions may not appear in string2 when translating\n",
+    );
+}
+
+#[test]
+fn tr_equivalence_class_low_priority() {
+    const INPUT: &str = "aaa bbb ccc 123";
+    const OUTPUT: &str = "YYY bbb ccc 123";
+
+    tr_test(&["[=a=]a", "XY"], INPUT, OUTPUT);
+
+    tr_test(&["a[=a=]", "XY"], INPUT, OUTPUT);
+}
+
+#[test]
+fn tr_arguments_validation_error_message_format() {
+    tr_bad_arguments_failure_test(
+        &["a"],
+        "tr: missing operand after ‘a’. Two strings must be given when translating.\n",
+    );
+}

--- a/text/tests/tr/mod.rs
+++ b/text/tests/tr/mod.rs
@@ -594,3 +594,18 @@ fn tr_arguments_validation_error_message_format() {
         "tr: missing operand after ‘a’. Two strings must be given when translating.\n",
     );
 }
+
+// POSIX does not specify how invalid backslash sequences are handled, so there is some flexibility here
+// Still, something useful should be done (for instance, tr should not abort in this case)
+#[test]
+fn tr_ranges_with_invalid_escape_sequences() {
+    const INPUT: &str = "abcdef ABCDEF -\\ \x07 -\\ 123456789";
+
+    // "\7-\9" is:
+    //     treated as a range from \007 through '9' by bsdutils and GNU Core Utilities
+    //     treated as: 1) a range from \007 through '\', and 2) separately the character '9', by BusyBox
+    tr_test(&["-d", r"\7-\9"], INPUT, r"abcdefABCDEF\\");
+
+    // Similar to above
+    tr_test(&["-d", r"\7-\A"], INPUT, r"abcdefBCDEF\\");
+}

--- a/text/tr.rs
+++ b/text/tr.rs
@@ -2,14 +2,13 @@ use clap::Parser;
 use deunicode::deunicode_char;
 use gettextrs::{bind_textdomain_codeset, setlocale, textdomain, LocaleCategory};
 use plib::PROJECT_NAME;
-use regex::Regex;
 use std::collections::{HashMap, HashSet};
 use std::error::Error;
-use std::io::{self, Read, Write};
+use std::io::{self, ErrorKind, Read, Write};
 use std::iter::{self, Peekable};
 use std::process;
 use std::slice::Iter;
-use std::sync::OnceLock;
+use std::str::Chars;
 
 /// tr - translate or delete characters
 #[derive(Parser)]
@@ -42,7 +41,7 @@ impl Args {
     fn validate_args(&self) -> Result<(), String> {
         // Check if conflicting options are used together
         if self.complement_char && self.complement_val {
-            return Err("Options '-c' and '-C' cannot be used together".to_owned());
+            return Err("tr: options '-c' and '-C' cannot be used together".to_owned());
         }
 
         if self.squeeze_repeats
@@ -50,15 +49,14 @@ impl Args {
             && (self.complement_char || self.complement_val)
             && !self.delete
         {
-            return Err("Option '-c' or '-C' may only be used with 2 strings".to_owned());
+            return Err("tr: option '-c' or '-C' may only be used with 2 strings".to_owned());
         }
 
         if !self.squeeze_repeats && !self.delete && self.string2.is_none() {
-            return Err("Need two strings operand".to_owned());
-        }
-
-        if self.string1.is_empty() {
-            return Err("At least 1 string operand is required".to_owned());
+            return Err(format!(
+                "tr: missing operand after ‘{}’. Two strings must be given when translating.",
+                self.string1
+            ));
         }
 
         Ok(())
@@ -71,27 +69,33 @@ enum CharRepetition {
     N(usize),
 }
 
-// The Char struct represents a character along with its repetition count.
 #[derive(Clone)]
-struct Char {
-    // The character.
+struct CharOperand {
+    // The character
     char: char,
     // The number of times the character is repeated
     char_repetition: CharRepetition,
 }
 
-// The Equiv struct represents a character equivalent
 #[derive(Clone)]
-struct Equiv {
+struct EquivOperand {
     // The character equivalent
     char: char,
 }
 
-// The Operand enum can be either a Char or an Equiv
 #[derive(Clone)]
 enum Operand {
-    Char(Char),
-    Equiv(Equiv),
+    Char(CharOperand),
+    Equiv(EquivOperand),
+}
+
+impl Operand {
+    fn char(&self) -> &char {
+        match self {
+            Operand::Char(CharOperand { char, .. }) => char,
+            Operand::Equiv(EquivOperand { char }) => char,
+        }
+    }
 }
 
 impl Operand {
@@ -108,13 +112,13 @@ impl Operand {
     fn contains(operands: &[Operand], target: &char) -> bool {
         for operand in operands {
             match operand {
-                Operand::Equiv(eq) => {
-                    if compare_deunicoded_chars(eq.char, *target) {
+                Operand::Equiv(EquivOperand { char }) => {
+                    if compare_deunicoded_chars(*char, *target) {
                         return true;
                     }
                 }
-                Operand::Char(ch) => {
-                    if ch.char == *target {
+                Operand::Char(CharOperand { char, .. }) => {
+                    if char == target {
                         return true;
                     }
                 }
@@ -147,47 +151,55 @@ impl Operand {
 /// - The sequence does not contain a closing `]`.
 /// - The sequence contains no characters between the `=` symbols.
 ///
-fn parse_equiv(chars: &mut Peekable<Iter<char>>) -> Result<Vec<Operand>, String> {
+fn parse_equiv(square_bracket_constructs_buffer: &[char]) -> Result<Operand, String> {
+    let mut iter = square_bracket_constructs_buffer.iter();
+
     // Skip '[='
-    assert!(chars.next() == Some(&'['));
-    assert!(chars.next() == Some(&'='));
+    assert!(iter.next() == Some(&'['));
+    assert!(iter.next() == Some(&'='));
 
-    let mut equiv = String::new();
+    let mut between_equals_signs = Vec::<char>::with_capacity(1_usize);
 
-    while let Some(&next_ch) = chars.peek() {
-        if next_ch == &'=' {
-            break;
+    between_equals_signs.extend(iter.take_while(|&&ch| ch != '='));
+
+    let char_between_equals_signs = match between_equals_signs.as_slice() {
+        &[ch] => ch,
+        &[] => {
+            unreachable!();
         }
+        sl => {
+            const ERROR_MESSAGE_PREFIX: &str = "tr: ";
+            const ERROR_MESSAGE_SUFFIX: &str =
+                ": equivalence class operand must be a single character";
 
-        chars.next();
+            const ERROR_MESSAGE_PREFIX_AND_SUFFIX_LENGTH: usize =
+                ERROR_MESSAGE_PREFIX.len() + ERROR_MESSAGE_SUFFIX.len();
 
-        equiv.push(*next_ch);
-    }
+            let mut error_message =
+                String::with_capacity(ERROR_MESSAGE_PREFIX_AND_SUFFIX_LENGTH + sl.len());
 
-    if equiv.is_empty() {
-        return Err("Error: Missing equiv symbol after '[='".to_owned());
-    }
+            error_message.push_str(ERROR_MESSAGE_PREFIX);
 
-    // Skip '='
-    let Some('=') = chars.next() else {
-        return Err("Error: Missing '=' before ']' for '[=equiv=]'".to_owned());
+            for &ch in sl {
+                error_message.push(ch);
+            }
+
+            error_message.push_str(ERROR_MESSAGE_SUFFIX);
+
+            return Err(error_message);
+        }
     };
 
-    // Skip ']'
-    let Some(']') = chars.next() else {
-        return Err("Error: Missing closing ']' for '[=equiv=]'".to_owned());
-    };
+    let operand = Operand::Equiv(EquivOperand {
+        char: char_between_equals_signs,
+    });
 
-    let mut operands = Vec::<Operand>::new();
-
-    for equiv_char in equiv.chars() {
-        operands.push(Operand::Equiv(Equiv { char: equiv_char }));
-    }
-
-    Ok(operands)
+    Ok(operand)
 }
 
-fn parse_repeated_char(chars: &[char]) -> Result<Operand, String> {
+fn parse_repeated_char(square_bracket_constructs_buffer: &[char]) -> Result<Operand, String> {
+    // TODO
+    // Clean this up
     fn fill_repeat_str(iter: &mut Iter<char>, repeat_string: &mut String) {
         while let Some(&ch) = iter.next() {
             if ch == ']' {
@@ -202,7 +214,7 @@ fn parse_repeated_char(chars: &[char]) -> Result<Operand, String> {
         unreachable!();
     }
 
-    let mut iter = chars.iter();
+    let mut iter = square_bracket_constructs_buffer.iter();
 
     // Skip '['
     assert!(iter.next() == Some(&'['));
@@ -213,7 +225,7 @@ fn parse_repeated_char(chars: &[char]) -> Result<Operand, String> {
     // Skip '*'
     assert!(iter.next() == Some(&'*'));
 
-    let mut repeat_string = String::with_capacity(chars.len());
+    let mut repeat_string = String::with_capacity(square_bracket_constructs_buffer.len());
 
     fill_repeat_str(&mut iter, &mut repeat_string);
 
@@ -241,51 +253,279 @@ fn parse_repeated_char(chars: &[char]) -> Result<Operand, String> {
         }
     };
 
-    Ok(Operand::Char(Char {
+    let operand = Operand::Char(CharOperand {
         char,
         char_repetition,
-    }))
+    });
+
+    Ok(operand)
 }
 
-/// Parses an input string and converts it into a vector of `Operand` entries.
-///
-/// This function processes the input string, looking for sequences in the formats
-/// `[=equiv=]` and `[x*n]`, as well as regular characters. It delegates the parsing
-/// of the specific formats to helper functions `parse_equiv` and `parse_repeated_char`.
-///
-/// # Arguments
-///
-/// * `input` - A string slice containing the input to be parsed.
-///
-/// # Returns
-///
-/// A `Result` containing a vector of `Operand` entries if successful, or a `String`
-/// describing the error if parsing fails.
-///
-/// # Errors
-///
-/// This function will return an error if:
-/// - It encounters an invalid format.
-/// - It encounters any specific error from `parse_equiv` or `parse_repeated_char`.
-fn parse_symbols(string1_or_string2: &str) -> Result<Vec<Operand>, String> {
+fn parse_octal_sequence(
+    first_octal_digit: char,
+    peekable: &mut Peekable<Chars>,
+) -> Result<char, String> {
+    let mut st = String::with_capacity(3_usize);
+
+    st.push(first_octal_digit);
+
+    let mut added_octal_digit_to_buffer = |pe: &mut Peekable<Chars>| {
+        if let Some(&second_octal_digit @ '0'..='7') = pe.peek() {
+            st.push(second_octal_digit);
+
+            true
+        } else {
+            false
+        }
+    };
+
+    let advance_peekable_if_parsing_succeed = if added_octal_digit_to_buffer(peekable) {
+        peekable.next();
+
+        added_octal_digit_to_buffer(peekable)
+    } else {
+        false
+    };
+
+    let from_str_radix_result = u16::from_str_radix(&st, 8_u32);
+
+    let octal_digits_parsed = match from_str_radix_result {
+        Ok(uo) => uo,
+        Err(pa) => {
+            return Err(format!("tr: failed to parse octal sequence '{st}' ({pa})"));
+        }
+    };
+
+    // There is no consensus on how to handle this:
+    //
+    // BusyBox and GNU Core Utilities:
+    //     parse "\501" as \050 (which is '(') and '1'
+    //         GNU Core Utilities prints a warning, BusyBox does not
+    // uutils' coreutils:
+    //     parses "\501" as '1'
+    // bsdutils:
+    //     parses "\501" as 'Ł' (U+0141)
+    //
+    // None of these implementations treat this as a fatal error
+    // POSIX says: "Multi-byte characters require multiple, concatenated escape sequences of this type, including the leading <backslash> for each byte."
+    //
+    // Following BusyBox and GNU Core Utilities, because their handling seems to be most in keeping with the POSIX
+    // specification
+    let byte = match u8::try_from(octal_digits_parsed) {
+        Ok(ue) => {
+            if advance_peekable_if_parsing_succeed {
+                peekable.next();
+            }
+
+            ue
+        }
+        Err(_tr) => {
+            // This should only happen when the sequence is \400 and above
+            // Cannot happen with a two character sequence like \77, because 8^2 is 64 (within u8 bounds)
+            assert!(st.len() == 3_usize);
+
+            let mut chars = st.chars();
+
+            let third_octal_digit = chars.next_back().unwrap();
+
+            // `chars_str` is a view of the first two octal digits
+            let chars_str = chars.as_str();
+
+            assert!(chars_str.len() == 2_usize);
+
+            // Treat the sequence \abc (where a, b, and c are octal digits) as \0abc
+            // The byte represented by \0ab is what will be returned from this function
+            // Parsing of c is handled outside this function
+            match u8::from_str_radix(chars_str, 8_u32) {
+                Ok(ue) => {
+                    eprintln!(
+                        "tr: warning: the ambiguous octal escape \\{st} is being interpreted as the 2-byte sequence \\0{chars_str}, {third_octal_digit}"
+                    );
+
+                    ue
+                }
+                Err(pa) => {
+                    return Err(format!("tr: invalid octal sequence '{chars_str}' ({pa})"));
+                }
+            }
+        }
+    };
+
+    let char = char::from(byte);
+
+    Ok(char)
+}
+
+fn parse_single_char(peekable: &mut Peekable<Chars>) -> Result<Option<char>, String> {
+    let option = match peekable.next() {
+        Some('\\') => {
+            let char = match peekable.next() {
+                /* #region \octal */
+                Some(first_octal_digit @ '0'..='7') => {
+                    parse_octal_sequence(first_octal_digit, peekable)?
+                }
+                /* #endregion */
+                //
+                /* #region \character */
+                // <alert>
+                // Code point 0007
+                Some('a') => '\u{0007}',
+                // <backspace>
+                // Code point 0008
+                Some('b') => '\u{0008}',
+                // <tab>
+                // Code point 0009
+                Some('t') => '\u{0009}',
+                // <newline>
+                // Code point 000A
+                Some('n') => '\u{000A}',
+                // <vertical-tab>
+                // Code point 000B
+                Some('v') => '\u{000B}',
+                // <form-feed>
+                // Code point 000C
+                Some('f') => '\u{000C}',
+                // <carriage-return>
+                // Code point 000D
+                Some('r') => '\u{000D}',
+                // <backslash>
+                // Code point 005C
+                Some('\\') => {
+                    // An escaped backslash
+                    '\u{005C}'
+                }
+                /* #endregion */
+                //
+                Some(cha) => {
+                    // If a backslash is not at the end of the string, and is not followed by one of the valid
+                    // escape characters (including another backslash), the backslash is basically just ignored:
+                    // the following character is the character added to the set.
+                    cha
+                }
+                None => {
+                    eprintln!(
+                        "tr: warning: an unescaped backslash at end of string is not portable"
+                    );
+
+                    // If an unescaped backslash is the last character of the string, treat it as though it were
+                    // escaped (backslash is added to the set)
+                    '\u{005C}'
+                }
+            };
+
+            Some(char)
+        }
+        op => op,
+    };
+
+    Ok(option)
+}
+
+fn parse_range_or_single_char(
+    starting_char: char,
+    peekable: &mut Peekable<Chars>,
+    operand_vec: &mut Vec<Operand>,
+) -> Result<(), String> {
+    match peekable.peek() {
+        Some(&hyphen @ '-') => {
+            // Possible "c-c" construct
+            // Move past `hyphen`
+            peekable.next();
+
+            // The parsed character after the hyphen
+            // e.g. "tr 'A-Z' '\044-1'"
+            match parse_single_char(peekable)? {
+                Some(after_hyphen) => {
+                    // Ranges are inclusive
+                    let range_inclusive = starting_char..=after_hyphen;
+
+                    if range_inclusive.is_empty() {
+                        let message =
+                            format!(
+                                "tr: range-endpoints of '{}-{}' are in reverse collating sequence order",
+                                starting_char.escape_default(),
+                                after_hyphen.escape_default()
+                            );
+
+                        return Err(message);
+                    }
+
+                    let range_inclusive_to_operand_iterator = range_inclusive.map(|ch| {
+                        Operand::Char(CharOperand {
+                            char: ch,
+                            char_repetition: CharRepetition::N(1_usize),
+                        })
+                    });
+
+                    // TODO
+                    // Does this reserve the right capacity?
+                    operand_vec.extend(range_inclusive_to_operand_iterator);
+                }
+                None => {
+                    // End of input, do not handle as a range
+                    // e.g. "tr 'ab' 'c-'"
+                    operand_vec.extend_from_slice(&[
+                        Operand::Char(CharOperand {
+                            char: starting_char,
+                            char_repetition: CharRepetition::N(1_usize),
+                        }),
+                        Operand::Char(CharOperand {
+                            char: hyphen,
+                            char_repetition: CharRepetition::N(1_usize),
+                        }),
+                    ]);
+                }
+            }
+        }
+        _ => {
+            // Not a "c-c" construct
+            operand_vec.push(Operand::Char(CharOperand {
+                char: starting_char,
+                char_repetition: CharRepetition::N(1_usize),
+            }))
+        }
+    }
+
+    Ok(())
+}
+
+fn parse_string1_or_string2(string1_or_string2: &str) -> Result<Vec<Operand>, String> {
+    // The longest valid "[:class:]", "[=equiv=]", or "[x*n]" construct is a "[x*n]" construct
+    // These are (seemingly) the shortest invalid "[x*n]" constructs (octal and decimal):
+    // [a*010000000000000000000000]
+    // [a*100000000000000000000]
+    // Therefore, the longest valid one should be:
+    // [a*01000000000000000000000]
+    // Rounding up to 32
+    const SQUARE_BRACKET_CONSTRUCTS_BUFFER_CAPACITY: usize = 32_usize;
+
     // This capacity will be sufficient at least some of the time
     let mut operand_vec = Vec::<Operand>::with_capacity(string1_or_string2.len());
 
-    let mut iterator = string1_or_string2.chars().peekable();
+    let mut peekable = string1_or_string2.chars().peekable();
 
-    while let Some(&ch) = iterator.peek() {
-        match ch {
-            '[' => {
-                // Use a String instead?
-                let mut vec = Vec::<char>::with_capacity(1_usize);
+    let mut parse_left_square_bracket_normally = false;
+
+    while let Some(&ch) = peekable.peek() {
+        match (ch, parse_left_square_bracket_normally) {
+            ('[', false) => {
+                // Save the state of `peekable` before advancing it, see note below
+                let peekable_saved = peekable.clone();
+
+                // TODO
+                // Avoid repeated allocation
+                let mut square_bracket_constructs_buffer =
+                    Vec::<char>::with_capacity(SQUARE_BRACKET_CONSTRUCTS_BUFFER_CAPACITY);
 
                 let mut found_closing_square_bracket = false;
 
-                for ch in iterator.by_ref() {
-                    vec.push(ch);
+                for ch in peekable.by_ref() {
+                    square_bracket_constructs_buffer.push(ch);
+
+                    let vec_len = square_bracket_constructs_buffer.len();
 
                     // Length check is a hacky fix for "[:]", "[=]", "[]*]", etc.
-                    if ch == ']' && vec.len() > 3_usize {
+                    if ch == ']' && vec_len > 3_usize {
                         found_closing_square_bracket = true;
 
                         break;
@@ -293,27 +533,19 @@ fn parse_symbols(string1_or_string2: &str) -> Result<Vec<Operand>, String> {
                 }
 
                 if found_closing_square_bracket {
-                    let after_opening_square_bracket = vec.get(1_usize);
+                    let after_opening_square_bracket =
+                        square_bracket_constructs_buffer.get(1_usize);
 
-                    let before_closing_square_bracket = vec.iter().rev().nth(1_usize);
+                    let before_closing_square_bracket =
+                        square_bracket_constructs_buffer.iter().rev().nth(1_usize);
 
                     if after_opening_square_bracket == Some(&':')
                         && before_closing_square_bracket == Some(&':')
                     {
-                        // "[:class:]" construct
-                        let mut into_iter = vec.into_iter();
-
-                        assert!(into_iter.next() == Some('['));
-                        assert!(into_iter.next() == Some(':'));
-
-                        assert!(into_iter.next_back() == Some(']'));
-                        assert!(into_iter.next_back() == Some(':'));
-
-                        // TODO
-                        // Performance
-                        let class = into_iter.collect::<String>();
-
-                        expand_character_class(&class, &mut operand_vec)?;
+                        expand_character_class(
+                            &square_bracket_constructs_buffer,
+                            &mut operand_vec,
+                        )?;
 
                         continue;
                     }
@@ -322,161 +554,51 @@ fn parse_symbols(string1_or_string2: &str) -> Result<Vec<Operand>, String> {
                         && before_closing_square_bracket == Some(&'=')
                     {
                         // "[=equiv=]" construct
-                        operand_vec.extend(parse_equiv(&mut vec.iter().peekable())?);
-
-                        continue;
-                    }
-
-                    if vec.get(2_usize) == Some(&'*') {
-                        // "[x*n]" construct
-                        let operand = parse_repeated_char(&vec)?;
+                        let operand = parse_equiv(&square_bracket_constructs_buffer)?;
 
                         operand_vec.push(operand);
 
                         continue;
                     }
-                }
 
-                // Not "[:class:]", "[=equiv=]", or "[x*n]"
-                // TODO
-                // This is not correct
-                // "c-c" and backslash-escape sequences must be handled
-                for ch in vec {
-                    operand_vec.push(Operand::Char(Char {
-                        char: ch,
-                        char_repetition: CharRepetition::N(1),
-                    }))
-                }
-            }
-            // A single backslash character (0x5C)
-            // https://pubs.opengroup.org/onlinepubs/9799919799/basedefs/V1_chap05.html#tagtcjh_2
-            // https://www.unicode.org/Public/UCD/latest/ucd/NameAliases.txt
-            '\\' => {
-                // Move past '\'
-                iterator.next();
-
-                let char_for_operand = match iterator.peek() {
-                    /* #region \octal */
-                    Some(&first_octal_digit @ '0'..='7') => {
-                        // Move past `first_octal_digit`
-                        iterator.next();
-
-                        let mut st = String::with_capacity(3_usize);
-
-                        st.push(first_octal_digit);
-
-                        for _ in 0_usize..2_usize {
-                            if let Some(&octal_digit @ '0'..='7') = iterator.peek() {
-                                // Move past `octal_digit`
-                                iterator.next();
-
-                                st.push(octal_digit);
-                            } else {
-                                break;
-                            }
-                        }
-
-                        let from_str_radix_result = u16::from_str_radix(&st, 8_u32);
-
-                        let octal_digits_parsed = match from_str_radix_result {
-                            Ok(uo) => uo,
-                            Err(pa) => {
-                                return Err(format!(
-                                    "tr: failed to parse octal sequence '{st}' ({pa})"
-                                ));
-                            }
-                        };
-
-                        let byte = match u8::try_from(octal_digits_parsed) {
-                            Ok(ue) => ue,
-                            Err(tr) => {
-                                return Err(format!("tr: invalid octal sequence '{st}' ({tr})"));
-                            }
-                        };
-
-                        operand_vec.push(Operand::Char(Char {
-                            char: char::from(byte),
-                            char_repetition: CharRepetition::N(1),
-                        }));
+                    if square_bracket_constructs_buffer.get(2_usize) == Some(&'*') {
+                        // "[x*n]" construct
+                        operand_vec.push(parse_repeated_char(&square_bracket_constructs_buffer)?);
 
                         continue;
                     }
-                    /* #endregion */
-                    //
-                    /* #region \character */
-                    // <alert>
-                    // Code point 0007
-                    Some('a') => '\u{0007}',
-                    // <backspace>
-                    // Code point 0008
-                    Some('b') => '\u{0008}',
-                    // <tab>
-                    // Code point 0009
-                    Some('t') => '\u{0009}',
-                    // <newline>
-                    // Code point 000A
-                    Some('n') => '\u{000A}',
-                    // <vertical-tab>
-                    // Code point 000B
-                    Some('v') => '\u{000B}',
-                    // <form-feed>
-                    // Code point 000C
-                    Some('f') => '\u{000C}',
-                    // <carriage-return>
-                    // Code point 000D
-                    Some('r') => '\u{000D}',
-                    // <backslash>
-                    // Code point 005C
-                    Some('\\') => {
-                        // An escaped backslash
-                        '\u{005C}'
-                    }
-                    /* #endregion */
-                    //
-                    Some(&cha) => {
-                        // If a backslash is not at the end of the string, and is not followed by one of the valid
-                        // escape characters (including another backslash), the backslash is basically just ignored:
-                        // the following character is the character added to the set.
-                        cha
-                    }
-                    None => {
-                        eprintln!(
-                            "tr: warning: an unescaped backslash at end of string is not portable"
-                        );
+                }
 
-                        // If an unescaped backslash is the last character of the string, treat it as though it were
-                        // escaped (backslash is added to the set)
-                        '\u{005C}'
-                    }
-                };
-
-                // Move past character following '\'
-                iterator.next();
-
-                operand_vec.push(Operand::Char(Char {
-                    char: char_for_operand,
-                    char_repetition: CharRepetition::N(1),
-                }));
+                // Not a "[:class:]", "[=equiv=]", or "[x*n]" construct
+                // The hacky way to continue is to reset `peekable` (to `peekable_saved`)
+                // This moves the Peekable back to the point it was at before attempting to parse square bracket
+                // constructs
+                parse_left_square_bracket_normally = true;
+                peekable = peekable_saved;
             }
-            cha => {
-                // Move past `cha`
-                iterator.next();
+            (cha, bo) => {
+                // '[' is not the start of a square bracket construct, so handle it normally
+                if bo {
+                    assert!(cha == '[');
 
-                // Add a regular character with a repetition of 1
-                operand_vec.push(Operand::Char(Char {
-                    char: cha,
-                    char_repetition: CharRepetition::N(1),
-                }));
+                    // When encountering '[' in the future, try to parse square bracket constructs first
+                    parse_left_square_bracket_normally = false;
+                }
+
+                if let Some(char) = parse_single_char(&mut peekable)? {
+                    parse_range_or_single_char(char, &mut peekable, &mut operand_vec)?;
+                }
             }
         }
     }
 
-    // eprintln!("{operand_vec:?}");
-
-    // eprintln!();
-
     Ok(operand_vec)
 }
+
+// TODO
+// No other implementations actually seem to do anything with equivalence classes:
+// they seem to just treat them as the parsed character (e.g. "[=a=]" is treated as "a").
+// Should this implementation continue to try to actually handle them?
 
 /// Compares two characters after normalizing them.
 /// This function uses the hypothetical `deunicode_char` function to normalize
@@ -494,11 +616,34 @@ fn compare_deunicoded_chars(char1: char, char2: char) -> bool {
     let normalized_char1 = deunicode_char(char1);
     let normalized_char2 = deunicode_char(char2);
 
-    normalized_char1 == normalized_char2
+    match (normalized_char1, normalized_char2) {
+        (Some(st), Some(str)) => st == str,
+        (None, None) => {
+            // Purpose of match: prevent this from being considered equal
+            false
+        }
+        _ => false,
+    }
 }
 
-fn expand_character_class(class: &str, operand_vec: &mut Vec<Operand>) -> Result<(), String> {
-    let char_vec = match class {
+fn expand_character_class(
+    square_bracket_constructs_buffer: &[char],
+    operand_vec: &mut Vec<Operand>,
+) -> Result<(), String> {
+    // "[:class:]" construct
+    let mut into_iter = square_bracket_constructs_buffer.iter();
+
+    assert!(into_iter.next() == Some(&'['));
+    assert!(into_iter.next() == Some(&':'));
+
+    assert!(into_iter.next_back() == Some(&']'));
+    assert!(into_iter.next_back() == Some(&':'));
+
+    // TODO
+    // Performance
+    let class = into_iter.collect::<String>();
+
+    let char_vec = match class.as_str() {
         "alnum" => ('0'..='9')
             .chain('A'..='Z')
             .chain('a'..='z')
@@ -529,155 +674,19 @@ fn expand_character_class(class: &str, operand_vec: &mut Vec<Operand>) -> Result
             .chain('A'..='F')
             .chain('a'..='f')
             .collect::<Vec<_>>(),
-        _ => return Err("Error: Invalid class name ".to_owned()),
+        st => return Err(format!("tr: invalid character class ‘{st}’")),
     };
 
     operand_vec.reserve(char_vec.len());
 
     for ch in char_vec {
-        operand_vec.push(Operand::Char(Char {
+        operand_vec.push(Operand::Char(CharOperand {
             char: ch,
-            char_repetition: CharRepetition::N(1),
+            char_repetition: CharRepetition::N(1_usize),
         }));
     }
 
     Ok(())
-}
-
-/// Parses an octal string and returns the corresponding character, if valid.
-///
-/// # Arguments
-///
-/// * `s` - A string slice that holds the octal representation of the character.
-///
-/// # Returns
-///
-/// * `Option<char>` - Returns `Some(char)` if the input string is a valid octal
-///   representation of a Unicode character. Returns `None` if the string is
-///   not a valid octal number or if the resulting number does not correspond
-///   to a valid Unicode character.
-///
-fn parse_octal(s: &str) -> Option<char> {
-    u32::from_str_radix(s, 8).ok().and_then(char::from_u32)
-}
-
-/// Parses a string representing a range of characters or octal values and returns a vector of `Operand`s.
-///
-/// This function handles ranges specified in square brackets, such as `[a-z]` or `[\\141-\\172]`.
-/// It supports ranges of plain characters and ranges of octal-encoded characters. The function
-/// trims the square brackets from the input string, splits the range into start and end parts,
-/// and then expands the range into a list of `Operand`s.
-///
-/// # Arguments
-///
-/// * `input` - A string slice containing the range to be parsed. The range can be in the form of
-///   `[a-z]`, `[\\141-\\172]`, etc.
-///
-/// # Returns
-///
-/// * `Result<Vec<Operand>, String>` - Returns `Ok(Vec<Operand>)` if the input string represents
-///   a valid range. Returns `Err(String)` with an error message if the input is invalid.
-///
-/// # Errors
-///
-/// This function returns an error if:
-/// - The input string does not contain a valid range.
-/// - The octal values in the range cannot be parsed into valid characters.
-///
-fn parse_ranges(string1_or_string2: &str) -> Result<Vec<Operand>, String> {
-    // Remove square brackets
-    let input_without_square_brackets =
-        string1_or_string2.trim_matches(|ch| ch == '[' || ch == ']');
-
-    let mut split = input_without_square_brackets.split('-');
-
-    let start = split.next().ok_or("Iteration failed")?;
-    let end = split.next().ok_or("Iteration failed")?;
-
-    let mut chars = Vec::<char>::new();
-
-    if start.starts_with('\\') && end.starts_with('\\') {
-        // Processing the \octal-\octal range
-        if let (Some(start_char), Some(end_char)) =
-            (parse_octal(&start[1..]), parse_octal(&end[1..]))
-        {
-            let start_u32 = start_char as u32;
-            let end_u32 = end_char as u32;
-
-            for code in start_u32..=end_u32 {
-                if let Some(c) = char::from_u32(code) {
-                    chars.push(c);
-                }
-            }
-        }
-    } else if !start.starts_with('\\') && !end.starts_with('\\') {
-        // Processing the c-c range
-        let start_char = start.chars().next().unwrap();
-        let end_char = end.chars().next().unwrap();
-
-        for ch in start_char..=end_char {
-            chars.push(ch);
-        }
-    }
-
-    let vec = chars
-        .into_iter()
-        .map(|ch| {
-            Operand::Char(Char {
-                char: ch,
-                char_repetition: CharRepetition::N(1),
-            })
-        })
-        .collect::<Vec<_>>();
-
-    Ok(vec)
-}
-
-fn parse_string1_or_string2(string1_or_string2: &str) -> Result<Vec<Operand>, String> {
-    let vec = if contains_single_range(string1_or_string2) {
-        // TODO
-        // Ranges need to be handled in all cases
-        parse_ranges(string1_or_string2)?
-    } else {
-        parse_symbols(string1_or_string2)?
-    };
-
-    Ok(vec)
-}
-
-/// Determines if a string contains a single valid range expression.
-///
-/// This function uses a regular expression to check if the input string matches any
-/// of the following range formats:
-/// - `[a-z]` or `[A-Z]` or `[0-9]`: Character ranges enclosed in square brackets
-/// - `\\octal-\\octal`: Ranges of octal-encoded characters
-/// - `a-z` or `A-Z` or `0-9`: Simple character-symbol ranges
-///
-/// # Arguments
-///
-/// * `s` - A string slice to be checked for containing a single valid range.
-///
-/// # Returns
-///
-/// * `bool` - Returns `true` if the input string matches any of the valid range formats.
-///   Returns `false` otherwise.
-///
-fn contains_single_range(string1_or_string2: &str) -> bool {
-    static REGEX_ONCE_CELL: OnceLock<Regex> = OnceLock::new();
-
-    let regex = REGEX_ONCE_CELL.get_or_init(|| {
-        // Regular expression for a range of characters or \octal
-        Regex::new(
-            r"(?x)
-            ^ \[ [a-zA-Z0-9\\]+ - [a-zA-Z0-9\\]+ \] $ |   # Range in square brackets
-            ^ \\ [0-7]{1,3} - \\ [0-7]{1,3} $ |           # Range \octal-\octal
-            ^ [a-zA-Z0-9] - [a-zA-Z0-9] $                 # Character-symbol range
-        ",
-        )
-        .unwrap()
-    });
-
-    regex.is_match(string1_or_string2)
 }
 
 /// Computes the complement of a string with respect to two sets of characters.
@@ -707,15 +716,15 @@ fn complement_chars(
     let mut depleted = Vec::<usize>::with_capacity(chars2.len());
 
     for op in chars2 {
-        if let Operand::Char(ch) = op {
-            if let CharRepetition::N(n) = ch.char_repetition {
-                depleted.push(n);
+        let us = match op {
+            Operand::Char(CharOperand {
+                char_repetition: CharRepetition::N(n),
+                ..
+            }) => *n,
+            _ => usize::MAX,
+        };
 
-                continue;
-            }
-        }
-
-        depleted.push(usize::MAX);
+        depleted.push(us);
     }
 
     let depleted_clone = depleted.clone();
@@ -743,8 +752,8 @@ fn complement_chars(
         let operand = chars2.get(chars2_index).ok_or("Indexing failed")?;
 
         match operand {
-            Operand::Char(char) => {
-                result.push(char.char);
+            Operand::Char(CharOperand { char, .. }) => {
+                result.push(*char);
 
                 let mut_ref = depleted.get_mut(chars2_index).ok_or("Indexing failed")?;
 
@@ -756,8 +765,8 @@ fn complement_chars(
                     continue;
                 }
             }
-            Operand::Equiv(equiv) => {
-                result.push(equiv.char);
+            Operand::Equiv(EquivOperand { char }) => {
+                result.push(*char);
             }
         }
 
@@ -816,17 +825,20 @@ fn check_repeatable(
 
 // TODO
 // This should be optimized
-fn generate_transformation_hash_map(
-    string1_operands: &[Operand],
-    string2_operands: &[Operand],
-) -> Result<HashMap<char, char>, Box<dyn Error>> {
+fn generate_for_translation(
+    string1_operands: Vec<Operand>,
+    string2_operands: Vec<Operand>,
+) -> Result<ForTranslation, Box<dyn Error>> {
     let mut char_repeating_total = 0_usize;
 
-    let mut string1_operands_flattened = Vec::<char>::new();
+    let mut string1_operands_flattened = Vec::<Operand>::new();
 
     for op in string1_operands {
         match op {
-            Operand::Char(ch) => match ch.char_repetition {
+            Operand::Char(CharOperand {
+                char_repetition,
+                char,
+            }) => match char_repetition {
                 CharRepetition::AsManyAsNeeded => {
                     return Err(Box::from(
                         "tr: the [c*] repeat construct may not appear in string1".to_owned(),
@@ -837,26 +849,38 @@ fn generate_transformation_hash_map(
                         .checked_add(n)
                         .ok_or("Arithmetic overflow")?;
 
+                    let new_char = Operand::Char(CharOperand {
+                        char,
+                        char_repetition: CharRepetition::N(1_usize),
+                    });
+
                     for _ in 0_usize..n {
-                        string1_operands_flattened.push(ch.char);
+                        string1_operands_flattened.push(new_char.clone());
                     }
                 }
             },
-            _ => {
-                return Err(Box::from("Expectation violated".to_owned()));
+            op @ Operand::Equiv(_) => {
+                // Take up one position?
+                string1_operands_flattened.push(op);
             }
         }
     }
 
+    // TODO
+    // Indexing is a workaround for the borrow checker
     let mut as_many_as_needed_index = Option::<usize>::None;
 
     let mut replacement_char_repeating_total = 0_usize;
 
     for (us, op) in string2_operands.iter().enumerate() {
         match op {
-            Operand::Char(ch) => match ch.char_repetition {
+            Operand::Char(CharOperand {
+                char_repetition, ..
+            }) => match char_repetition {
                 CharRepetition::AsManyAsNeeded => {
                     if as_many_as_needed_index.is_some() {
+                        // TODO
+                        // Do this validation earlier?
                         return Err(Box::from(
                             "tr: only one [c*] repeat construct may appear in string2".to_owned(),
                         ));
@@ -866,24 +890,28 @@ fn generate_transformation_hash_map(
                 }
                 CharRepetition::N(n) => {
                     replacement_char_repeating_total = replacement_char_repeating_total
-                        .checked_add(n)
+                        .checked_add(*n)
                         .ok_or("Arithmetic overflow")?;
                 }
             },
-            _ => {
-                return Err(Box::from("Expectation violated".to_owned()));
+            Operand::Equiv { .. } => {
+                // TODO
+                // Do this validation earlier?
+                return Err(Box::from(
+                    "tr: [=c=] expressions may not appear in string2 when translating".to_owned(),
+                ));
             }
         }
     }
-
-    let mut string2_operands_with_leftover: Vec<Operand>;
 
     let string2_operands_to_use = if replacement_char_repeating_total < char_repeating_total {
         let leftover = char_repeating_total
             .checked_sub(replacement_char_repeating_total)
             .ok_or("Arithmetic overflow")?;
 
-        string2_operands_with_leftover = string2_operands.to_vec();
+        // TODO
+        // to_vec
+        let mut string2_operands_with_leftover = string2_operands.to_vec();
 
         match as_many_as_needed_index {
             Some(us) => {
@@ -892,48 +920,42 @@ fn generate_transformation_hash_map(
                     .ok_or("Indexing failed")?;
 
                 match op {
-                    Operand::Char(ch) => {
-                        *op = Operand::Char(Char {
-                            char: ch.char,
-                            char_repetition: CharRepetition::N(leftover),
-                        });
+                    Operand::Char(CharOperand {
+                        ref mut char_repetition,
+                        ..
+                    }) => {
+                        *char_repetition = CharRepetition::N(leftover);
                     }
-                    _ => {
-                        return Err(Box::from("Expectation violated".to_owned()));
+                    Operand::Equiv(_) => {
+                        unreachable!();
                     }
                 }
             }
             None => {
-                let op = string2_operands_with_leftover
-                    .last_mut()
-                    .ok_or("Unexpected empty collection")?;
+                let mut n_updated = false;
 
-                match op {
-                    Operand::Char(ch) => {
-                        let current_n = match ch.char_repetition {
-                            CharRepetition::N(n) => n,
-                            _ => {
-                                return Err(Box::from("Expectation violated".to_owned()));
-                            }
-                        };
+                for op in string2_operands_with_leftover.iter_mut().rev() {
+                    if let Operand::Char(CharOperand {
+                        char_repetition: CharRepetition::N(ref mut n),
+                        ..
+                    }) = op
+                    {
+                        let n_plus_leftover =
+                            n.checked_add(leftover).ok_or("Arithmetic overflow")?;
 
-                        let current_n_plus_leftover = current_n
-                            .checked_add(leftover)
-                            .ok_or("Arithmetic overflow")?;
+                        *n = n_plus_leftover;
 
-                        *op = Operand::Char(Char {
-                            char: ch.char,
-                            char_repetition: CharRepetition::N(current_n_plus_leftover),
-                        });
-                    }
-                    _ => {
-                        return Err(Box::from("Expectation violated".to_owned()));
+                        n_updated = true;
+
+                        break;
                     }
                 }
+
+                assert!(n_updated);
             }
         }
 
-        &string2_operands_with_leftover
+        string2_operands_with_leftover
     } else {
         string2_operands
     };
@@ -944,33 +966,483 @@ fn generate_transformation_hash_map(
 
     for op in string2_operands_to_use {
         match op {
-            Operand::Char(ch) => match ch.char_repetition {
+            Operand::Char(CharOperand {
+                char_repetition,
+                char,
+            }) => match char_repetition {
                 CharRepetition::N(n) => {
                     for _ in 0_usize..n {
-                        string2_operands_to_use_flattened.push(ch.char);
+                        string2_operands_to_use_flattened.push(char);
                     }
                 }
                 CharRepetition::AsManyAsNeeded => {
                     // The "[c*]" construct was not needed, ignore it
                 }
             },
-            _ => {
-                return Err(Box::from("Expectation violated".to_owned()));
+            Operand::Equiv(_) => {
+                unreachable!();
             }
         }
     }
 
-    let mut translation_hash_map = HashMap::<char, char>::new();
+    // TODO
+    // Capacities
+    let mut equiv_translation_chars = Vec::<(char, char)>::new();
+    let mut multi_byte_translation_hash_map = HashMap::<char, char>::new();
+    let mut single_byte_translation_lookup_table = [Option::<char>::None; 128_usize];
 
-    for (us, ch) in string1_operands_flattened.into_iter().enumerate() {
-        let cha = string2_operands_to_use_flattened
+    let mut encoding_buffer = [0_u8; 4_usize];
+
+    let mut add_normal_char = |ch: char, replacement_char: char| {
+        let sl = ch.encode_utf8(&mut encoding_buffer);
+
+        match sl.as_bytes() {
+            &[ue] => {
+                single_byte_translation_lookup_table[usize::from(ue)] = Some(replacement_char);
+            }
+            _ => {
+                multi_byte_translation_hash_map.insert(ch, replacement_char);
+            }
+        }
+    };
+
+    for (us, op) in string1_operands_flattened.into_iter().enumerate() {
+        let replacement_char = string2_operands_to_use_flattened
             .get(us)
-            .ok_or("Indexing failed")?;
+            .ok_or("Indexing failed")?
+            .to_owned();
 
-        translation_hash_map.insert(ch, *cha);
+        match op {
+            Operand::Char(CharOperand {
+                char,
+                char_repetition,
+            }) => {
+                // TODO
+                // Enforce with types
+                assert!(matches!(char_repetition, CharRepetition::N(1_usize)));
+
+                add_normal_char(char, replacement_char);
+            }
+            Operand::Equiv(EquivOperand { char }) => {
+                equiv_translation_chars.push((char, replacement_char));
+
+                // TODO
+                // Fix for `tr_equivalence_class_low_priority`
+                add_normal_char(char, replacement_char);
+            }
+        }
     }
 
-    Ok(translation_hash_map)
+    let for_translate = ForTranslation {
+        equiv_translation_chars,
+        multi_byte_translation_hash_map,
+        single_byte_translation_lookup_table: Box::new(single_byte_translation_lookup_table),
+    };
+
+    Ok(for_translate)
+}
+
+fn generate_for_removal(string1_operands: Vec<Operand>) -> Result<ForRemoval, Box<dyn Error>> {
+    let mut equiv_removal_chars = Vec::<char>::new();
+    let mut multi_byte_removal_hash_set = HashSet::<char>::new();
+    let mut single_byte_removal_lookup_table = [false; 128_usize];
+
+    let mut encoding_buffer = [0_u8; 4_usize];
+
+    for op in string1_operands {
+        match op {
+            Operand::Char(CharOperand {
+                char_repetition,
+                char,
+            }) => match char_repetition {
+                CharRepetition::AsManyAsNeeded => {
+                    return Err(Box::from(
+                        "tr: the [c*] repeat construct may not appear in string1".to_owned(),
+                    ));
+                }
+                CharRepetition::N(_) => {
+                    let char_to_owned = char.to_owned();
+
+                    let sl = char_to_owned.encode_utf8(&mut encoding_buffer);
+
+                    match sl.as_bytes() {
+                        &[ue] => {
+                            single_byte_removal_lookup_table[usize::from(ue)] = true;
+                        }
+                        _ => {
+                            multi_byte_removal_hash_set.insert(char_to_owned);
+                        }
+                    }
+                }
+            },
+            Operand::Equiv(EquivOperand { char }) => {
+                equiv_removal_chars.push(char);
+            }
+        }
+    }
+
+    let delete_or_squeeze = ForRemoval {
+        multi_byte_removal_hash_set,
+        single_byte_removal_lookup_table: Box::new(single_byte_removal_lookup_table),
+        equiv_removal_chars,
+    };
+
+    Ok(delete_or_squeeze)
+}
+
+fn streaming_transform(transformation_type: TransformationType) -> Result<(), Box<dyn Error>> {
+    const SIZE: usize = 8_usize * 1_024;
+
+    // Buffers
+    let mut input = vec![0_u8; SIZE];
+    let mut output = Vec::<u8>::with_capacity(SIZE);
+    let mut temporary_leftover = Vec::<u8>::new();
+
+    // TODO
+    // Improve this
+    let mut leftover_bytes = 0_usize;
+
+    let mut stdin_lock = io::stdin().lock();
+    let mut stdout_lock = io::stdout().lock();
+
+    loop {
+        let buf = &mut input[leftover_bytes..];
+
+        match stdin_lock.read(buf) {
+            Ok(0_usize) => {
+                assert!(leftover_bytes == 0_usize);
+
+                assert!(!buf.is_empty());
+
+                break;
+            }
+            Ok(us) => {
+                let read_slice = &input[..(leftover_bytes + us)];
+
+                let for_transform = match std::str::from_utf8(read_slice) {
+                    Ok(st) => st,
+                    Err(ut) => {
+                        let (valid, remainder) = read_slice.split_at(ut.valid_up_to());
+
+                        temporary_leftover.extend_from_slice(remainder);
+
+                        // https://doc.rust-lang.org/std/str/struct.Utf8Error.html#examples
+                        unsafe { std::str::from_utf8_unchecked(valid) }
+                    }
+                };
+
+                transformation_type.transform(for_transform, &mut output);
+
+                // TODO
+                // Do this in a nicer way
+                for (us, ue) in temporary_leftover.iter().enumerate() {
+                    // TODO
+                    // Indexing
+                    input[us] = *ue;
+                }
+
+                leftover_bytes = temporary_leftover.len();
+
+                temporary_leftover.clear();
+
+                stdout_lock.write_all(&output)?;
+
+                output.clear();
+            }
+            Err(er) => {
+                if er.kind() == ErrorKind::Interrupted {
+                    continue;
+                }
+
+                return Err(Box::from(er));
+            }
+        }
+    }
+
+    Ok(())
+}
+
+struct ForRemoval {
+    equiv_removal_chars: Vec<char>,
+    multi_byte_removal_hash_set: HashSet<char>,
+    single_byte_removal_lookup_table: Box<[bool; 128_usize]>,
+}
+
+#[derive(Debug)]
+struct ForTranslation {
+    equiv_translation_chars: Vec<(char, char)>,
+    multi_byte_translation_hash_map: HashMap<char, char>,
+    single_byte_translation_lookup_table: Box<[Option<char>; 128_usize]>,
+}
+
+enum TransformationType {
+    Delete(ForRemoval),
+    Squeeze(ForRemoval),
+    SqueezeAndTranslate(ForTranslation),
+    Translate(ForTranslation),
+}
+
+impl TransformationType {
+    fn transform(&self, input: &str, output: &mut Vec<u8>) {
+        match self {
+            TransformationType::Delete(ForRemoval {
+                equiv_removal_chars,
+                multi_byte_removal_hash_set,
+                single_byte_removal_lookup_table,
+            }) => {
+                let mut encoding_buffer = [0_u8; 4_usize];
+
+                'process_next_char_label: for ch in input.chars() {
+                    let as_bytes = ch.encode_utf8(&mut encoding_buffer).as_bytes();
+
+                    let is_deleted_char = match as_bytes {
+                        &[ue] => single_byte_removal_lookup_table[usize::from(ue)],
+                        _ => multi_byte_removal_hash_set.contains(&ch),
+                    };
+
+                    if is_deleted_char {
+                        continue 'process_next_char_label;
+                    }
+
+                    for &cha in equiv_removal_chars {
+                        if compare_deunicoded_chars(ch, cha) {
+                            continue 'process_next_char_label;
+                        }
+                    }
+
+                    output.extend_from_slice(as_bytes);
+                }
+            }
+            TransformationType::Squeeze(ForRemoval {
+                equiv_removal_chars,
+                multi_byte_removal_hash_set,
+                single_byte_removal_lookup_table,
+            }) => {
+                let is_squeezed = |ch: char, char_slice: &[u8]| {
+                    let first_check = match char_slice {
+                        &[ue] => single_byte_removal_lookup_table[usize::from(ue)],
+                        _ => multi_byte_removal_hash_set.contains(&ch),
+                    };
+
+                    if first_check {
+                        true
+                    } else {
+                        let mut bo = false;
+
+                        for &cha in equiv_removal_chars {
+                            if compare_deunicoded_chars(ch, cha) {
+                                bo = true;
+
+                                break;
+                            }
+                        }
+
+                        bo
+                    }
+                };
+
+                let mut chars = input.chars();
+
+                let Some(first_char_encountered) = chars.next() else {
+                    return;
+                };
+
+                let mut encoding_buffer = [0_u8; 4_usize];
+
+                // Add the first char
+                let (first_char_is_squeezed, first_char_slice) = {
+                    let char_slice = first_char_encountered
+                        .encode_utf8(&mut encoding_buffer)
+                        .as_bytes();
+
+                    output.extend_from_slice(char_slice);
+
+                    let char_is_squeezed = is_squeezed(first_char_encountered, char_slice);
+
+                    (char_is_squeezed, char_slice)
+                };
+
+                let mut last_char_encountered = first_char_encountered;
+                let mut last_char_is_squeezed = first_char_is_squeezed;
+                let mut last_char_slice = first_char_slice;
+
+                for ch in chars {
+                    if last_char_encountered == ch {
+                        if !last_char_is_squeezed {
+                            output.extend_from_slice(last_char_slice);
+                        }
+
+                        continue;
+                    }
+
+                    let char_slice = ch.encode_utf8(&mut encoding_buffer).as_bytes();
+
+                    output.extend_from_slice(char_slice);
+
+                    last_char_encountered = ch;
+                    last_char_is_squeezed = is_squeezed(ch, char_slice);
+                    last_char_slice = char_slice;
+                }
+            }
+            TransformationType::SqueezeAndTranslate(ForTranslation {
+                equiv_translation_chars,
+                multi_byte_translation_hash_map,
+                single_byte_translation_lookup_table,
+            }) => {
+                let has_squeezed_translation = |ch: char, char_slice: &[u8]| {
+                    let first_check = match char_slice {
+                        &[ue] => single_byte_translation_lookup_table[usize::from(ue)],
+                        _ => multi_byte_translation_hash_map.get(&ch).copied(),
+                    };
+
+                    match first_check {
+                        op @ Some(_) => op,
+                        None => {
+                            let mut op = Option::<char>::None;
+
+                            for (cha, char) in equiv_translation_chars {
+                                if compare_deunicoded_chars(ch, *cha) {
+                                    op = Some(*char);
+
+                                    break;
+                                }
+                            }
+
+                            op
+                        }
+                    }
+                };
+
+                let mut chars = input.chars();
+
+                let Some(first_char_encountered) = chars.next() else {
+                    return;
+                };
+
+                let mut encoding_buffer = [0_u8; 4_usize];
+
+                // Add the first char
+                let (first_char_has_squeezed_translation, first_char_slice) = {
+                    let char_slice = first_char_encountered
+                        .encode_utf8(&mut encoding_buffer)
+                        .as_bytes();
+
+                    let char_has_squeezed_translation =
+                        has_squeezed_translation(first_char_encountered, char_slice);
+
+                    let char_slice_to_use = match char_has_squeezed_translation {
+                        Some(replacement_char) => {
+                            let replacement_char_str =
+                                replacement_char.encode_utf8(&mut encoding_buffer);
+
+                            replacement_char_str.as_bytes()
+                        }
+                        None => char_slice,
+                    };
+
+                    output.extend_from_slice(char_slice_to_use);
+
+                    (char_has_squeezed_translation, char_slice_to_use)
+                };
+
+                let mut last_char_encountered = first_char_encountered;
+                let mut last_char_has_squeezed_translation = first_char_has_squeezed_translation;
+                let mut last_char_slice = first_char_slice;
+
+                for ch in chars {
+                    if last_char_encountered == ch {
+                        if last_char_has_squeezed_translation.is_none() {
+                            output.extend_from_slice(last_char_slice);
+                        }
+
+                        continue;
+                    }
+
+                    let char_slice = ch.encode_utf8(&mut encoding_buffer).as_bytes();
+
+                    let char_has_squeezed_translation = has_squeezed_translation(ch, char_slice);
+
+                    match (
+                        char_has_squeezed_translation,
+                        last_char_has_squeezed_translation,
+                    ) {
+                        (Some(ch), Some(cha)) if ch == cha => {
+                            last_char_slice = char_slice;
+
+                            continue;
+                        }
+                        _ => {}
+                    }
+
+                    let char_slice_to_use = match char_has_squeezed_translation {
+                        Some(replacement_char) => {
+                            let replacement_char_str =
+                                replacement_char.encode_utf8(&mut encoding_buffer);
+
+                            replacement_char_str.as_bytes()
+                        }
+                        None => char_slice,
+                    };
+
+                    output.extend_from_slice(char_slice_to_use);
+
+                    last_char_encountered = ch;
+                    last_char_has_squeezed_translation = char_has_squeezed_translation;
+                    last_char_slice = char_slice_to_use;
+                }
+            }
+            TransformationType::Translate(ForTranslation {
+                equiv_translation_chars,
+                multi_byte_translation_hash_map,
+                single_byte_translation_lookup_table,
+            }) => {
+                let mut encoding_buffer = [0_u8; 4_usize];
+
+                for ch in input.chars() {
+                    let as_bytes = ch.encode_utf8(&mut encoding_buffer).as_bytes();
+
+                    let replacement_char_option = match as_bytes {
+                        &[ue] => single_byte_translation_lookup_table[usize::from(ue)],
+                        _ => multi_byte_translation_hash_map.get(&ch).copied(),
+                    };
+
+                    // TODO
+                    // What is the precedence of equivalence classes?
+                    // GNU Core Utilities de-prioritizes them
+
+                    // Only use equivalence classes if normal translation failed
+                    let replacement_char_option_to_use = match replacement_char_option {
+                        Some(cha) => Some(cha),
+                        None => {
+                            let mut op = Option::<char>::None;
+
+                            for (equiv_char, equiv_char_replacement) in equiv_translation_chars {
+                                if compare_deunicoded_chars(ch, *equiv_char) {
+                                    op = Some(*equiv_char_replacement);
+
+                                    break;
+                                }
+                            }
+
+                            op
+                        }
+                    };
+
+                    let for_output = match replacement_char_option_to_use {
+                        Some(replacement_char) => {
+                            let replacement_char_str =
+                                replacement_char.encode_utf8(&mut encoding_buffer);
+
+                            replacement_char_str.as_bytes()
+                        }
+                        None => as_bytes,
+                    };
+
+                    output.extend_from_slice(for_output);
+                }
+            }
+        }
+    }
 }
 
 /// Translates or deletes characters from standard input, according to specified arguments.
@@ -989,14 +1461,6 @@ fn generate_transformation_hash_map(
 ///   if there is an error reading from standard input or processing the input string.
 ///
 fn tr(args: &Args) -> Result<(), Box<dyn std::error::Error>> {
-    let mut input = String::new();
-
-    // TODO
-    // tr should be streaming
-    io::stdin()
-        .read_to_string(&mut input)
-        .expect("Failed to read input");
-
     let string1_operands = parse_string1_or_string2(&args.string1)?;
 
     let string2_operands_option = match &args.string2 {
@@ -1004,9 +1468,76 @@ fn tr(args: &Args) -> Result<(), Box<dyn std::error::Error>> {
         None => None,
     };
 
-    let mut stdout_lock = io::stdout().lock();
+    if !args.complement_char && !args.complement_val {
+        // Fast path for "tr", "tr -d", and "tr -s" (without any other options)
+        match (args.delete, args.squeeze_repeats) {
+            (false, false) => {
+                // "tr"
+                let string2_operands = match string2_operands_option {
+                    Some(op) => op,
+                    None => {
+                        return Err(Box::from("tr: missing operand".to_owned()));
+                    }
+                };
 
-    if args.delete {
+                if string2_operands.is_empty() {
+                    return Err(Box::from(
+                        "tr: when not truncating set1, string2 must be non-empty".to_owned(),
+                    ));
+                }
+
+                let for_translation = generate_for_translation(string1_operands, string2_operands)?;
+
+                let transformation_type = TransformationType::Translate(for_translation);
+
+                return streaming_transform(transformation_type);
+            }
+            (true, false) => {
+                // "tr -d"
+                let delete_or_squeeze = generate_for_removal(string1_operands)?;
+
+                let transformation_type = TransformationType::Delete(delete_or_squeeze);
+
+                return streaming_transform(transformation_type);
+            }
+            (false, true) => {
+                // "tr -s"
+                let transformation_type = match string2_operands_option {
+                    Some(string2_operands) => {
+                        if string2_operands.is_empty() {
+                            return Err(Box::from(
+                                "tr: when not truncating set1, string2 must be non-empty"
+                                    .to_owned(),
+                            ));
+                        }
+
+                        let for_translation =
+                            generate_for_translation(string1_operands, string2_operands)?;
+
+                        TransformationType::SqueezeAndTranslate(for_translation)
+                    }
+                    None => {
+                        let delete_or_squeeze = generate_for_removal(string1_operands)?;
+
+                        TransformationType::Squeeze(delete_or_squeeze)
+                    }
+                };
+
+                return streaming_transform(transformation_type);
+            }
+            _ => {}
+        };
+    }
+
+    // TODO
+    // These paths are not streaming yet
+    let mut input = String::new();
+
+    io::stdin()
+        .read_to_string(&mut input)
+        .expect("Failed to read input");
+
+    let string_to_write = if args.delete {
         let filtered_string = if args.complement_char || args.complement_val {
             input
                 .chars()
@@ -1044,9 +1575,7 @@ fn tr(args: &Args) -> Result<(), Box<dyn std::error::Error>> {
             filtered_string
         };
 
-        stdout_lock.write_all(filtered_string_to_use.as_bytes())?;
-
-        Ok(())
+        filtered_string_to_use
     } else if args.squeeze_repeats && string2_operands_option.is_none() {
         let mut char_counts = HashMap::<char, i32>::new();
 
@@ -1073,11 +1602,11 @@ fn tr(args: &Args) -> Result<(), Box<dyn std::error::Error>> {
             })
             .collect::<String>();
 
-        stdout_lock.write_all(filtered_string.as_bytes())?;
-
-        return Ok(());
+        filtered_string
     } else {
-        let result_string = if args.complement_char || args.complement_val {
+        let result_string = {
+            assert!(args.complement_char || args.complement_val);
+
             if args.complement_char {
                 complement_chars(
                     &input,
@@ -1087,46 +1616,10 @@ fn tr(args: &Args) -> Result<(), Box<dyn std::error::Error>> {
             } else {
                 let mut set2 = string2_operands_option.as_deref().unwrap().to_vec();
 
-                set2.sort_by(|a, b| match (a, b) {
-                    (Operand::Char(char1), Operand::Char(char2)) => char1.char.cmp(&char2.char),
-                    (Operand::Equiv(equiv1), Operand::Equiv(equiv2)) => {
-                        equiv1.char.cmp(&equiv2.char)
-                    }
-                    (Operand::Char(char1), Operand::Equiv(equiv2)) => char1.char.cmp(&equiv2.char),
-                    (Operand::Equiv(equiv1), Operand::Char(char2)) => equiv1.char.cmp(&char2.char),
-                });
+                set2.sort_by(|op, ope| op.char().cmp(ope.char()));
 
                 complement_chars(&input, &string1_operands, &set2)?
             }
-        } else {
-            let string2_operands = match string2_operands_option.as_deref() {
-                Some(op) => op,
-                None => {
-                    return Err(Box::from("tr: missing operand".to_owned()));
-                }
-            };
-
-            if string2_operands.is_empty() {
-                return Err(Box::from(
-                    "tr: when not truncating set1, string2 must be non-empty".to_owned(),
-                ));
-            }
-
-            let transformation_map =
-                generate_transformation_hash_map(&string1_operands, string2_operands)?;
-
-            let mut result = String::with_capacity(input.len());
-
-            for ch in input.chars() {
-                let char_to_use = match transformation_map.get(&ch) {
-                    Some(cha) => *cha,
-                    None => ch,
-                };
-
-                result.push(char_to_use);
-            }
-
-            result
         };
 
         let result_string_to_use = if args.squeeze_repeats {
@@ -1154,10 +1647,12 @@ fn tr(args: &Args) -> Result<(), Box<dyn std::error::Error>> {
             result_string
         };
 
-        stdout_lock.write_all(result_string_to_use.as_bytes())?;
+        result_string_to_use
+    };
 
-        return Ok(());
-    }
+    io::stdout().write_all(string_to_write.as_bytes())?;
+
+    Ok(())
 }
 
 fn main() -> Result<(), Box<dyn Error>> {
@@ -1167,12 +1662,16 @@ fn main() -> Result<(), Box<dyn Error>> {
 
     let args = Args::parse();
 
-    args.validate_args()?;
+    if let Err(st) = args.validate_args() {
+        eprintln!("{st}");
+
+        process::exit(1_i32);
+    }
 
     if let Err(err) = tr(&args) {
-        eprintln!("{}", err);
+        eprintln!("{err}");
 
-        process::exit(1);
+        process::exit(1_i32);
     }
 
     Ok(())

--- a/text/tr.rs
+++ b/text/tr.rs
@@ -1,14 +1,19 @@
 use clap::Parser;
 use deunicode::deunicode_char;
 use gettextrs::{bind_textdomain_codeset, setlocale, textdomain, LocaleCategory};
+use parsing::parse_string1_or_string2;
 use plib::PROJECT_NAME;
-use std::collections::{HashMap, HashSet};
+use setup::{generate_for_removal, generate_for_translation};
 use std::error::Error;
-use std::io::{self, ErrorKind, Read, Write};
-use std::iter::{self, Peekable};
 use std::process;
-use std::slice::Iter;
-use std::str::Chars;
+use transformation::delete::{DeleteState, DeleteTransformation};
+use transformation::delete_and_squeeze::{DeleteAndSqueezeState, DeleteAndSqueezeTransformation};
+use transformation::squeeze::{SqueezeState, SqueezeTransformation};
+use transformation::squeeze_and_translate::{
+    SqueezeAndTranslateState, SqueezeAndTranslateTransformation,
+};
+use transformation::translate::TranslateTransformation;
+use transformation::Transformation;
 
 /// tr - translate or delete characters
 #[derive(Parser)]
@@ -63,1388 +68,6 @@ impl Args {
     }
 }
 
-#[derive(Clone)]
-enum CharRepetition {
-    AsManyAsNeeded,
-    N(usize),
-}
-
-#[derive(Clone)]
-struct CharOperand {
-    // The character
-    char: char,
-    // The number of times the character is repeated
-    char_repetition: CharRepetition,
-}
-
-#[derive(Clone)]
-struct EquivOperand {
-    // The character equivalent
-    char: char,
-}
-
-#[derive(Clone)]
-enum Operand {
-    Char(CharOperand),
-    Equiv(EquivOperand),
-}
-
-impl Operand {
-    fn char(&self) -> &char {
-        match self {
-            Operand::Char(CharOperand { char, .. }) => char,
-            Operand::Equiv(EquivOperand { char }) => char,
-        }
-    }
-}
-
-impl Operand {
-    /// Checks if a target character exists in a vector of `Operand` elements.
-    ///
-    /// # Arguments
-    ///
-    /// * `operands` - A reference to a vector of `Operand` elements.
-    /// * `target` - A reference to the target character to search for.
-    ///
-    /// # Returns
-    ///
-    /// `true` if the target character is found, `false` otherwise.
-    fn contains(operands: &[Operand], target: &char) -> bool {
-        for operand in operands {
-            match operand {
-                Operand::Equiv(EquivOperand { char }) => {
-                    if compare_deunicoded_chars(*char, *target) {
-                        return true;
-                    }
-                }
-                Operand::Char(CharOperand { char, .. }) => {
-                    if char == target {
-                        return true;
-                    }
-                }
-            }
-        }
-
-        false
-    }
-}
-
-/// Parses a sequence in the format `[=equiv=]` from the given character iterator.
-///
-/// The function expects the iterator to be positioned just before the first `=`
-/// character. It reads the equivalent characters between the `=` symbols and
-/// creates a list of `Operand::Equiv` entries, one for each character.
-///
-/// # Arguments
-///
-/// * `chars` - A mutable reference to a peekable character iterator.
-///
-/// # Returns
-///
-/// A `Result` containing a vector of `Operand::Equiv` entries if successful, or a
-/// `String` describing the error if parsing fails.
-///
-/// # Errors
-///
-/// This function will return an error if:
-/// - The sequence does not contain a closing `=` before `]`.
-/// - The sequence does not contain a closing `]`.
-/// - The sequence contains no characters between the `=` symbols.
-///
-fn parse_equiv(square_bracket_constructs_buffer: &[char]) -> Result<Operand, String> {
-    let mut iter = square_bracket_constructs_buffer.iter();
-
-    // Skip '[='
-    assert!(iter.next() == Some(&'['));
-    assert!(iter.next() == Some(&'='));
-
-    let mut between_equals_signs = Vec::<char>::with_capacity(1_usize);
-
-    between_equals_signs.extend(iter.take_while(|&&ch| ch != '='));
-
-    let char_between_equals_signs = match between_equals_signs.as_slice() {
-        &[ch] => ch,
-        &[] => {
-            unreachable!();
-        }
-        sl => {
-            const ERROR_MESSAGE_PREFIX: &str = "tr: ";
-            const ERROR_MESSAGE_SUFFIX: &str =
-                ": equivalence class operand must be a single character";
-
-            const ERROR_MESSAGE_PREFIX_AND_SUFFIX_LENGTH: usize =
-                ERROR_MESSAGE_PREFIX.len() + ERROR_MESSAGE_SUFFIX.len();
-
-            let mut error_message =
-                String::with_capacity(ERROR_MESSAGE_PREFIX_AND_SUFFIX_LENGTH + sl.len());
-
-            error_message.push_str(ERROR_MESSAGE_PREFIX);
-
-            for &ch in sl {
-                error_message.push(ch);
-            }
-
-            error_message.push_str(ERROR_MESSAGE_SUFFIX);
-
-            return Err(error_message);
-        }
-    };
-
-    let operand = Operand::Equiv(EquivOperand {
-        char: char_between_equals_signs,
-    });
-
-    Ok(operand)
-}
-
-fn parse_repeated_char(square_bracket_constructs_buffer: &[char]) -> Result<Operand, String> {
-    // TODO
-    // Clean this up
-    fn fill_repeat_str(iter: &mut Iter<char>, repeat_string: &mut String) {
-        while let Some(&ch) = iter.next() {
-            if ch == ']' {
-                assert!(iter.next().is_none());
-
-                return;
-            }
-
-            repeat_string.push(ch);
-        }
-
-        unreachable!();
-    }
-
-    let mut iter = square_bracket_constructs_buffer.iter();
-
-    // Skip '['
-    assert!(iter.next() == Some(&'['));
-
-    // Get character before '*'
-    let char = iter.next().unwrap().to_owned();
-
-    // Skip '*'
-    assert!(iter.next() == Some(&'*'));
-
-    let mut repeat_string = String::with_capacity(square_bracket_constructs_buffer.len());
-
-    fill_repeat_str(&mut iter, &mut repeat_string);
-
-    // "If n is omitted or is zero, it shall be interpreted as large enough to extend the string2-based sequence to the length of the string1-based sequence. If n has a leading zero, it shall be interpreted as an octal value. Otherwise, it shall be interpreted as a decimal value."
-    // https://pubs.opengroup.org/onlinepubs/9799919799/utilities/tr.html
-    let char_repetition = match repeat_string.as_str() {
-        "" => CharRepetition::AsManyAsNeeded,
-        st => {
-            let radix = if st.starts_with('0') {
-                // Octal
-                8_u32
-            } else {
-                10_u32
-            };
-
-            match usize::from_str_radix(st, radix) {
-                Ok(0_usize) => CharRepetition::AsManyAsNeeded,
-                Ok(n) => CharRepetition::N(n),
-                Err(_pa) => {
-                    return Err(format!(
-                        "tr: invalid repeat count ‘{st}’ in [c*n] construct",
-                    ));
-                }
-            }
-        }
-    };
-
-    let operand = Operand::Char(CharOperand {
-        char,
-        char_repetition,
-    });
-
-    Ok(operand)
-}
-
-fn parse_octal_sequence(
-    first_octal_digit: char,
-    peekable: &mut Peekable<Chars>,
-) -> Result<char, String> {
-    let mut st = String::with_capacity(3_usize);
-
-    st.push(first_octal_digit);
-
-    let mut added_octal_digit_to_buffer = |pe: &mut Peekable<Chars>| {
-        if let Some(&second_octal_digit @ '0'..='7') = pe.peek() {
-            st.push(second_octal_digit);
-
-            true
-        } else {
-            false
-        }
-    };
-
-    let advance_peekable_if_parsing_succeed = if added_octal_digit_to_buffer(peekable) {
-        peekable.next();
-
-        added_octal_digit_to_buffer(peekable)
-    } else {
-        false
-    };
-
-    let from_str_radix_result = u16::from_str_radix(&st, 8_u32);
-
-    let octal_digits_parsed = match from_str_radix_result {
-        Ok(uo) => uo,
-        Err(pa) => {
-            return Err(format!("tr: failed to parse octal sequence '{st}' ({pa})"));
-        }
-    };
-
-    // There is no consensus on how to handle this:
-    //
-    // BusyBox and GNU Core Utilities:
-    //     parse "\501" as \050 (which is '(') and '1'
-    //         GNU Core Utilities prints a warning, BusyBox does not
-    // uutils' coreutils:
-    //     parses "\501" as '1'
-    // bsdutils:
-    //     parses "\501" as 'Ł' (U+0141)
-    //
-    // None of these implementations treat this as a fatal error
-    // POSIX says: "Multi-byte characters require multiple, concatenated escape sequences of this type, including the leading <backslash> for each byte."
-    //
-    // Following BusyBox and GNU Core Utilities, because their handling seems to be most in keeping with the POSIX
-    // specification
-    let byte = match u8::try_from(octal_digits_parsed) {
-        Ok(ue) => {
-            if advance_peekable_if_parsing_succeed {
-                peekable.next();
-            }
-
-            ue
-        }
-        Err(_tr) => {
-            // This should only happen when the sequence is \400 and above
-            // Cannot happen with a two character sequence like \77, because 8^2 is 64 (within u8 bounds)
-            assert!(st.len() == 3_usize);
-
-            let mut chars = st.chars();
-
-            let third_octal_digit = chars.next_back().unwrap();
-
-            // `chars_str` is a view of the first two octal digits
-            let chars_str = chars.as_str();
-
-            assert!(chars_str.len() == 2_usize);
-
-            // Treat the sequence \abc (where a, b, and c are octal digits) as \0abc
-            // The byte represented by \0ab is what will be returned from this function
-            // Parsing of c is handled outside this function
-            match u8::from_str_radix(chars_str, 8_u32) {
-                Ok(ue) => {
-                    eprintln!(
-                        "tr: warning: the ambiguous octal escape \\{st} is being interpreted as the 2-byte sequence \\0{chars_str}, {third_octal_digit}"
-                    );
-
-                    ue
-                }
-                Err(pa) => {
-                    return Err(format!("tr: invalid octal sequence '{chars_str}' ({pa})"));
-                }
-            }
-        }
-    };
-
-    let char = char::from(byte);
-
-    Ok(char)
-}
-
-fn parse_single_char(peekable: &mut Peekable<Chars>) -> Result<Option<char>, String> {
-    let option = match peekable.next() {
-        Some('\\') => {
-            let char = match peekable.next() {
-                /* #region \octal */
-                Some(first_octal_digit @ '0'..='7') => {
-                    parse_octal_sequence(first_octal_digit, peekable)?
-                }
-                /* #endregion */
-                //
-                /* #region \character */
-                // <alert>
-                // Code point 0007
-                Some('a') => '\u{0007}',
-                // <backspace>
-                // Code point 0008
-                Some('b') => '\u{0008}',
-                // <tab>
-                // Code point 0009
-                Some('t') => '\u{0009}',
-                // <newline>
-                // Code point 000A
-                Some('n') => '\u{000A}',
-                // <vertical-tab>
-                // Code point 000B
-                Some('v') => '\u{000B}',
-                // <form-feed>
-                // Code point 000C
-                Some('f') => '\u{000C}',
-                // <carriage-return>
-                // Code point 000D
-                Some('r') => '\u{000D}',
-                // <backslash>
-                // Code point 005C
-                Some('\\') => {
-                    // An escaped backslash
-                    '\u{005C}'
-                }
-                /* #endregion */
-                //
-                Some(cha) => {
-                    // If a backslash is not at the end of the string, and is not followed by one of the valid
-                    // escape characters (including another backslash), the backslash is basically just ignored:
-                    // the following character is the character added to the set.
-                    cha
-                }
-                None => {
-                    eprintln!(
-                        "tr: warning: an unescaped backslash at end of string is not portable"
-                    );
-
-                    // If an unescaped backslash is the last character of the string, treat it as though it were
-                    // escaped (backslash is added to the set)
-                    '\u{005C}'
-                }
-            };
-
-            Some(char)
-        }
-        op => op,
-    };
-
-    Ok(option)
-}
-
-fn parse_range_or_single_char(
-    starting_char: char,
-    peekable: &mut Peekable<Chars>,
-    operand_vec: &mut Vec<Operand>,
-) -> Result<(), String> {
-    match peekable.peek() {
-        Some(&hyphen @ '-') => {
-            // Possible "c-c" construct
-            // Move past `hyphen`
-            peekable.next();
-
-            // The parsed character after the hyphen
-            // e.g. "tr 'A-Z' '\044-1'"
-            match parse_single_char(peekable)? {
-                Some(after_hyphen) => {
-                    // Ranges are inclusive
-                    let range_inclusive = starting_char..=after_hyphen;
-
-                    if range_inclusive.is_empty() {
-                        let message =
-                            format!(
-                                "tr: range-endpoints of '{}-{}' are in reverse collating sequence order",
-                                starting_char.escape_default(),
-                                after_hyphen.escape_default()
-                            );
-
-                        return Err(message);
-                    }
-
-                    let range_inclusive_to_operand_iterator = range_inclusive.map(|ch| {
-                        Operand::Char(CharOperand {
-                            char: ch,
-                            char_repetition: CharRepetition::N(1_usize),
-                        })
-                    });
-
-                    // TODO
-                    // Does this reserve the right capacity?
-                    operand_vec.extend(range_inclusive_to_operand_iterator);
-                }
-                None => {
-                    // End of input, do not handle as a range
-                    // e.g. "tr 'ab' 'c-'"
-                    operand_vec.extend_from_slice(&[
-                        Operand::Char(CharOperand {
-                            char: starting_char,
-                            char_repetition: CharRepetition::N(1_usize),
-                        }),
-                        Operand::Char(CharOperand {
-                            char: hyphen,
-                            char_repetition: CharRepetition::N(1_usize),
-                        }),
-                    ]);
-                }
-            }
-        }
-        _ => {
-            // Not a "c-c" construct
-            operand_vec.push(Operand::Char(CharOperand {
-                char: starting_char,
-                char_repetition: CharRepetition::N(1_usize),
-            }))
-        }
-    }
-
-    Ok(())
-}
-
-fn parse_string1_or_string2(string1_or_string2: &str) -> Result<Vec<Operand>, String> {
-    // The longest valid "[:class:]", "[=equiv=]", or "[x*n]" construct is a "[x*n]" construct
-    // These are (seemingly) the shortest invalid "[x*n]" constructs (octal and decimal):
-    // [a*010000000000000000000000]
-    // [a*100000000000000000000]
-    // Therefore, the longest valid one should be:
-    // [a*01000000000000000000000]
-    // Rounding up to 32
-    const SQUARE_BRACKET_CONSTRUCTS_BUFFER_CAPACITY: usize = 32_usize;
-
-    // This capacity will be sufficient at least some of the time
-    let mut operand_vec = Vec::<Operand>::with_capacity(string1_or_string2.len());
-
-    let mut peekable = string1_or_string2.chars().peekable();
-
-    let mut parse_left_square_bracket_normally = false;
-
-    while let Some(&ch) = peekable.peek() {
-        match (ch, parse_left_square_bracket_normally) {
-            ('[', false) => {
-                // Save the state of `peekable` before advancing it, see note below
-                let peekable_saved = peekable.clone();
-
-                // TODO
-                // Avoid repeated allocation
-                let mut square_bracket_constructs_buffer =
-                    Vec::<char>::with_capacity(SQUARE_BRACKET_CONSTRUCTS_BUFFER_CAPACITY);
-
-                let mut found_closing_square_bracket = false;
-
-                for ch in peekable.by_ref() {
-                    square_bracket_constructs_buffer.push(ch);
-
-                    let vec_len = square_bracket_constructs_buffer.len();
-
-                    // Length check is a hacky fix for "[:]", "[=]", "[]*]", etc.
-                    if ch == ']' && vec_len > 3_usize {
-                        found_closing_square_bracket = true;
-
-                        break;
-                    }
-                }
-
-                if found_closing_square_bracket {
-                    let after_opening_square_bracket =
-                        square_bracket_constructs_buffer.get(1_usize);
-
-                    let before_closing_square_bracket =
-                        square_bracket_constructs_buffer.iter().rev().nth(1_usize);
-
-                    if after_opening_square_bracket == Some(&':')
-                        && before_closing_square_bracket == Some(&':')
-                    {
-                        expand_character_class(
-                            &square_bracket_constructs_buffer,
-                            &mut operand_vec,
-                        )?;
-
-                        continue;
-                    }
-
-                    if after_opening_square_bracket == Some(&'=')
-                        && before_closing_square_bracket == Some(&'=')
-                    {
-                        // "[=equiv=]" construct
-                        let operand = parse_equiv(&square_bracket_constructs_buffer)?;
-
-                        operand_vec.push(operand);
-
-                        continue;
-                    }
-
-                    if square_bracket_constructs_buffer.get(2_usize) == Some(&'*') {
-                        // "[x*n]" construct
-                        operand_vec.push(parse_repeated_char(&square_bracket_constructs_buffer)?);
-
-                        continue;
-                    }
-                }
-
-                // Not a "[:class:]", "[=equiv=]", or "[x*n]" construct
-                // The hacky way to continue is to reset `peekable` (to `peekable_saved`)
-                // This moves the Peekable back to the point it was at before attempting to parse square bracket
-                // constructs
-                parse_left_square_bracket_normally = true;
-                peekable = peekable_saved;
-            }
-            (cha, bo) => {
-                // '[' is not the start of a square bracket construct, so handle it normally
-                if bo {
-                    assert!(cha == '[');
-
-                    // When encountering '[' in the future, try to parse square bracket constructs first
-                    parse_left_square_bracket_normally = false;
-                }
-
-                if let Some(char) = parse_single_char(&mut peekable)? {
-                    parse_range_or_single_char(char, &mut peekable, &mut operand_vec)?;
-                }
-            }
-        }
-    }
-
-    Ok(operand_vec)
-}
-
-// TODO
-// No other implementations actually seem to do anything with equivalence classes:
-// they seem to just treat them as the parsed character (e.g. "[=a=]" is treated as "a").
-// Should this implementation continue to try to actually handle them?
-
-/// Compares two characters after normalizing them.
-/// This function uses the hypothetical `deunicode_char` function to normalize
-/// the input characters and then compares them for equality.
-/// # Arguments
-///
-/// * `char1` - The first character to compare.
-/// * `char2` - The second character to compare.
-///
-/// # Returns
-///
-/// * `true` if the normalized characters are equal.
-/// * `false` otherwise.
-fn compare_deunicoded_chars(char1: char, char2: char) -> bool {
-    let normalized_char1 = deunicode_char(char1);
-    let normalized_char2 = deunicode_char(char2);
-
-    match (normalized_char1, normalized_char2) {
-        (Some(st), Some(str)) => st == str,
-        (None, None) => {
-            // Purpose of match: prevent this from being considered equal
-            false
-        }
-        _ => false,
-    }
-}
-
-fn expand_character_class(
-    square_bracket_constructs_buffer: &[char],
-    operand_vec: &mut Vec<Operand>,
-) -> Result<(), String> {
-    // "[:class:]" construct
-    let mut into_iter = square_bracket_constructs_buffer.iter();
-
-    assert!(into_iter.next() == Some(&'['));
-    assert!(into_iter.next() == Some(&':'));
-
-    assert!(into_iter.next_back() == Some(&']'));
-    assert!(into_iter.next_back() == Some(&':'));
-
-    // TODO
-    // Performance
-    let class = into_iter.collect::<String>();
-
-    let char_vec = match class.as_str() {
-        "alnum" => ('0'..='9')
-            .chain('A'..='Z')
-            .chain('a'..='z')
-            .collect::<Vec<_>>(),
-        "alpha" => ('A'..='Z').chain('a'..='z').collect::<Vec<_>>(),
-        "digit" => ('0'..='9').collect::<Vec<_>>(),
-        "lower" => ('a'..='z').collect::<Vec<_>>(),
-        "upper" => ('A'..='Z').collect::<Vec<_>>(),
-        "space" => vec![' ', '\t', '\n', '\r', '\x0b', '\x0c'],
-        "blank" => vec![' ', '\t'],
-        "cntrl" => (0..=31)
-            .chain(iter::once(127))
-            .map(|it| char::from(it as u8))
-            .collect::<Vec<_>>(),
-        "graph" => (33..=126)
-            .map(|it| char::from(it as u8))
-            .collect::<Vec<_>>(),
-        "print" => (32..=126)
-            .map(|it| char::from(it as u8))
-            .collect::<Vec<_>>(),
-        "punct" => (33..=47)
-            .chain(58..=64)
-            .chain(91..=96)
-            .chain(123..=126)
-            .map(|it| char::from(it as u8))
-            .collect::<Vec<_>>(),
-        "xdigit" => ('0'..='9')
-            .chain('A'..='F')
-            .chain('a'..='f')
-            .collect::<Vec<_>>(),
-        st => return Err(format!("tr: invalid character class ‘{st}’")),
-    };
-
-    operand_vec.reserve(char_vec.len());
-
-    for ch in char_vec {
-        operand_vec.push(Operand::Char(CharOperand {
-            char: ch,
-            char_repetition: CharRepetition::N(1_usize),
-        }));
-    }
-
-    Ok(())
-}
-
-/// Computes the complement of a string with respect to two sets of characters.
-///
-/// This function takes an input string and two sets of characters (`chars1` and `chars2`)
-/// and computes the complement of the input string with respect to the characters in `chars1`.
-/// For each character in the input string:
-/// - If the character is present in `chars1`, it remains unchanged in the result.
-/// - If the character is not present in `chars1`, it is replaced with characters from `chars2`
-///   sequentially until all characters in `chars2` are exhausted, and then the process repeats.
-///
-/// # Arguments
-///
-/// * `input` - A string slice representing the input string.
-/// * `chars1` - A vector of `Operand` representing the first set of characters.
-/// * `chars2` - A vector of `Operand` representing the second set of characters.
-///
-/// # Returns
-///
-/// * `String` - Returns a string representing the complement of the input string.
-///
-fn complement_chars(
-    input: &str,
-    chars1: &[Operand],
-    chars2: &[Operand],
-) -> Result<String, Box<dyn Error>> {
-    let mut depleted = Vec::<usize>::with_capacity(chars2.len());
-
-    for op in chars2 {
-        let us = match op {
-            Operand::Char(CharOperand {
-                char_repetition: CharRepetition::N(n),
-                ..
-            }) => *n,
-            _ => usize::MAX,
-        };
-
-        depleted.push(us);
-    }
-
-    let depleted_clone = depleted.clone();
-
-    // Create a variable to store the result
-    let mut result = String::new();
-
-    // Initialize the index for the chars2 vector
-    let mut chars2_index = 0;
-
-    // Go through each character in the input string
-    for ch in input.chars() {
-        // Check if the character is in the chars1 vector
-        if Operand::contains(chars1, &ch) {
-            // If the character is in the chars1 vector, add it to the result without changing it
-            result.push(ch);
-
-            continue;
-        }
-
-        // If the character is not in the chars1 vector, replace it with a character from the chars2 vector
-        // Add the character from the chars2 vector to the result
-        // TODO
-        // Indexing
-        let operand = chars2.get(chars2_index).ok_or("Indexing failed")?;
-
-        match operand {
-            Operand::Char(CharOperand { char, .. }) => {
-                result.push(*char);
-
-                let mut_ref = depleted.get_mut(chars2_index).ok_or("Indexing failed")?;
-
-                let decremented = (*mut_ref) - 1_usize;
-
-                *mut_ref = decremented;
-
-                if decremented > 0_usize {
-                    continue;
-                }
-            }
-            Operand::Equiv(EquivOperand { char }) => {
-                result.push(*char);
-            }
-        }
-
-        // Increase the index for the chars2 vector
-        chars2_index += 1;
-
-        // If the index has reached the end of the chars2 vector, reset it to zero
-        if chars2_index >= chars2.len() {
-            chars2_index = 0;
-
-            depleted.clone_from(&depleted_clone);
-        }
-    }
-
-    Ok(result)
-}
-
-/// Checks if a character is repeatable based on certain conditions.
-///
-/// This function determines if a character `c` is repeatable based on the following conditions:
-/// - The character occurs more than once in the input string.
-/// - The character is present in the set `set2`.
-///
-/// If the conditions are met and the character has not been seen before, it is considered repeatable.
-///
-/// # Arguments
-///
-/// * `c` - A character to be checked for repeatability.
-/// * `char_counts` - A reference to a hashmap containing character counts in the input string.
-/// * `seen` - A mutable reference to a hash set to keep track of characters seen so far.
-/// * `set2` - A reference to a vector of `Operand` representing the second set of characters.
-///
-/// # Returns
-///
-/// * `bool` - Returns `true` if the character is repeatable based on the conditions specified above.
-///            Returns `false` otherwise.
-///
-fn check_repeatable(
-    ch: char,
-    char_counts: &HashMap<char, usize>,
-    seen: &mut HashSet<char>,
-    set2: &[Operand],
-) -> bool {
-    if char_counts[&ch] > 1 && Operand::contains(set2, &ch) {
-        if seen.contains(&ch) {
-            false
-        } else {
-            seen.insert(ch);
-
-            true
-        }
-    } else {
-        true
-    }
-}
-
-// TODO
-// This should be optimized
-fn generate_for_translation(
-    string1_operands: Vec<Operand>,
-    string2_operands: Vec<Operand>,
-) -> Result<ForTranslation, Box<dyn Error>> {
-    let mut char_repeating_total = 0_usize;
-
-    let mut string1_operands_flattened = Vec::<Operand>::new();
-
-    for op in string1_operands {
-        match op {
-            Operand::Char(CharOperand {
-                char_repetition,
-                char,
-            }) => match char_repetition {
-                CharRepetition::AsManyAsNeeded => {
-                    return Err(Box::from(
-                        "tr: the [c*] repeat construct may not appear in string1".to_owned(),
-                    ));
-                }
-                CharRepetition::N(n) => {
-                    char_repeating_total = char_repeating_total
-                        .checked_add(n)
-                        .ok_or("Arithmetic overflow")?;
-
-                    let new_char = Operand::Char(CharOperand {
-                        char,
-                        char_repetition: CharRepetition::N(1_usize),
-                    });
-
-                    for _ in 0_usize..n {
-                        string1_operands_flattened.push(new_char.clone());
-                    }
-                }
-            },
-            op @ Operand::Equiv(_) => {
-                // Take up one position?
-                string1_operands_flattened.push(op);
-            }
-        }
-    }
-
-    // TODO
-    // Indexing is a workaround for the borrow checker
-    let mut as_many_as_needed_index = Option::<usize>::None;
-
-    let mut replacement_char_repeating_total = 0_usize;
-
-    for (us, op) in string2_operands.iter().enumerate() {
-        match op {
-            Operand::Char(CharOperand {
-                char_repetition, ..
-            }) => match char_repetition {
-                CharRepetition::AsManyAsNeeded => {
-                    if as_many_as_needed_index.is_some() {
-                        // TODO
-                        // Do this validation earlier?
-                        return Err(Box::from(
-                            "tr: only one [c*] repeat construct may appear in string2".to_owned(),
-                        ));
-                    }
-
-                    as_many_as_needed_index = Some(us);
-                }
-                CharRepetition::N(n) => {
-                    replacement_char_repeating_total = replacement_char_repeating_total
-                        .checked_add(*n)
-                        .ok_or("Arithmetic overflow")?;
-                }
-            },
-            Operand::Equiv { .. } => {
-                // TODO
-                // Do this validation earlier?
-                return Err(Box::from(
-                    "tr: [=c=] expressions may not appear in string2 when translating".to_owned(),
-                ));
-            }
-        }
-    }
-
-    let string2_operands_to_use = if replacement_char_repeating_total < char_repeating_total {
-        let leftover = char_repeating_total
-            .checked_sub(replacement_char_repeating_total)
-            .ok_or("Arithmetic overflow")?;
-
-        // TODO
-        // to_vec
-        let mut string2_operands_with_leftover = string2_operands.to_vec();
-
-        match as_many_as_needed_index {
-            Some(us) => {
-                let op = string2_operands_with_leftover
-                    .get_mut(us)
-                    .ok_or("Indexing failed")?;
-
-                match op {
-                    Operand::Char(CharOperand {
-                        ref mut char_repetition,
-                        ..
-                    }) => {
-                        *char_repetition = CharRepetition::N(leftover);
-                    }
-                    Operand::Equiv(_) => {
-                        unreachable!();
-                    }
-                }
-            }
-            None => {
-                let mut n_updated = false;
-
-                for op in string2_operands_with_leftover.iter_mut().rev() {
-                    if let Operand::Char(CharOperand {
-                        char_repetition: CharRepetition::N(ref mut n),
-                        ..
-                    }) = op
-                    {
-                        let n_plus_leftover =
-                            n.checked_add(leftover).ok_or("Arithmetic overflow")?;
-
-                        *n = n_plus_leftover;
-
-                        n_updated = true;
-
-                        break;
-                    }
-                }
-
-                assert!(n_updated);
-            }
-        }
-
-        string2_operands_with_leftover
-    } else {
-        string2_operands
-    };
-
-    // TODO
-    // Capacity
-    let mut string2_operands_to_use_flattened = Vec::<char>::new();
-
-    for op in string2_operands_to_use {
-        match op {
-            Operand::Char(CharOperand {
-                char_repetition,
-                char,
-            }) => match char_repetition {
-                CharRepetition::N(n) => {
-                    for _ in 0_usize..n {
-                        string2_operands_to_use_flattened.push(char);
-                    }
-                }
-                CharRepetition::AsManyAsNeeded => {
-                    // The "[c*]" construct was not needed, ignore it
-                }
-            },
-            Operand::Equiv(_) => {
-                unreachable!();
-            }
-        }
-    }
-
-    // TODO
-    // Capacities
-    let mut equiv_translation_chars = Vec::<(char, char)>::new();
-    let mut multi_byte_translation_hash_map = HashMap::<char, char>::new();
-    let mut single_byte_translation_lookup_table = [Option::<char>::None; 128_usize];
-
-    let mut encoding_buffer = [0_u8; 4_usize];
-
-    let mut add_normal_char = |ch: char, replacement_char: char| {
-        let sl = ch.encode_utf8(&mut encoding_buffer);
-
-        match sl.as_bytes() {
-            &[ue] => {
-                single_byte_translation_lookup_table[usize::from(ue)] = Some(replacement_char);
-            }
-            _ => {
-                multi_byte_translation_hash_map.insert(ch, replacement_char);
-            }
-        }
-    };
-
-    for (us, op) in string1_operands_flattened.into_iter().enumerate() {
-        let replacement_char = string2_operands_to_use_flattened
-            .get(us)
-            .ok_or("Indexing failed")?
-            .to_owned();
-
-        match op {
-            Operand::Char(CharOperand {
-                char,
-                char_repetition,
-            }) => {
-                // TODO
-                // Enforce with types
-                assert!(matches!(char_repetition, CharRepetition::N(1_usize)));
-
-                add_normal_char(char, replacement_char);
-            }
-            Operand::Equiv(EquivOperand { char }) => {
-                equiv_translation_chars.push((char, replacement_char));
-
-                // TODO
-                // Fix for `tr_equivalence_class_low_priority`
-                add_normal_char(char, replacement_char);
-            }
-        }
-    }
-
-    let for_translate = ForTranslation {
-        equiv_translation_chars,
-        multi_byte_translation_hash_map,
-        single_byte_translation_lookup_table: Box::new(single_byte_translation_lookup_table),
-    };
-
-    Ok(for_translate)
-}
-
-fn generate_for_removal(string1_operands: Vec<Operand>) -> Result<ForRemoval, Box<dyn Error>> {
-    let mut equiv_removal_chars = Vec::<char>::new();
-    let mut multi_byte_removal_hash_set = HashSet::<char>::new();
-    let mut single_byte_removal_lookup_table = [false; 128_usize];
-
-    let mut encoding_buffer = [0_u8; 4_usize];
-
-    for op in string1_operands {
-        match op {
-            Operand::Char(CharOperand {
-                char_repetition,
-                char,
-            }) => match char_repetition {
-                CharRepetition::AsManyAsNeeded => {
-                    return Err(Box::from(
-                        "tr: the [c*] repeat construct may not appear in string1".to_owned(),
-                    ));
-                }
-                CharRepetition::N(_) => {
-                    let char_to_owned = char.to_owned();
-
-                    let sl = char_to_owned.encode_utf8(&mut encoding_buffer);
-
-                    match sl.as_bytes() {
-                        &[ue] => {
-                            single_byte_removal_lookup_table[usize::from(ue)] = true;
-                        }
-                        _ => {
-                            multi_byte_removal_hash_set.insert(char_to_owned);
-                        }
-                    }
-                }
-            },
-            Operand::Equiv(EquivOperand { char }) => {
-                equiv_removal_chars.push(char);
-            }
-        }
-    }
-
-    let delete_or_squeeze = ForRemoval {
-        multi_byte_removal_hash_set,
-        single_byte_removal_lookup_table: Box::new(single_byte_removal_lookup_table),
-        equiv_removal_chars,
-    };
-
-    Ok(delete_or_squeeze)
-}
-
-fn streaming_transform(transformation_type: TransformationType) -> Result<(), Box<dyn Error>> {
-    const SIZE: usize = 8_usize * 1_024;
-
-    // Buffers
-    let mut input = vec![0_u8; SIZE];
-    let mut output = Vec::<u8>::with_capacity(SIZE);
-    let mut temporary_leftover = Vec::<u8>::new();
-
-    // TODO
-    // Improve this
-    let mut leftover_bytes = 0_usize;
-
-    let mut stdin_lock = io::stdin().lock();
-    let mut stdout_lock = io::stdout().lock();
-
-    loop {
-        let buf = &mut input[leftover_bytes..];
-
-        match stdin_lock.read(buf) {
-            Ok(0_usize) => {
-                assert!(leftover_bytes == 0_usize);
-
-                assert!(!buf.is_empty());
-
-                break;
-            }
-            Ok(us) => {
-                let read_slice = &input[..(leftover_bytes + us)];
-
-                let for_transform = match std::str::from_utf8(read_slice) {
-                    Ok(st) => st,
-                    Err(ut) => {
-                        let (valid, remainder) = read_slice.split_at(ut.valid_up_to());
-
-                        temporary_leftover.extend_from_slice(remainder);
-
-                        // https://doc.rust-lang.org/std/str/struct.Utf8Error.html#examples
-                        unsafe { std::str::from_utf8_unchecked(valid) }
-                    }
-                };
-
-                transformation_type.transform(for_transform, &mut output);
-
-                // TODO
-                // Do this in a nicer way
-                for (us, ue) in temporary_leftover.iter().enumerate() {
-                    // TODO
-                    // Indexing
-                    input[us] = *ue;
-                }
-
-                leftover_bytes = temporary_leftover.len();
-
-                temporary_leftover.clear();
-
-                stdout_lock.write_all(&output)?;
-
-                output.clear();
-            }
-            Err(er) => {
-                if er.kind() == ErrorKind::Interrupted {
-                    continue;
-                }
-
-                return Err(Box::from(er));
-            }
-        }
-    }
-
-    Ok(())
-}
-
-struct ForRemoval {
-    equiv_removal_chars: Vec<char>,
-    multi_byte_removal_hash_set: HashSet<char>,
-    single_byte_removal_lookup_table: Box<[bool; 128_usize]>,
-}
-
-#[derive(Debug)]
-struct ForTranslation {
-    equiv_translation_chars: Vec<(char, char)>,
-    multi_byte_translation_hash_map: HashMap<char, char>,
-    single_byte_translation_lookup_table: Box<[Option<char>; 128_usize]>,
-}
-
-enum TransformationType {
-    Delete(ForRemoval),
-    Squeeze(ForRemoval),
-    SqueezeAndTranslate(ForTranslation),
-    Translate(ForTranslation),
-}
-
-impl TransformationType {
-    fn transform(&self, input: &str, output: &mut Vec<u8>) {
-        match self {
-            TransformationType::Delete(ForRemoval {
-                equiv_removal_chars,
-                multi_byte_removal_hash_set,
-                single_byte_removal_lookup_table,
-            }) => {
-                let mut encoding_buffer = [0_u8; 4_usize];
-
-                'process_next_char_label: for ch in input.chars() {
-                    let as_bytes = ch.encode_utf8(&mut encoding_buffer).as_bytes();
-
-                    let is_deleted_char = match as_bytes {
-                        &[ue] => single_byte_removal_lookup_table[usize::from(ue)],
-                        _ => multi_byte_removal_hash_set.contains(&ch),
-                    };
-
-                    if is_deleted_char {
-                        continue 'process_next_char_label;
-                    }
-
-                    for &cha in equiv_removal_chars {
-                        if compare_deunicoded_chars(ch, cha) {
-                            continue 'process_next_char_label;
-                        }
-                    }
-
-                    output.extend_from_slice(as_bytes);
-                }
-            }
-            TransformationType::Squeeze(ForRemoval {
-                equiv_removal_chars,
-                multi_byte_removal_hash_set,
-                single_byte_removal_lookup_table,
-            }) => {
-                let is_squeezed = |ch: char, char_slice: &[u8]| {
-                    let first_check = match char_slice {
-                        &[ue] => single_byte_removal_lookup_table[usize::from(ue)],
-                        _ => multi_byte_removal_hash_set.contains(&ch),
-                    };
-
-                    if first_check {
-                        true
-                    } else {
-                        let mut bo = false;
-
-                        for &cha in equiv_removal_chars {
-                            if compare_deunicoded_chars(ch, cha) {
-                                bo = true;
-
-                                break;
-                            }
-                        }
-
-                        bo
-                    }
-                };
-
-                let mut chars = input.chars();
-
-                let Some(first_char_encountered) = chars.next() else {
-                    return;
-                };
-
-                let mut encoding_buffer = [0_u8; 4_usize];
-
-                // Add the first char
-                let (first_char_is_squeezed, first_char_slice) = {
-                    let char_slice = first_char_encountered
-                        .encode_utf8(&mut encoding_buffer)
-                        .as_bytes();
-
-                    output.extend_from_slice(char_slice);
-
-                    let char_is_squeezed = is_squeezed(first_char_encountered, char_slice);
-
-                    (char_is_squeezed, char_slice)
-                };
-
-                let mut last_char_encountered = first_char_encountered;
-                let mut last_char_is_squeezed = first_char_is_squeezed;
-                let mut last_char_slice = first_char_slice;
-
-                for ch in chars {
-                    if last_char_encountered == ch {
-                        if !last_char_is_squeezed {
-                            output.extend_from_slice(last_char_slice);
-                        }
-
-                        continue;
-                    }
-
-                    let char_slice = ch.encode_utf8(&mut encoding_buffer).as_bytes();
-
-                    output.extend_from_slice(char_slice);
-
-                    last_char_encountered = ch;
-                    last_char_is_squeezed = is_squeezed(ch, char_slice);
-                    last_char_slice = char_slice;
-                }
-            }
-            TransformationType::SqueezeAndTranslate(ForTranslation {
-                equiv_translation_chars,
-                multi_byte_translation_hash_map,
-                single_byte_translation_lookup_table,
-            }) => {
-                let has_squeezed_translation = |ch: char, char_slice: &[u8]| {
-                    let first_check = match char_slice {
-                        &[ue] => single_byte_translation_lookup_table[usize::from(ue)],
-                        _ => multi_byte_translation_hash_map.get(&ch).copied(),
-                    };
-
-                    match first_check {
-                        op @ Some(_) => op,
-                        None => {
-                            let mut op = Option::<char>::None;
-
-                            for (cha, char) in equiv_translation_chars {
-                                if compare_deunicoded_chars(ch, *cha) {
-                                    op = Some(*char);
-
-                                    break;
-                                }
-                            }
-
-                            op
-                        }
-                    }
-                };
-
-                let mut chars = input.chars();
-
-                let Some(first_char_encountered) = chars.next() else {
-                    return;
-                };
-
-                let mut encoding_buffer = [0_u8; 4_usize];
-
-                // Add the first char
-                let (first_char_has_squeezed_translation, first_char_slice) = {
-                    let char_slice = first_char_encountered
-                        .encode_utf8(&mut encoding_buffer)
-                        .as_bytes();
-
-                    let char_has_squeezed_translation =
-                        has_squeezed_translation(first_char_encountered, char_slice);
-
-                    let char_slice_to_use = match char_has_squeezed_translation {
-                        Some(replacement_char) => {
-                            let replacement_char_str =
-                                replacement_char.encode_utf8(&mut encoding_buffer);
-
-                            replacement_char_str.as_bytes()
-                        }
-                        None => char_slice,
-                    };
-
-                    output.extend_from_slice(char_slice_to_use);
-
-                    (char_has_squeezed_translation, char_slice_to_use)
-                };
-
-                let mut last_char_encountered = first_char_encountered;
-                let mut last_char_has_squeezed_translation = first_char_has_squeezed_translation;
-                let mut last_char_slice = first_char_slice;
-
-                for ch in chars {
-                    if last_char_encountered == ch {
-                        if last_char_has_squeezed_translation.is_none() {
-                            output.extend_from_slice(last_char_slice);
-                        }
-
-                        continue;
-                    }
-
-                    let char_slice = ch.encode_utf8(&mut encoding_buffer).as_bytes();
-
-                    let char_has_squeezed_translation = has_squeezed_translation(ch, char_slice);
-
-                    match (
-                        char_has_squeezed_translation,
-                        last_char_has_squeezed_translation,
-                    ) {
-                        (Some(ch), Some(cha)) if ch == cha => {
-                            last_char_slice = char_slice;
-
-                            continue;
-                        }
-                        _ => {}
-                    }
-
-                    let char_slice_to_use = match char_has_squeezed_translation {
-                        Some(replacement_char) => {
-                            let replacement_char_str =
-                                replacement_char.encode_utf8(&mut encoding_buffer);
-
-                            replacement_char_str.as_bytes()
-                        }
-                        None => char_slice,
-                    };
-
-                    output.extend_from_slice(char_slice_to_use);
-
-                    last_char_encountered = ch;
-                    last_char_has_squeezed_translation = char_has_squeezed_translation;
-                    last_char_slice = char_slice_to_use;
-                }
-            }
-            TransformationType::Translate(ForTranslation {
-                equiv_translation_chars,
-                multi_byte_translation_hash_map,
-                single_byte_translation_lookup_table,
-            }) => {
-                let mut encoding_buffer = [0_u8; 4_usize];
-
-                for ch in input.chars() {
-                    let as_bytes = ch.encode_utf8(&mut encoding_buffer).as_bytes();
-
-                    let replacement_char_option = match as_bytes {
-                        &[ue] => single_byte_translation_lookup_table[usize::from(ue)],
-                        _ => multi_byte_translation_hash_map.get(&ch).copied(),
-                    };
-
-                    // TODO
-                    // What is the precedence of equivalence classes?
-                    // GNU Core Utilities de-prioritizes them
-
-                    // Only use equivalence classes if normal translation failed
-                    let replacement_char_option_to_use = match replacement_char_option {
-                        Some(cha) => Some(cha),
-                        None => {
-                            let mut op = Option::<char>::None;
-
-                            for (equiv_char, equiv_char_replacement) in equiv_translation_chars {
-                                if compare_deunicoded_chars(ch, *equiv_char) {
-                                    op = Some(*equiv_char_replacement);
-
-                                    break;
-                                }
-                            }
-
-                            op
-                        }
-                    };
-
-                    let for_output = match replacement_char_option_to_use {
-                        Some(replacement_char) => {
-                            let replacement_char_str =
-                                replacement_char.encode_utf8(&mut encoding_buffer);
-
-                            replacement_char_str.as_bytes()
-                        }
-                        None => as_bytes,
-                    };
-
-                    output.extend_from_slice(for_output);
-                }
-            }
-        }
-    }
-}
-
 /// Translates or deletes characters from standard input, according to specified arguments.
 ///
 /// This function reads from standard input, processes the input string based on the specified arguments,
@@ -1468,189 +91,103 @@ fn tr(args: &Args) -> Result<(), Box<dyn std::error::Error>> {
         None => None,
     };
 
-    if !args.complement_char && !args.complement_val {
-        // Fast path for "tr", "tr -d", and "tr -s" (without any other options)
-        match (args.delete, args.squeeze_repeats) {
-            (false, false) => {
-                // "tr"
-                let string2_operands = match string2_operands_option {
-                    Some(op) => op,
-                    None => {
-                        return Err(Box::from("tr: missing operand".to_owned()));
-                    }
-                };
-
-                if string2_operands.is_empty() {
-                    return Err(Box::from(
-                        "tr: when not truncating set1, string2 must be non-empty".to_owned(),
-                    ));
-                }
-
-                let for_translation = generate_for_translation(string1_operands, string2_operands)?;
-
-                let transformation_type = TransformationType::Translate(for_translation);
-
-                return streaming_transform(transformation_type);
-            }
-            (true, false) => {
-                // "tr -d"
-                let delete_or_squeeze = generate_for_removal(string1_operands)?;
-
-                let transformation_type = TransformationType::Delete(delete_or_squeeze);
-
-                return streaming_transform(transformation_type);
-            }
-            (false, true) => {
-                // "tr -s"
-                let transformation_type = match string2_operands_option {
-                    Some(string2_operands) => {
-                        if string2_operands.is_empty() {
-                            return Err(Box::from(
-                                "tr: when not truncating set1, string2 must be non-empty"
-                                    .to_owned(),
-                            ));
-                        }
-
-                        let for_translation =
-                            generate_for_translation(string1_operands, string2_operands)?;
-
-                        TransformationType::SqueezeAndTranslate(for_translation)
-                    }
-                    None => {
-                        let delete_or_squeeze = generate_for_removal(string1_operands)?;
-
-                        TransformationType::Squeeze(delete_or_squeeze)
-                    }
-                };
-
-                return streaming_transform(transformation_type);
-            }
-            _ => {}
-        };
-    }
-
     // TODO
-    // These paths are not streaming yet
-    let mut input = String::new();
+    // How are these different?
+    let complement = args.complement_char || args.complement_val;
 
-    io::stdin()
-        .read_to_string(&mut input)
-        .expect("Failed to read input");
-
-    let string_to_write = if args.delete {
-        let filtered_string = if args.complement_char || args.complement_val {
-            input
-                .chars()
-                .filter(|c| Operand::contains(&string1_operands, c))
-                .collect::<String>()
-        } else {
-            input
-                .chars()
-                .filter(|c| !Operand::contains(&string1_operands, c))
-                .collect::<String>()
-        };
-
-        let filtered_string_to_use = if args.squeeze_repeats && string2_operands_option.is_some() {
-            // Counting the frequency of characters in the chars vector
-            let mut char_counts = HashMap::<char, usize>::new();
-
-            for ch in filtered_string.chars() {
-                *(char_counts.entry(ch).or_insert(0)) += 1;
-            }
-
-            let mut seen = HashSet::<char>::new();
-
-            filtered_string
-                .chars()
-                .filter(|&ch| {
-                    check_repeatable(
-                        ch,
-                        &char_counts,
-                        &mut seen,
-                        string2_operands_option.as_deref().unwrap(),
-                    )
-                })
-                .collect::<String>()
-        } else {
-            filtered_string
-        };
-
-        filtered_string_to_use
-    } else if args.squeeze_repeats && string2_operands_option.is_none() {
-        let mut char_counts = HashMap::<char, i32>::new();
-
-        for ch in input.chars() {
-            *(char_counts.entry(ch).or_insert(0)) += 1;
-        }
-
-        let mut seen = HashSet::<char>::new();
-
-        let filtered_string = input
-            .chars()
-            .filter(|&ch| {
-                if char_counts[&ch] > 1 && Operand::contains(&string1_operands, &ch) {
-                    if seen.contains(&ch) {
-                        false
-                    } else {
-                        seen.insert(ch);
-
-                        true
-                    }
-                } else {
-                    true
+    let mut transformation: Box<dyn Transformation> = match (args.delete, args.squeeze_repeats) {
+        (false, false) => {
+            // "tr"
+            let string2_operands = match string2_operands_option {
+                Some(op) => op,
+                None => {
+                    return Err(Box::from("tr: missing operand".to_owned()));
                 }
-            })
-            .collect::<String>();
+            };
 
-        filtered_string
-    } else {
-        let result_string = {
-            assert!(args.complement_char || args.complement_val);
-
-            if args.complement_char {
-                complement_chars(
-                    &input,
-                    &string1_operands,
-                    string2_operands_option.as_deref().unwrap(),
-                )?
-            } else {
-                let mut set2 = string2_operands_option.as_deref().unwrap().to_vec();
-
-                set2.sort_by(|op, ope| op.char().cmp(ope.char()));
-
-                complement_chars(&input, &string1_operands, &set2)?
-            }
-        };
-
-        let result_string_to_use = if args.squeeze_repeats {
-            // Counting the frequency of characters in the chars vector
-            let mut char_counts = HashMap::<char, usize>::new();
-
-            for ch in result_string.chars() {
-                *(char_counts.entry(ch).or_insert(0)) += 1;
+            if string2_operands.is_empty() {
+                return Err(Box::from(
+                    "tr: when not truncating set1, string2 must be non-empty".to_owned(),
+                ));
             }
 
-            let mut seen = HashSet::<char>::new();
+            let for_translation =
+                generate_for_translation(complement, string1_operands, string2_operands)?;
 
-            result_string
-                .chars()
-                .filter(|&ch| {
-                    check_repeatable(
-                        ch,
-                        &char_counts,
-                        &mut seen,
-                        string2_operands_option.as_deref().unwrap(),
-                    )
-                })
-                .collect::<String>()
-        } else {
-            result_string
-        };
+            let bo: Box<dyn Transformation> =
+                Box::from(TranslateTransformation { for_translation });
 
-        result_string_to_use
+            bo
+        }
+        (true, false) => {
+            // "tr -d"
+            let for_removal = generate_for_removal(complement, string1_operands)?;
+
+            let bo: Box<dyn Transformation> = Box::from(DeleteTransformation {
+                for_removal,
+                delete_state: DeleteState::Start,
+            });
+
+            bo
+        }
+        (false, true) => {
+            // "tr -s"
+            match string2_operands_option {
+                Some(string2_operands) => {
+                    if string2_operands.is_empty() {
+                        return Err(Box::from(
+                            "tr: when not truncating set1, string2 must be non-empty".to_owned(),
+                        ));
+                    }
+
+                    let for_translation =
+                        generate_for_translation(complement, string1_operands, string2_operands)?;
+
+                    let bo: Box<dyn Transformation> =
+                        Box::from(SqueezeAndTranslateTransformation {
+                            for_translation,
+                            squeeze_and_translate_state: SqueezeAndTranslateState::Start,
+                        });
+
+                    bo
+                }
+                None => {
+                    let for_removal = generate_for_removal(complement, string1_operands)?;
+
+                    let bo: Box<dyn Transformation> = Box::from(SqueezeTransformation {
+                        for_removal,
+                        squeeze_state: SqueezeState::Start,
+                    });
+
+                    bo
+                }
+            }
+        }
+        (true, true) => {
+            // "tr -d -s"
+            let string2_operands = match string2_operands_option {
+                Some(op) => op,
+                None => {
+                    return Err(Box::from("tr: missing operand".to_owned()));
+                }
+            };
+
+            // "The same string cannot be used for both the -d and the -s option; when both options are specified, both string1 (used for deletion) and string2 (used for squeezing) shall be required."
+            let delete = generate_for_removal(complement, string1_operands)?;
+
+            let squeeze = generate_for_removal(complement, string2_operands)?;
+
+            let bo: Box<dyn Transformation> = Box::from(DeleteAndSqueezeTransformation {
+                delete,
+                squeeze,
+                delete_and_squeeze_state: DeleteAndSqueezeState::Start,
+            });
+
+            bo
+        }
     };
 
-    io::stdout().write_all(string_to_write.as_bytes())?;
+    transformation.streaming_transform()?;
 
     Ok(())
 }
@@ -1675,4 +212,1686 @@ fn main() -> Result<(), Box<dyn Error>> {
     }
 
     Ok(())
+}
+
+mod parsing {
+    use std::iter::{self, Peekable};
+    use std::slice::Iter;
+    use std::str::Chars;
+
+    #[derive(Clone)]
+    pub enum CharRepetition {
+        AsManyAsNeeded,
+        N(usize),
+    }
+
+    #[derive(Clone)]
+    pub struct CharOperand {
+        // The character
+        pub char: char,
+        // The number of times the character is repeated
+        pub char_repetition: CharRepetition,
+    }
+
+    #[derive(Clone)]
+    pub struct EquivOperand {
+        // The character equivalent
+        pub char: char,
+    }
+
+    #[derive(Clone)]
+    pub enum Operand {
+        Char(CharOperand),
+        Equiv(EquivOperand),
+    }
+
+    pub fn parse_string1_or_string2(string1_or_string2: &str) -> Result<Vec<Operand>, String> {
+        // The longest valid "[:class:]", "[=equiv=]", or "[x*n]" construct is a "[x*n]" construct
+        // These are (seemingly) the shortest invalid "[x*n]" constructs (octal and decimal):
+        // [a*010000000000000000000000]
+        // [a*100000000000000000000]
+        // Therefore, the longest valid one should be:
+        // [a*01000000000000000000000]
+        // Rounding up to 32
+        const SQUARE_BRACKET_CONSTRUCTS_BUFFER_CAPACITY: usize = 32_usize;
+
+        // This capacity will be sufficient at least some of the time
+        let mut operand_vec = Vec::<Operand>::with_capacity(string1_or_string2.len());
+
+        let mut peekable = string1_or_string2.chars().peekable();
+
+        let mut parse_left_square_bracket_normally = false;
+
+        while let Some(&ch) = peekable.peek() {
+            match (ch, parse_left_square_bracket_normally) {
+                ('[', false) => {
+                    // Save the state of `peekable` before advancing it, see note below
+                    let peekable_saved = peekable.clone();
+
+                    // TODO
+                    // Avoid repeated allocation
+                    let mut square_bracket_constructs_buffer =
+                        Vec::<char>::with_capacity(SQUARE_BRACKET_CONSTRUCTS_BUFFER_CAPACITY);
+
+                    let mut found_closing_square_bracket = false;
+
+                    for ch in peekable.by_ref() {
+                        square_bracket_constructs_buffer.push(ch);
+
+                        let vec_len = square_bracket_constructs_buffer.len();
+
+                        // Length check is a hacky fix for "[:]", "[=]", "[]*]", etc.
+                        if ch == ']' && vec_len > 3_usize {
+                            found_closing_square_bracket = true;
+
+                            break;
+                        }
+                    }
+
+                    if found_closing_square_bracket {
+                        let after_opening_square_bracket =
+                            square_bracket_constructs_buffer.get(1_usize);
+
+                        let before_closing_square_bracket =
+                            square_bracket_constructs_buffer.iter().rev().nth(1_usize);
+
+                        if after_opening_square_bracket == Some(&':')
+                            && before_closing_square_bracket == Some(&':')
+                        {
+                            expand_character_class(
+                                &square_bracket_constructs_buffer,
+                                &mut operand_vec,
+                            )?;
+
+                            continue;
+                        }
+
+                        if after_opening_square_bracket == Some(&'=')
+                            && before_closing_square_bracket == Some(&'=')
+                        {
+                            // "[=equiv=]" construct
+                            let operand = parse_equiv(&square_bracket_constructs_buffer)?;
+
+                            operand_vec.push(operand);
+
+                            continue;
+                        }
+
+                        if square_bracket_constructs_buffer.get(2_usize) == Some(&'*') {
+                            // "[x*n]" construct
+                            operand_vec
+                                .push(parse_repeated_char(&square_bracket_constructs_buffer)?);
+
+                            continue;
+                        }
+                    }
+
+                    // Not a "[:class:]", "[=equiv=]", or "[x*n]" construct
+                    // The hacky way to continue is to reset `peekable` (to `peekable_saved`)
+                    // This moves the Peekable back to the point it was at before attempting to parse square bracket
+                    // constructs
+                    parse_left_square_bracket_normally = true;
+                    peekable = peekable_saved;
+                }
+                (cha, bo) => {
+                    // '[' is not the start of a square bracket construct, so handle it normally
+                    if bo {
+                        assert!(cha == '[');
+
+                        // When encountering '[' in the future, try to parse square bracket constructs first
+                        parse_left_square_bracket_normally = false;
+                    }
+
+                    if let Some(char) = parse_single_char(&mut peekable)? {
+                        parse_range_or_single_char(char, &mut peekable, &mut operand_vec)?;
+                    }
+                }
+            }
+        }
+
+        Ok(operand_vec)
+    }
+
+    /// Parses a sequence in the format `[=equiv=]` from the given character iterator.
+    ///
+    /// The function expects the iterator to be positioned just before the first `=`
+    /// character. It reads the equivalent characters between the `=` symbols and
+    /// creates a list of `Operand::Equiv` entries, one for each character.
+    ///
+    /// # Arguments
+    ///
+    /// * `chars` - A mutable reference to a peekable character iterator.
+    ///
+    /// # Returns
+    ///
+    /// A `Result` containing a vector of `Operand::Equiv` entries if successful, or a
+    /// `String` describing the error if parsing fails.
+    ///
+    /// # Errors
+    ///
+    /// This function will return an error if:
+    /// - The sequence does not contain a closing `=` before `]`.
+    /// - The sequence does not contain a closing `]`.
+    /// - The sequence contains no characters between the `=` symbols.
+    ///
+    fn parse_equiv(square_bracket_constructs_buffer: &[char]) -> Result<Operand, String> {
+        let mut iter = square_bracket_constructs_buffer.iter();
+
+        // Skip '[='
+        assert!(iter.next() == Some(&'['));
+        assert!(iter.next() == Some(&'='));
+
+        let mut between_equals_signs = Vec::<char>::with_capacity(1_usize);
+
+        between_equals_signs.extend(iter.take_while(|&&ch| ch != '='));
+
+        let char_between_equals_signs = match between_equals_signs.as_slice() {
+            &[ch] => ch,
+            &[] => {
+                unreachable!();
+            }
+            sl => {
+                const ERROR_MESSAGE_PREFIX: &str = "tr: ";
+                const ERROR_MESSAGE_SUFFIX: &str =
+                    ": equivalence class operand must be a single character";
+
+                const ERROR_MESSAGE_PREFIX_AND_SUFFIX_LENGTH: usize =
+                    ERROR_MESSAGE_PREFIX.len() + ERROR_MESSAGE_SUFFIX.len();
+
+                let mut error_message =
+                    String::with_capacity(ERROR_MESSAGE_PREFIX_AND_SUFFIX_LENGTH + sl.len());
+
+                error_message.push_str(ERROR_MESSAGE_PREFIX);
+
+                for &ch in sl {
+                    error_message.push(ch);
+                }
+
+                error_message.push_str(ERROR_MESSAGE_SUFFIX);
+
+                return Err(error_message);
+            }
+        };
+
+        let operand = Operand::Equiv(EquivOperand {
+            char: char_between_equals_signs,
+        });
+
+        Ok(operand)
+    }
+
+    fn parse_repeated_char(square_bracket_constructs_buffer: &[char]) -> Result<Operand, String> {
+        // TODO
+        // Clean this up
+        fn fill_repeat_str(iter: &mut Iter<char>, repeat_string: &mut String) {
+            while let Some(&ch) = iter.next() {
+                if ch == ']' {
+                    assert!(iter.next().is_none());
+
+                    return;
+                }
+
+                repeat_string.push(ch);
+            }
+
+            unreachable!();
+        }
+
+        let mut iter = square_bracket_constructs_buffer.iter();
+
+        // Skip '['
+        assert!(iter.next() == Some(&'['));
+
+        // Get character before '*'
+        let char = iter.next().unwrap().to_owned();
+
+        // Skip '*'
+        assert!(iter.next() == Some(&'*'));
+
+        let mut repeat_string = String::with_capacity(square_bracket_constructs_buffer.len());
+
+        fill_repeat_str(&mut iter, &mut repeat_string);
+
+        // "If n is omitted or is zero, it shall be interpreted as large enough to extend the string2-based sequence to the length of the string1-based sequence. If n has a leading zero, it shall be interpreted as an octal value. Otherwise, it shall be interpreted as a decimal value."
+        // https://pubs.opengroup.org/onlinepubs/9799919799/utilities/tr.html
+        let char_repetition = match repeat_string.as_str() {
+            "" => CharRepetition::AsManyAsNeeded,
+            st => {
+                let radix = if st.starts_with('0') {
+                    // Octal
+                    8_u32
+                } else {
+                    10_u32
+                };
+
+                match usize::from_str_radix(st, radix) {
+                    Ok(0_usize) => CharRepetition::AsManyAsNeeded,
+                    Ok(n) => CharRepetition::N(n),
+                    Err(_pa) => {
+                        return Err(format!(
+                            "tr: invalid repeat count ‘{st}’ in [c*n] construct",
+                        ));
+                    }
+                }
+            }
+        };
+
+        let operand = Operand::Char(CharOperand {
+            char,
+            char_repetition,
+        });
+
+        Ok(operand)
+    }
+
+    fn parse_octal_sequence(
+        first_octal_digit: char,
+        peekable: &mut Peekable<Chars>,
+    ) -> Result<char, String> {
+        let mut st = String::with_capacity(3_usize);
+
+        st.push(first_octal_digit);
+
+        let mut added_octal_digit_to_buffer = |pe: &mut Peekable<Chars>| {
+            if let Some(&second_octal_digit @ '0'..='7') = pe.peek() {
+                st.push(second_octal_digit);
+
+                true
+            } else {
+                false
+            }
+        };
+
+        let advance_peekable_if_parsing_succeed = if added_octal_digit_to_buffer(peekable) {
+            peekable.next();
+
+            added_octal_digit_to_buffer(peekable)
+        } else {
+            false
+        };
+
+        let from_str_radix_result = u16::from_str_radix(&st, 8_u32);
+
+        let octal_digits_parsed = match from_str_radix_result {
+            Ok(uo) => uo,
+            Err(pa) => {
+                return Err(format!("tr: failed to parse octal sequence '{st}' ({pa})"));
+            }
+        };
+
+        // There is no consensus on how to handle this:
+        //
+        // BusyBox and GNU Core Utilities:
+        //     parse "\501" as \050 (which is '(') and '1'
+        //         GNU Core Utilities prints a warning, BusyBox does not
+        // uutils' coreutils:
+        //     parses "\501" as '1'
+        // bsdutils:
+        //     parses "\501" as 'Ł' (U+0141)
+        //
+        // None of these implementations treat this as a fatal error
+        // POSIX says: "Multi-byte characters require multiple, concatenated escape sequences of this type, including the leading <backslash> for each byte."
+        //
+        // Following BusyBox and GNU Core Utilities, because their handling seems to be most in keeping with the POSIX
+        // specification
+        let byte = match u8::try_from(octal_digits_parsed) {
+            Ok(ue) => {
+                if advance_peekable_if_parsing_succeed {
+                    peekable.next();
+                }
+
+                ue
+            }
+            Err(_tr) => {
+                // This should only happen when the sequence is \400 and above
+                // Cannot happen with a two character sequence like \77, because 8^2 is 64 (within u8 bounds)
+                assert!(st.len() == 3_usize);
+
+                let mut chars = st.chars();
+
+                let third_octal_digit = chars.next_back().unwrap();
+
+                // `chars_str` is a view of the first two octal digits
+                let chars_str = chars.as_str();
+
+                assert!(chars_str.len() == 2_usize);
+
+                // Treat the sequence \abc (where a, b, and c are octal digits) as \0abc
+                // The byte represented by \0ab is what will be returned from this function
+                // Parsing of c is handled outside this function
+                match u8::from_str_radix(chars_str, 8_u32) {
+                    Ok(ue) => {
+                        eprintln!(
+                        "tr: warning: the ambiguous octal escape \\{st} is being interpreted as the 2-byte sequence \\0{chars_str}, {third_octal_digit}"
+                    );
+
+                        ue
+                    }
+                    Err(pa) => {
+                        return Err(format!("tr: invalid octal sequence '{chars_str}' ({pa})"));
+                    }
+                }
+            }
+        };
+
+        let char = char::from(byte);
+
+        Ok(char)
+    }
+
+    fn parse_single_char(peekable: &mut Peekable<Chars>) -> Result<Option<char>, String> {
+        let option = match peekable.next() {
+            Some('\\') => {
+                let char = match peekable.next() {
+                    /* #region \octal */
+                    Some(first_octal_digit @ '0'..='7') => {
+                        parse_octal_sequence(first_octal_digit, peekable)?
+                    }
+                    /* #endregion */
+                    //
+                    /* #region \character */
+                    // <alert>
+                    // Code point 0007
+                    Some('a') => '\u{0007}',
+                    // <backspace>
+                    // Code point 0008
+                    Some('b') => '\u{0008}',
+                    // <tab>
+                    // Code point 0009
+                    Some('t') => '\u{0009}',
+                    // <newline>
+                    // Code point 000A
+                    Some('n') => '\u{000A}',
+                    // <vertical-tab>
+                    // Code point 000B
+                    Some('v') => '\u{000B}',
+                    // <form-feed>
+                    // Code point 000C
+                    Some('f') => '\u{000C}',
+                    // <carriage-return>
+                    // Code point 000D
+                    Some('r') => '\u{000D}',
+                    // <backslash>
+                    // Code point 005C
+                    Some('\\') => {
+                        // An escaped backslash
+                        '\u{005C}'
+                    }
+                    /* #endregion */
+                    //
+                    Some(cha) => {
+                        // If a backslash is not at the end of the string, and is not followed by one of the valid
+                        // escape characters (including another backslash), the backslash is basically just ignored:
+                        // the following character is the character added to the set.
+                        cha
+                    }
+                    None => {
+                        eprintln!(
+                            "tr: warning: an unescaped backslash at end of string is not portable"
+                        );
+
+                        // If an unescaped backslash is the last character of the string, treat it as though it were
+                        // escaped (backslash is added to the set)
+                        '\u{005C}'
+                    }
+                };
+
+                Some(char)
+            }
+            op => op,
+        };
+
+        Ok(option)
+    }
+
+    fn parse_range_or_single_char(
+        starting_char: char,
+        peekable: &mut Peekable<Chars>,
+        operand_vec: &mut Vec<Operand>,
+    ) -> Result<(), String> {
+        match peekable.peek() {
+            Some(&hyphen @ '-') => {
+                // Possible "c-c" construct
+                // Move past `hyphen`
+                peekable.next();
+
+                // The parsed character after the hyphen
+                // e.g. "tr 'A-Z' '\044-1'"
+                match parse_single_char(peekable)? {
+                    Some(after_hyphen) => {
+                        // Ranges are inclusive
+                        let range_inclusive = starting_char..=after_hyphen;
+
+                        if range_inclusive.is_empty() {
+                            let message =
+                                format!(
+                                    "tr: range-endpoints of '{}-{}' are in reverse collating sequence order",
+                                    starting_char.escape_default(),
+                                    after_hyphen.escape_default()
+                                );
+
+                            return Err(message);
+                        }
+
+                        let range_inclusive_to_operand_iterator = range_inclusive.map(|ch| {
+                            Operand::Char(CharOperand {
+                                char: ch,
+                                char_repetition: CharRepetition::N(1_usize),
+                            })
+                        });
+
+                        // TODO
+                        // Does this reserve the right capacity?
+                        operand_vec.extend(range_inclusive_to_operand_iterator);
+                    }
+                    None => {
+                        // End of input, do not handle as a range
+                        // e.g. "tr 'ab' 'c-'"
+                        operand_vec.extend_from_slice(&[
+                            Operand::Char(CharOperand {
+                                char: starting_char,
+                                char_repetition: CharRepetition::N(1_usize),
+                            }),
+                            Operand::Char(CharOperand {
+                                char: hyphen,
+                                char_repetition: CharRepetition::N(1_usize),
+                            }),
+                        ]);
+                    }
+                }
+            }
+            _ => {
+                // Not a "c-c" construct
+                operand_vec.push(Operand::Char(CharOperand {
+                    char: starting_char,
+                    char_repetition: CharRepetition::N(1_usize),
+                }))
+            }
+        }
+
+        Ok(())
+    }
+
+    fn expand_character_class(
+        square_bracket_constructs_buffer: &[char],
+        operand_vec: &mut Vec<Operand>,
+    ) -> Result<(), String> {
+        // "[:class:]" construct
+        let mut into_iter = square_bracket_constructs_buffer.iter();
+
+        assert!(into_iter.next() == Some(&'['));
+        assert!(into_iter.next() == Some(&':'));
+
+        assert!(into_iter.next_back() == Some(&']'));
+        assert!(into_iter.next_back() == Some(&':'));
+
+        // TODO
+        // Performance
+        let class = into_iter.collect::<String>();
+
+        let char_vec = match class.as_str() {
+            "alnum" => ('0'..='9')
+                .chain('A'..='Z')
+                .chain('a'..='z')
+                .collect::<Vec<_>>(),
+            "alpha" => ('A'..='Z').chain('a'..='z').collect::<Vec<_>>(),
+            "digit" => ('0'..='9').collect::<Vec<_>>(),
+            "lower" => ('a'..='z').collect::<Vec<_>>(),
+            "upper" => ('A'..='Z').collect::<Vec<_>>(),
+            "space" => vec![' ', '\t', '\n', '\r', '\x0b', '\x0c'],
+            "blank" => vec![' ', '\t'],
+            "cntrl" => (0_u8..=31_u8)
+                .chain(iter::once(127_u8))
+                .map(char::from)
+                .collect::<Vec<_>>(),
+            "graph" => (33_u8..=126_u8).map(char::from).collect::<Vec<_>>(),
+            "print" => (32_u8..=126_u8).map(char::from).collect::<Vec<_>>(),
+            "punct" => (33_u8..=47_u8)
+                .chain(58_u8..=64_u8)
+                .chain(91_u8..=96_u8)
+                .chain(123_u8..=126_u8)
+                .map(char::from)
+                .collect::<Vec<_>>(),
+            "xdigit" => ('0'..='9')
+                .chain('A'..='F')
+                .chain('a'..='f')
+                .collect::<Vec<_>>(),
+            st => return Err(format!("tr: invalid character class ‘{st}’")),
+        };
+
+        operand_vec.extend(char_vec.into_iter().map(|ch| {
+            Operand::Char(CharOperand {
+                char: ch,
+                char_repetition: CharRepetition::N(1_usize),
+            })
+        }));
+
+        Ok(())
+    }
+}
+
+mod setup {
+    use crate::compare_deunicoded_chars;
+    use crate::parsing::{CharOperand, CharRepetition, EquivOperand, Operand};
+    use std::collections::{HashMap, HashSet};
+    use std::error::Error;
+
+    fn complement_operands(operand_slice: &[Operand]) -> Vec<Operand> {
+        let mut hash_set = HashSet::<u8>::with_capacity(operand_slice.len());
+
+        for op in operand_slice {
+            match op {
+                Operand::Char(char_operand) => {
+                    let char = char_operand.char;
+
+                    match u8::try_from(char) {
+                        Ok(ue) => {
+                            hash_set.insert(ue);
+                        }
+                        Err(_) => {
+                            // Ignore
+                        }
+                    }
+                }
+                Operand::Equiv(_) => {
+                    unreachable!();
+                }
+            }
+        }
+
+        let mut vec = Vec::<Operand>::new();
+
+        for ue in 0_u8..=255_u8 {
+            if !hash_set.contains(&ue) {
+                vec.push(Operand::Char(CharOperand {
+                    char: char::from(ue),
+                    char_repetition: CharRepetition::N(1_usize),
+                }));
+            }
+        }
+
+        vec
+    }
+
+    // TODO
+    // This should be optimized
+    pub fn generate_for_translation(
+        complement: bool,
+        string1_operands: Vec<Operand>,
+        string2_operands: Vec<Operand>,
+    ) -> Result<ForTranslation, Box<dyn Error>> {
+        let string1_operands_to_use = if complement {
+            complement_operands(&string1_operands)
+        } else {
+            string1_operands
+        };
+
+        let mut char_repeating_total = 0_usize;
+
+        let mut string1_operands_flattened = Vec::<Operand>::new();
+
+        for op in string1_operands_to_use {
+            match op {
+                Operand::Char(CharOperand {
+                    char_repetition,
+                    char,
+                }) => match char_repetition {
+                    CharRepetition::AsManyAsNeeded => {
+                        return Err(Box::from(
+                            "tr: the [c*] repeat construct may not appear in string1".to_owned(),
+                        ));
+                    }
+                    CharRepetition::N(n) => {
+                        char_repeating_total = char_repeating_total
+                            .checked_add(n)
+                            .ok_or("Arithmetic overflow")?;
+
+                        let new_char = Operand::Char(CharOperand {
+                            char,
+                            char_repetition: CharRepetition::N(1_usize),
+                        });
+
+                        for _ in 0_usize..n {
+                            string1_operands_flattened.push(new_char.clone());
+                        }
+                    }
+                },
+                op @ Operand::Equiv(_) => {
+                    // Take up one position?
+                    string1_operands_flattened.push(op);
+                }
+            }
+        }
+
+        // TODO
+        // Indexing is a workaround for the borrow checker
+        let mut as_many_as_needed_index = Option::<usize>::None;
+
+        let mut replacement_char_repeating_total = 0_usize;
+
+        for (us, op) in string2_operands.iter().enumerate() {
+            match op {
+                Operand::Char(CharOperand {
+                    char_repetition, ..
+                }) => match char_repetition {
+                    CharRepetition::AsManyAsNeeded => {
+                        if as_many_as_needed_index.is_some() {
+                            // TODO
+                            // Do this validation earlier?
+                            return Err(Box::from(
+                                "tr: only one [c*] repeat construct may appear in string2"
+                                    .to_owned(),
+                            ));
+                        }
+
+                        as_many_as_needed_index = Some(us);
+                    }
+                    CharRepetition::N(n) => {
+                        replacement_char_repeating_total = replacement_char_repeating_total
+                            .checked_add(*n)
+                            .ok_or("Arithmetic overflow")?;
+                    }
+                },
+                Operand::Equiv { .. } => {
+                    // TODO
+                    // Do this validation earlier?
+                    return Err(Box::from(
+                        "tr: [=c=] expressions may not appear in string2 when translating"
+                            .to_owned(),
+                    ));
+                }
+            }
+        }
+
+        let string2_operands_to_use = if replacement_char_repeating_total < char_repeating_total {
+            let leftover = char_repeating_total
+                .checked_sub(replacement_char_repeating_total)
+                .ok_or("Arithmetic overflow")?;
+
+            // TODO
+            // to_vec
+            let mut string2_operands_with_leftover = string2_operands.to_vec();
+
+            match as_many_as_needed_index {
+                Some(us) => {
+                    let op = string2_operands_with_leftover
+                        .get_mut(us)
+                        .ok_or("Indexing failed")?;
+
+                    match op {
+                        Operand::Char(CharOperand {
+                            ref mut char_repetition,
+                            ..
+                        }) => {
+                            *char_repetition = CharRepetition::N(leftover);
+                        }
+                        Operand::Equiv(_) => {
+                            unreachable!();
+                        }
+                    }
+                }
+                None => {
+                    let mut n_updated = false;
+
+                    for op in string2_operands_with_leftover.iter_mut().rev() {
+                        if let Operand::Char(CharOperand {
+                            char_repetition: CharRepetition::N(ref mut n),
+                            ..
+                        }) = op
+                        {
+                            let n_plus_leftover =
+                                n.checked_add(leftover).ok_or("Arithmetic overflow")?;
+
+                            *n = n_plus_leftover;
+
+                            n_updated = true;
+
+                            break;
+                        }
+                    }
+
+                    assert!(n_updated);
+                }
+            }
+
+            string2_operands_with_leftover
+        } else {
+            string2_operands
+        };
+
+        // TODO
+        // Capacity
+        let mut string2_operands_to_use_flattened = Vec::<char>::new();
+
+        for op in string2_operands_to_use {
+            match op {
+                Operand::Char(CharOperand {
+                    char_repetition,
+                    char,
+                }) => match char_repetition {
+                    CharRepetition::N(n) => {
+                        for _ in 0_usize..n {
+                            string2_operands_to_use_flattened.push(char);
+                        }
+                    }
+                    CharRepetition::AsManyAsNeeded => {
+                        // The "[c*]" construct was not needed, ignore it
+                    }
+                },
+                Operand::Equiv(_) => {
+                    unreachable!();
+                }
+            }
+        }
+
+        // TODO
+        // Capacities
+        let mut equiv_translation_chars = Vec::<(char, char)>::new();
+        let mut multi_byte_translation_hash_map = HashMap::<char, char>::new();
+        let mut single_byte_translation_lookup_table = [Option::<char>::None; 128_usize];
+
+        let mut encoding_buffer = [0_u8; 4_usize];
+
+        let mut add_normal_char = |ch: char, replacement_char: char| {
+            let sl = ch.encode_utf8(&mut encoding_buffer);
+
+            match sl.as_bytes() {
+                &[ue] => {
+                    single_byte_translation_lookup_table[usize::from(ue)] = Some(replacement_char);
+                }
+                _ => {
+                    multi_byte_translation_hash_map.insert(ch, replacement_char);
+                }
+            }
+        };
+
+        for (us, op) in string1_operands_flattened.into_iter().enumerate() {
+            let replacement_char = *(string2_operands_to_use_flattened
+                .get(us)
+                .ok_or("Indexing failed")?);
+
+            match op {
+                Operand::Char(CharOperand {
+                    char,
+                    char_repetition,
+                }) => {
+                    // TODO
+                    // Enforce with types
+                    assert!(matches!(char_repetition, CharRepetition::N(1_usize)));
+
+                    add_normal_char(char, replacement_char);
+                }
+                Operand::Equiv(EquivOperand { char }) => {
+                    equiv_translation_chars.push((char, replacement_char));
+
+                    // TODO
+                    // Fix for `tr_equivalence_class_low_priority`
+                    add_normal_char(char, replacement_char);
+                }
+            }
+        }
+
+        let for_translate = ForTranslation {
+            equiv_translation_chars,
+            multi_byte_translation_hash_map,
+            single_byte_translation_lookup_table: Box::new(single_byte_translation_lookup_table),
+        };
+
+        Ok(for_translate)
+    }
+
+    pub fn generate_for_removal(
+        complement: bool,
+        string1_operands: Vec<Operand>,
+    ) -> Result<ForRemoval, Box<dyn Error>> {
+        let mut equiv_removal_chars = Vec::<char>::new();
+        let mut multi_byte_removal_hash_set = HashSet::<char>::new();
+        let mut single_byte_removal_lookup_table = [false; 128_usize];
+
+        let mut encoding_buffer = [0_u8; 4_usize];
+
+        for op in string1_operands {
+            match op {
+                Operand::Char(CharOperand {
+                    char_repetition,
+                    char,
+                }) => match char_repetition {
+                    CharRepetition::AsManyAsNeeded => {
+                        return Err(Box::from(
+                            "tr: the [c*] repeat construct may not appear in string1".to_owned(),
+                        ));
+                    }
+                    CharRepetition::N(_) => {
+                        let sl = char.encode_utf8(&mut encoding_buffer);
+
+                        match sl.as_bytes() {
+                            &[ue] => {
+                                single_byte_removal_lookup_table[usize::from(ue)] = true;
+                            }
+                            _ => {
+                                multi_byte_removal_hash_set.insert(char);
+                            }
+                        }
+                    }
+                },
+                Operand::Equiv(EquivOperand { char }) => {
+                    equiv_removal_chars.push(char);
+                }
+            }
+        }
+
+        let for_removal = ForRemoval {
+            complement,
+            multi_byte_removal_hash_set,
+            single_byte_removal_lookup_table: Box::new(single_byte_removal_lookup_table),
+            equiv_removal_chars,
+        };
+
+        Ok(for_removal)
+    }
+
+    pub struct ForTranslation {
+        pub equiv_translation_chars: Vec<(char, char)>,
+        pub multi_byte_translation_hash_map: HashMap<char, char>,
+        pub single_byte_translation_lookup_table: Box<[Option<char>; 128_usize]>,
+    }
+
+    impl ForTranslation {
+        pub fn char_has_translation(&self, ch: char, char_slice: &[u8]) -> Option<char> {
+            let first_check = match char_slice {
+                &[ue] => self.single_byte_translation_lookup_table[usize::from(ue)],
+                _ => self.multi_byte_translation_hash_map.get(&ch).copied(),
+            };
+
+            match first_check {
+                op @ Some(_) => {
+                    return op;
+                }
+                None => {
+                    for (cha, char) in &self.equiv_translation_chars {
+                        if compare_deunicoded_chars(ch, *cha) {
+                            return Some(*char);
+                        }
+                    }
+                }
+            }
+
+            None
+        }
+    }
+
+    pub struct ForRemoval {
+        complement: bool,
+        equiv_removal_chars: Vec<char>,
+        multi_byte_removal_hash_set: HashSet<char>,
+        single_byte_removal_lookup_table: Box<[bool; 128_usize]>,
+    }
+
+    impl ForRemoval {
+        pub fn char_matches(&self, ch: char, char_slice: &[u8]) -> bool {
+            let first_check = match char_slice {
+                &[ue] => self.single_byte_removal_lookup_table[usize::from(ue)],
+                _ => self.multi_byte_removal_hash_set.contains(&ch),
+            };
+
+            let first_check_to_use = if self.complement {
+                !first_check
+            } else {
+                first_check
+            };
+
+            if first_check_to_use {
+                return true;
+            }
+
+            // Second check
+            for &cha in &self.equiv_removal_chars {
+                let second_check = compare_deunicoded_chars(ch, cha);
+
+                let second_check_to_use = if self.complement {
+                    !second_check
+                } else {
+                    second_check
+                };
+
+                if second_check_to_use {
+                    return true;
+                }
+            }
+
+            false
+        }
+    }
+}
+
+mod transformation {
+    use std::error::Error;
+    use std::io::{self, ErrorKind, Read, Write};
+
+    pub trait Transformation {
+        fn transform(&mut self, input: &str, output: &mut Vec<u8>);
+    }
+
+    impl dyn Transformation {
+        pub fn streaming_transform(&mut self) -> Result<(), Box<dyn Error>> {
+            // Must be big enough to hold at least one UTF-8 character
+            const SIZE: usize = 8_usize * 1_024_usize;
+
+            // Buffers
+            let mut input = vec![0_u8; SIZE];
+            let mut output = Vec::<u8>::with_capacity(SIZE);
+            let mut temporary_leftover = Vec::<u8>::new();
+
+            // TODO
+            // Improve this
+            let mut leftover_bytes = 0_usize;
+
+            let mut stdin_lock = io::stdin().lock();
+            let mut stdout_lock = io::stdout().lock();
+
+            loop {
+                let buf = &mut input[leftover_bytes..];
+
+                match stdin_lock.read(buf) {
+                    Ok(0_usize) => {
+                        assert!(leftover_bytes == 0_usize);
+
+                        assert!(!buf.is_empty());
+
+                        break;
+                    }
+                    Ok(us) => {
+                        let read_slice = &input[..(leftover_bytes + us)];
+
+                        let for_transform = match std::str::from_utf8(read_slice) {
+                            Ok(st) => st,
+                            Err(ut) => {
+                                let (valid, remainder) = read_slice.split_at(ut.valid_up_to());
+
+                                temporary_leftover.extend_from_slice(remainder);
+
+                                // https://doc.rust-lang.org/std/str/struct.Utf8Error.html#examples
+                                unsafe { std::str::from_utf8_unchecked(valid) }
+                            }
+                        };
+
+                        self.transform(for_transform, &mut output);
+
+                        // TODO
+                        // Do this in a nicer way
+                        for (us, ue) in temporary_leftover.iter().enumerate() {
+                            // TODO
+                            // Indexing
+                            input[us] = *ue;
+                        }
+
+                        leftover_bytes = temporary_leftover.len();
+
+                        temporary_leftover.clear();
+
+                        stdout_lock.write_all(&output)?;
+
+                        output.clear();
+                    }
+                    Err(er) => {
+                        if er.kind() == ErrorKind::Interrupted {
+                            continue;
+                        }
+
+                        return Err(Box::from(er));
+                    }
+                }
+            }
+
+            Ok(())
+        }
+    }
+
+    pub mod delete {
+        use super::Transformation;
+        use crate::setup::ForRemoval;
+
+        struct PreviousChar<'a> {
+            char: char,
+            bytes_to_print: Option<&'a [u8]>,
+        }
+
+        impl PreviousChar<'_> {
+            fn get_owned(&self) -> PreviousCharOwned {
+                PreviousCharOwned {
+                    char: self.char,
+                    bytes_to_print: self.bytes_to_print.map(|sl| sl.to_vec()),
+                }
+            }
+        }
+
+        #[derive(Clone)]
+        pub struct PreviousCharOwned {
+            char: char,
+            bytes_to_print: Option<Vec<u8>>,
+        }
+
+        impl<'a> PreviousCharOwned {
+            fn get_borrowed(&'a self) -> PreviousChar<'a> {
+                PreviousChar {
+                    char: self.char,
+                    bytes_to_print: self.bytes_to_print.as_deref(),
+                }
+            }
+        }
+
+        #[derive(Clone)]
+        pub enum DeleteState {
+            Start,
+            Continuation(PreviousCharOwned),
+        }
+
+        pub struct DeleteTransformation {
+            pub delete_state: DeleteState,
+            pub for_removal: ForRemoval,
+        }
+
+        impl Transformation for DeleteTransformation {
+            fn transform(&mut self, input: &str, output: &mut Vec<u8>) {
+                let mut chars = input.chars();
+
+                let mut encoding_buffer = [0_u8; 4_usize];
+
+                let previous_char_owned = match self.delete_state.to_owned() {
+                    DeleteState::Continuation(pr) => pr,
+                    DeleteState::Start => {
+                        // First character
+                        if let Some(ch) = chars.next() {
+                            let char_slice = ch.encode_utf8(&mut encoding_buffer).as_bytes();
+
+                            let delete_char = self.for_removal.char_matches(ch, char_slice);
+
+                            if delete_char {
+                                PreviousCharOwned {
+                                    char: ch,
+                                    bytes_to_print: None,
+                                }
+                            } else {
+                                output.extend_from_slice(char_slice);
+
+                                PreviousCharOwned {
+                                    bytes_to_print: Some(char_slice.to_vec()),
+                                    char: ch,
+                                }
+                            }
+                        } else {
+                            // No input to process
+                            return;
+                        }
+                    }
+                };
+
+                let mut previous_char = previous_char_owned.get_borrowed();
+
+                for ch in chars {
+                    // Optimization for repeated deletions
+                    // TODO
+                    // Track state across calls to `transform`
+                    if ch == previous_char.char {
+                        if let Some(sl) = previous_char.bytes_to_print {
+                            output.extend_from_slice(sl);
+                        }
+
+                        continue;
+                    }
+
+                    let char_slice = ch.encode_utf8(&mut encoding_buffer).as_bytes();
+
+                    let delete_char = self.for_removal.char_matches(ch, char_slice);
+
+                    previous_char = if delete_char {
+                        PreviousChar {
+                            char: ch,
+                            bytes_to_print: None,
+                        }
+                    } else {
+                        output.extend_from_slice(char_slice);
+
+                        PreviousChar {
+                            char: ch,
+                            bytes_to_print: Some(char_slice),
+                        }
+                    };
+                }
+
+                self.delete_state = DeleteState::Continuation(previous_char.get_owned());
+            }
+        }
+    }
+
+    pub mod delete_and_squeeze {
+        use super::Transformation;
+        use crate::setup::ForRemoval;
+
+        enum Behavior<'a> {
+            Delete,
+            Print {
+                squeeze_char: bool,
+                bytes_to_print: &'a [u8],
+            },
+        }
+
+        #[derive(Clone)]
+        pub enum BehaviorOwned {
+            Delete,
+            Print {
+                squeeze_char: bool,
+                bytes_to_print: Vec<u8>,
+            },
+        }
+
+        #[derive(Clone)]
+        pub struct LastPrintedChar {
+            char: char,
+            squeeze_char: bool,
+        }
+
+        pub struct PreviousChar<'a> {
+            char: char,
+            on_consecutive_appearance: Behavior<'a>,
+        }
+
+        impl PreviousChar<'_> {
+            fn get_owned(&self) -> PreviousCharOwned {
+                PreviousCharOwned {
+                    char: self.char,
+                    on_consecutive_appearance: match self.on_consecutive_appearance {
+                        Behavior::Delete => BehaviorOwned::Delete,
+                        Behavior::Print {
+                            squeeze_char,
+                            bytes_to_print,
+                        } => BehaviorOwned::Print {
+                            squeeze_char,
+                            bytes_to_print: bytes_to_print.to_vec(),
+                        },
+                    },
+                }
+            }
+        }
+
+        #[derive(Clone)]
+        pub struct PreviousCharOwned {
+            char: char,
+            on_consecutive_appearance: BehaviorOwned,
+        }
+
+        impl<'a> PreviousCharOwned {
+            fn get_borrowed(&'a self) -> PreviousChar<'a> {
+                PreviousChar {
+                    char: self.char,
+                    on_consecutive_appearance: match &self.on_consecutive_appearance {
+                        BehaviorOwned::Delete => Behavior::Delete,
+                        BehaviorOwned::Print {
+                            squeeze_char,
+                            bytes_to_print,
+                        } => Behavior::Print {
+                            squeeze_char: *squeeze_char,
+                            bytes_to_print,
+                        },
+                    },
+                }
+            }
+        }
+
+        pub enum DeleteAndSqueezeState {
+            Start,
+            Continuation(Option<LastPrintedChar>, PreviousCharOwned),
+        }
+
+        pub struct DeleteAndSqueezeTransformation {
+            pub delete_and_squeeze_state: DeleteAndSqueezeState,
+            pub delete: ForRemoval,
+            pub squeeze: ForRemoval,
+        }
+
+        impl Transformation for DeleteAndSqueezeTransformation {
+            fn transform(&mut self, input: &str, output: &mut Vec<u8>) {
+                let mut chars = input.chars();
+
+                let mut encoding_buffer = [0_u8; 4_usize];
+
+                // TODO
+                // to_owned()
+                let (mut last_printed_char_option, previous_char_state_owned) = match &self
+                    .delete_and_squeeze_state
+                {
+                    DeleteAndSqueezeState::Continuation(op, pr) => (op.to_owned(), pr.to_owned()),
+                    DeleteAndSqueezeState::Start => {
+                        // First character
+                        if let Some(ch) = chars.next() {
+                            let sl = ch.encode_utf8(&mut encoding_buffer).as_bytes();
+
+                            let (op, behavior) = if self.delete.char_matches(ch, sl) {
+                                // Do not print anything
+                                (None, BehaviorOwned::Delete)
+                            } else {
+                                let squeeze_char = self.squeeze.char_matches(ch, sl);
+
+                                output.extend_from_slice(sl);
+
+                                (
+                                    Some(LastPrintedChar {
+                                        char: ch,
+                                        squeeze_char,
+                                    }),
+                                    BehaviorOwned::Print {
+                                        squeeze_char,
+                                        bytes_to_print: sl.to_vec(),
+                                    },
+                                )
+                            };
+
+                            (
+                                op,
+                                PreviousCharOwned {
+                                    char: ch,
+                                    on_consecutive_appearance: behavior,
+                                },
+                            )
+                        } else {
+                            // No input to process
+                            return;
+                        }
+                    }
+                };
+
+                let mut previous_char_state = previous_char_state_owned.get_borrowed();
+
+                for ch in chars {
+                    if ch == previous_char_state.char {
+                        match previous_char_state.on_consecutive_appearance {
+                            Behavior::Delete => {
+                                // Do not print anything
+                            }
+                            Behavior::Print {
+                                squeeze_char,
+                                bytes_to_print,
+                            } => {
+                                if squeeze_char {
+                                    match last_printed_char_option {
+                                        Some(LastPrintedChar { char, .. }) if ch == char => {
+                                            // Do not print anything
+                                        }
+                                        _ => {
+                                            output.extend_from_slice(bytes_to_print);
+                                        }
+                                    }
+                                } else {
+                                    output.extend_from_slice(bytes_to_print);
+                                }
+                            }
+                        }
+
+                        continue;
+                    }
+
+                    let char_slice = ch.encode_utf8(&mut encoding_buffer).as_bytes();
+
+                    /* #region Delete */
+                    let delete_char = self.delete.char_matches(ch, char_slice);
+
+                    if delete_char {
+                        previous_char_state = PreviousChar {
+                            char: ch,
+                            on_consecutive_appearance: Behavior::Delete,
+                        };
+
+                        continue;
+                    }
+                    /* #endregion */
+
+                    /* #region Squeeze */
+                    match last_printed_char_option {
+                        Some(LastPrintedChar { char, squeeze_char }) if ch == char => {
+                            if squeeze_char {
+                                // Squeeze
+                            } else {
+                                // Do not squeeze
+                                output.extend_from_slice(char_slice);
+                            }
+
+                            previous_char_state = PreviousChar {
+                                char: ch,
+                                on_consecutive_appearance: Behavior::Print {
+                                    squeeze_char,
+                                    bytes_to_print: char_slice,
+                                },
+                            };
+                        }
+                        _ => {
+                            let squeeze_char = self.squeeze.char_matches(ch, char_slice);
+
+                            previous_char_state = PreviousChar {
+                                char: ch,
+                                on_consecutive_appearance: Behavior::Print {
+                                    squeeze_char,
+                                    bytes_to_print: char_slice,
+                                },
+                            };
+
+                            last_printed_char_option = Some(LastPrintedChar {
+                                char: ch,
+                                squeeze_char,
+                            });
+
+                            output.extend_from_slice(char_slice);
+                        }
+                    }
+                    /* #endregion */
+                }
+
+                self.delete_and_squeeze_state = DeleteAndSqueezeState::Continuation(
+                    last_printed_char_option,
+                    previous_char_state.get_owned(),
+                );
+            }
+        }
+    }
+
+    pub mod squeeze {
+        use super::Transformation;
+        use crate::setup::ForRemoval;
+
+        pub struct PreviousChar {
+            char: char,
+            squeeze_char: bool,
+            bytes_to_print: Vec<u8>,
+        }
+
+        pub enum SqueezeState {
+            Start,
+            Continuation(PreviousChar),
+        }
+
+        pub struct SqueezeTransformation {
+            pub for_removal: ForRemoval,
+            pub squeeze_state: SqueezeState,
+        }
+
+        impl Transformation for SqueezeTransformation {
+            fn transform(&mut self, input: &str, output: &mut Vec<u8>) {
+                let mut chars = input.chars();
+
+                let mut encoding_buffer = [0_u8; 4_usize];
+
+                // TODO
+                // Improve code style
+                let (
+                    mut previous_char,
+                    mut previous_char_squeeze_char,
+                    mut previous_char_bytes_to_print,
+                ) = match &self.squeeze_state {
+                    SqueezeState::Continuation(sq) => {
+                        (sq.char, sq.squeeze_char, sq.bytes_to_print.as_slice())
+                    }
+                    SqueezeState::Start => {
+                        // First character
+                        let Some(char) = chars.next() else {
+                            // No input to process
+                            return;
+                        };
+
+                        let char_slice = char.encode_utf8(&mut encoding_buffer).as_bytes();
+
+                        // Add the first char
+                        output.extend_from_slice(char_slice);
+
+                        let squeeze_char = self.for_removal.char_matches(char, char_slice);
+
+                        (char, squeeze_char, char_slice)
+                    }
+                };
+
+                for ch in chars {
+                    if ch == previous_char {
+                        if !previous_char_squeeze_char {
+                            output.extend_from_slice(previous_char_bytes_to_print);
+                        }
+
+                        continue;
+                    }
+
+                    let char_slice = ch.encode_utf8(&mut encoding_buffer).as_bytes();
+
+                    output.extend_from_slice(char_slice);
+
+                    // Atomic, do all of these or none
+                    {
+                        previous_char = ch;
+                        previous_char_bytes_to_print = char_slice;
+                        previous_char_squeeze_char = self.for_removal.char_matches(ch, char_slice);
+                    }
+                }
+
+                // Persist state for handling of next chunk
+                self.squeeze_state = SqueezeState::Continuation(PreviousChar {
+                    bytes_to_print: previous_char_bytes_to_print.to_vec(),
+                    char: previous_char,
+                    squeeze_char: previous_char_squeeze_char,
+                });
+            }
+        }
+    }
+
+    pub mod squeeze_and_translate {
+        use super::Transformation;
+        use crate::setup::ForTranslation;
+
+        #[derive(Clone)]
+        pub struct PreviousChar {
+            char: char,
+            translate_char: Option<char>,
+            last_printed_bytes: Vec<u8>,
+        }
+
+        pub enum SqueezeAndTranslateState {
+            Start,
+            Continuation(PreviousChar),
+        }
+
+        pub struct SqueezeAndTranslateTransformation {
+            pub for_translation: ForTranslation,
+            pub squeeze_and_translate_state: SqueezeAndTranslateState,
+        }
+
+        impl Transformation for SqueezeAndTranslateTransformation {
+            fn transform(&mut self, input: &str, output: &mut Vec<u8>) {
+                let mut chars = input.chars();
+
+                let mut encoding_buffer = [0_u8; 4_usize];
+
+                let mut previous_char = match &self.squeeze_and_translate_state {
+                    SqueezeAndTranslateState::Continuation(pr) => pr.to_owned(),
+                    SqueezeAndTranslateState::Start => {
+                        // First character
+                        let Some(char) = chars.next() else {
+                            // No input to process
+                            return;
+                        };
+
+                        let char_vec = char.encode_utf8(&mut encoding_buffer).as_bytes().to_vec();
+
+                        let translate_char =
+                            self.for_translation.char_has_translation(char, &char_vec);
+
+                        let char_vec_to_use = match translate_char {
+                            Some(replacement_char) => {
+                                let replacement_char_str =
+                                    replacement_char.encode_utf8(&mut encoding_buffer);
+
+                                replacement_char_str.as_bytes().to_vec()
+                            }
+                            None => char_vec.clone(),
+                        };
+
+                        // Add the first char
+                        output.extend_from_slice(char_vec_to_use.as_slice());
+
+                        PreviousChar {
+                            char,
+                            last_printed_bytes: char_vec_to_use,
+                            translate_char,
+                        }
+                    }
+                };
+
+                for ch in chars {
+                    if ch == previous_char.char {
+                        if previous_char.translate_char.is_some() {
+                            // Have the same translation because they're the same character, so will need to be squeezed
+                        } else {
+                            // Fast path for repeated, non-squeezed characters
+                            output.extend_from_slice(previous_char.last_printed_bytes.as_slice());
+                        }
+
+                        continue;
+                    }
+
+                    let char_slice = ch.encode_utf8(&mut encoding_buffer).as_bytes();
+
+                    let translate_char = self.for_translation.char_has_translation(ch, char_slice);
+
+                    match (translate_char, previous_char.translate_char) {
+                        (Some(ch), Some(cha)) if ch == cha => {
+                            // Squeeze if not the same character as the last, but has the same translation
+                            previous_char.char = ch;
+
+                            continue;
+                        }
+                        _ => {}
+                    }
+
+                    let char_slice_to_use = match translate_char {
+                        Some(replacement_char) => {
+                            let replacement_char_str =
+                                replacement_char.encode_utf8(&mut encoding_buffer);
+
+                            replacement_char_str.as_bytes()
+                        }
+                        None => char_slice,
+                    };
+
+                    output.extend_from_slice(char_slice_to_use);
+
+                    previous_char.char = ch;
+                    previous_char.translate_char = translate_char;
+
+                    // TODO
+                    previous_char.last_printed_bytes.clear();
+                    previous_char
+                        .last_printed_bytes
+                        .extend_from_slice(char_slice_to_use);
+                }
+
+                // Persist state for handling of next chunk
+                // TODO
+                // Improve code style
+                self.squeeze_and_translate_state =
+                    SqueezeAndTranslateState::Continuation(previous_char);
+            }
+        }
+    }
+
+    pub mod translate {
+        use super::Transformation;
+        use crate::{compare_deunicoded_chars, setup::ForTranslation};
+
+        pub struct TranslateTransformation {
+            pub for_translation: ForTranslation,
+        }
+
+        impl Transformation for TranslateTransformation {
+            fn transform(&mut self, input: &str, output: &mut Vec<u8>) {
+                let mut encoding_buffer = [0_u8; 4_usize];
+
+                for ch in input.chars() {
+                    let char_slice = ch.encode_utf8(&mut encoding_buffer).as_bytes();
+
+                    let replacement_char_option = match char_slice {
+                        &[ue] => {
+                            self.for_translation.single_byte_translation_lookup_table
+                                [usize::from(ue)]
+                        }
+                        _ => self
+                            .for_translation
+                            .multi_byte_translation_hash_map
+                            .get(&ch)
+                            .copied(),
+                    };
+
+                    // TODO
+                    // What is the precedence of equivalence classes?
+                    // GNU Core Utilities de-prioritizes them
+
+                    // Only use equivalence classes if normal translation failed
+                    let replacement_char_option_to_use = match replacement_char_option {
+                        Some(cha) => Some(cha),
+                        None => {
+                            let mut op = Option::<char>::None;
+
+                            for (equiv_char, equiv_char_replacement) in
+                                &self.for_translation.equiv_translation_chars
+                            {
+                                if compare_deunicoded_chars(ch, *equiv_char) {
+                                    op = Some(*equiv_char_replacement);
+
+                                    break;
+                                }
+                            }
+
+                            op
+                        }
+                    };
+
+                    let for_output = match replacement_char_option_to_use {
+                        Some(replacement_char) => {
+                            let replacement_char_str =
+                                replacement_char.encode_utf8(&mut encoding_buffer);
+
+                            replacement_char_str.as_bytes()
+                        }
+                        None => char_slice,
+                    };
+
+                    output.extend_from_slice(for_output);
+                }
+            }
+        }
+    }
+}
+
+// TODO
+// No other implementations actually seem to do anything with equivalence classes:
+// they seem to just treat them as the parsed character (e.g. "[=a=]" is treated as "a").
+// Should this implementation continue to try to actually handle them?
+
+/// Compares two characters after normalizing them.
+/// This function uses the hypothetical `deunicode_char` function to normalize
+/// the input characters and then compares them for equality.
+/// # Arguments
+///
+/// * `char1` - The first character to compare.
+/// * `char2` - The second character to compare.
+///
+/// # Returns
+///
+/// * `true` if the normalized characters are equal.
+/// * `false` otherwise.
+pub fn compare_deunicoded_chars(char1: char, char2: char) -> bool {
+    let normalized_char1 = deunicode_char(char1);
+    let normalized_char2 = deunicode_char(char2);
+
+    match (normalized_char1, normalized_char2) {
+        (Some(st), Some(str)) => st == str,
+        (None, None) => {
+            // Purpose of match: prevent this from being considered equal
+            false
+        }
+        _ => false,
+    }
 }


### PR DESCRIPTION
tr currently only handles ranges if they are the only construct in
the string containing them (see `contains_single_range`).

Add proper handling of ranges: multiple in one string, ranges from
one character type to another (e.g. tr -d '\060-9 A-Z').

Fix handling of octal sequences above \377.

Add validation to ensure equiv (in "[=equiv=]" constructs) is only
one character.

Add validation to ensure ranges are not "backwards" (the ending
character be must greater than or equal to the starting character).

Parse and validate string1 and string2 before reading from stdin.