### PR TITLE
Add "needless_borrow" lint

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,5 +43,3 @@ errno = "0.3"
 
 [workspace.lints]
 
-[workspace.lints.clippy]
-needless_borrow = "deny"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,3 +43,5 @@ errno = "0.3"
 
 [workspace.lints]
 
+[workspace.lints.clippy]
+needless_borrow = "deny"

--- a/file/file.rs
+++ b/file/file.rs
@@ -182,7 +182,7 @@ fn analyze_file(mut path: String, args: &Args, magic_files: &Vec<PathBuf>) {
             println!("{path}: empty");
             return;
         }
-        match get_type_from_magic_file_dbs(&PathBuf::from(&path), &magic_files) {
+        match get_type_from_magic_file_dbs(&PathBuf::from(&path), magic_files) {
             Some(f_type) => println!("{path}: {f_type}"),
             None => println!("{path}: data"),
         }

--- a/fs/df.rs
+++ b/fs/df.rs
@@ -239,7 +239,7 @@ impl Mount {
         let percentage_used = percentage_used.ceil() as u32;
 
         FieldsData {
-            fields: &fields,
+            fields: fields,
             source: &self.devname,
             size: total,
             used,

--- a/m4/tests/integration_test.rs
+++ b/m4/tests/integration_test.rs
@@ -109,7 +109,7 @@ fn run_command(input: &Path) -> std::process::Output {
 #[test]
 fn test_bsd() {
     init();
-    let output = run_command(&Path::new("fixtures/integration_tests/bsd.m4"));
+    let output = run_command(Path::new("fixtures/integration_tests/bsd.m4"));
 
     let test: TestSnapshot = read_test("fixtures/integration_tests/bsd.out");
     assert_eq!(
@@ -135,7 +135,7 @@ fn test_bsd() {
 #[test]
 fn test_bsd_math() {
     init();
-    let output = run_command(&Path::new("fixtures/integration_tests/bsd_math.m4"));
+    let output = run_command(Path::new("fixtures/integration_tests/bsd_math.m4"));
 
     let test: TestSnapshot = read_test("fixtures/integration_tests/bsd_math.out");
     assert_eq!(
@@ -160,7 +160,7 @@ fn test_bsd_math() {
 #[test]
 fn test_changecom() {
     init();
-    let output = run_command(&Path::new("fixtures/integration_tests/changecom.m4"));
+    let output = run_command(Path::new("fixtures/integration_tests/changecom.m4"));
 
     let test: TestSnapshot = read_test("fixtures/integration_tests/changecom.out");
     assert_eq!(
@@ -185,7 +185,7 @@ fn test_changecom() {
 #[test]
 fn test_changequote() {
     init();
-    let output = run_command(&Path::new("fixtures/integration_tests/changequote.m4"));
+    let output = run_command(Path::new("fixtures/integration_tests/changequote.m4"));
 
     let test: TestSnapshot = read_test("fixtures/integration_tests/changequote.out");
     assert_eq!(
@@ -210,7 +210,7 @@ fn test_changequote() {
 #[test]
 fn test_decr() {
     init();
-    let output = run_command(&Path::new("fixtures/integration_tests/decr.m4"));
+    let output = run_command(Path::new("fixtures/integration_tests/decr.m4"));
 
     let test: TestSnapshot = read_test("fixtures/integration_tests/decr.out");
     assert_eq!(
@@ -235,7 +235,7 @@ fn test_decr() {
 #[test]
 fn test_define() {
     init();
-    let output = run_command(&Path::new("fixtures/integration_tests/define.m4"));
+    let output = run_command(Path::new("fixtures/integration_tests/define.m4"));
 
     let test: TestSnapshot = read_test("fixtures/integration_tests/define.out");
     assert_eq!(
@@ -260,7 +260,7 @@ fn test_define() {
 #[test]
 fn test_define_args() {
     init();
-    let output = run_command(&Path::new("fixtures/integration_tests/define_args.args"));
+    let output = run_command(Path::new("fixtures/integration_tests/define_args.args"));
 
     let test: TestSnapshot = read_test("fixtures/integration_tests/define_args.out");
     assert_eq!(
@@ -286,7 +286,7 @@ fn test_define_args() {
 #[test]
 fn test_define_eval_order_unquoted() {
     init();
-    let output = run_command(&Path::new(
+    let output = run_command(Path::new(
         "fixtures/integration_tests/define_eval_order_unquoted.m4",
     ));
 
@@ -314,7 +314,7 @@ fn test_define_eval_order_unquoted() {
 #[test]
 fn test_define_eval_syntax_order_quoted_evaluated() {
     init();
-    let output = run_command(&Path::new(
+    let output = run_command(Path::new(
         "fixtures/integration_tests/define_eval_syntax_order_quoted_evaluated.m4",
     ));
 
@@ -342,7 +342,7 @@ fn test_define_eval_syntax_order_quoted_evaluated() {
 #[test]
 fn test_define_eval_syntax_order_quoted_unevaluated() {
     init();
-    let output = run_command(&Path::new(
+    let output = run_command(Path::new(
         "fixtures/integration_tests/define_eval_syntax_order_quoted_unevaluated.m4",
     ));
 
@@ -371,7 +371,7 @@ fn test_define_eval_syntax_order_quoted_unevaluated() {
 #[test]
 fn test_define_eval_syntax_order_unquoted() {
     init();
-    let output = run_command(&Path::new(
+    let output = run_command(Path::new(
         "fixtures/integration_tests/define_eval_syntax_order_unquoted.m4",
     ));
 
@@ -399,7 +399,7 @@ fn test_define_eval_syntax_order_unquoted() {
 #[test]
 fn test_define_hanging_quotes() {
     init();
-    let output = run_command(&Path::new(
+    let output = run_command(Path::new(
         "fixtures/integration_tests/define_hanging_quotes.m4",
     ));
 
@@ -426,7 +426,7 @@ fn test_define_hanging_quotes() {
 #[test]
 fn test_define_invalid_macro_name() {
     init();
-    let output = run_command(&Path::new(
+    let output = run_command(Path::new(
         "fixtures/integration_tests/define_invalid_macro_name.m4",
     ));
 
@@ -453,7 +453,7 @@ fn test_define_invalid_macro_name() {
 #[test]
 fn test_define_iterative() {
     init();
-    let output = run_command(&Path::new("fixtures/integration_tests/define_iterative.m4"));
+    let output = run_command(Path::new("fixtures/integration_tests/define_iterative.m4"));
 
     let test: TestSnapshot = read_test("fixtures/integration_tests/define_iterative.out");
     assert_eq!(
@@ -478,7 +478,7 @@ fn test_define_iterative() {
 #[test]
 fn test_define_iterative_2() {
     init();
-    let output = run_command(&Path::new(
+    let output = run_command(Path::new(
         "fixtures/integration_tests/define_iterative_2.m4",
     ));
 
@@ -505,7 +505,7 @@ fn test_define_iterative_2() {
 #[test]
 fn test_define_nested() {
     init();
-    let output = run_command(&Path::new("fixtures/integration_tests/define_nested.m4"));
+    let output = run_command(Path::new("fixtures/integration_tests/define_nested.m4"));
 
     let test: TestSnapshot = read_test("fixtures/integration_tests/define_nested.out");
     assert_eq!(
@@ -531,7 +531,7 @@ fn test_define_nested() {
 #[test]
 fn test_define_nested_first_arg() {
     init();
-    let output = run_command(&Path::new(
+    let output = run_command(Path::new(
         "fixtures/integration_tests/define_nested_first_arg.m4",
     ));
 
@@ -558,7 +558,7 @@ fn test_define_nested_first_arg() {
 #[test]
 fn test_define_number_parsing() {
     init();
-    let output = run_command(&Path::new(
+    let output = run_command(Path::new(
         "fixtures/integration_tests/define_number_parsing.m4",
     ));
 
@@ -583,7 +583,7 @@ fn test_define_number_parsing() {
 #[test]
 fn test_define_order_defined() {
     init();
-    let output = run_command(&Path::new(
+    let output = run_command(Path::new(
         "fixtures/integration_tests/define_order_defined.m4",
     ));
 
@@ -610,7 +610,7 @@ fn test_define_order_defined() {
 #[test]
 fn test_define_order_undefined() {
     init();
-    let output = run_command(&Path::new(
+    let output = run_command(Path::new(
         "fixtures/integration_tests/define_order_undefined.m4",
     ));
 
@@ -637,7 +637,7 @@ fn test_define_order_undefined() {
 #[test]
 fn test_define_parse_brackets() {
     init();
-    let output = run_command(&Path::new(
+    let output = run_command(Path::new(
         "fixtures/integration_tests/define_parse_brackets.m4",
     ));
 
@@ -662,7 +662,7 @@ fn test_define_parse_brackets() {
 #[test]
 fn test_define_pushpopdef_undefine() {
     init();
-    let output = run_command(&Path::new(
+    let output = run_command(Path::new(
         "fixtures/integration_tests/define_pushpopdef_undefine.m4",
     ));
 
@@ -689,7 +689,7 @@ fn test_define_pushpopdef_undefine() {
 #[test]
 fn test_define_quoted_number_stacked() {
     init();
-    let output = run_command(&Path::new(
+    let output = run_command(Path::new(
         "fixtures/integration_tests/define_quoted_number_stacked.m4",
     ));
 
@@ -715,7 +715,7 @@ fn test_define_quoted_number_stacked() {
 #[test]
 fn test_define_stacked() {
     init();
-    let output = run_command(&Path::new("fixtures/integration_tests/define_stacked.m4"));
+    let output = run_command(Path::new("fixtures/integration_tests/define_stacked.m4"));
 
     let test: TestSnapshot = read_test("fixtures/integration_tests/define_stacked.out");
     assert_eq!(
@@ -740,7 +740,7 @@ fn test_define_stacked() {
 #[test]
 fn test_define_undefine_order() {
     init();
-    let output = run_command(&Path::new(
+    let output = run_command(Path::new(
         "fixtures/integration_tests/define_undefine_order.m4",
     ));
 
@@ -767,7 +767,7 @@ fn test_define_undefine_order() {
 #[test]
 fn test_define_unquoted_number_arg() {
     init();
-    let output = run_command(&Path::new(
+    let output = run_command(Path::new(
         "fixtures/integration_tests/define_unquoted_number_arg.m4",
     ));
 
@@ -792,7 +792,7 @@ fn test_define_unquoted_number_arg() {
 #[test]
 fn test_defn() {
     init();
-    let output = run_command(&Path::new("fixtures/integration_tests/defn.m4"));
+    let output = run_command(Path::new("fixtures/integration_tests/defn.m4"));
 
     let test: TestSnapshot = read_test("fixtures/integration_tests/defn.out");
     assert_eq!(
@@ -817,7 +817,7 @@ fn test_defn() {
 #[test]
 fn test_divert() {
     init();
-    let output = run_command(&Path::new("fixtures/integration_tests/divert.m4"));
+    let output = run_command(Path::new("fixtures/integration_tests/divert.m4"));
 
     let test: TestSnapshot = read_test("fixtures/integration_tests/divert.out");
     assert_eq!(
@@ -842,7 +842,7 @@ fn test_divert() {
 #[test]
 fn test_divert_nested() {
     init();
-    let output = run_command(&Path::new("fixtures/integration_tests/divert_nested.m4"));
+    let output = run_command(Path::new("fixtures/integration_tests/divert_nested.m4"));
 
     let test: TestSnapshot = read_test("fixtures/integration_tests/divert_nested.out");
     assert_eq!(
@@ -867,7 +867,7 @@ fn test_divert_nested() {
 #[test]
 fn test_divert_nested_2() {
     init();
-    let output = run_command(&Path::new("fixtures/integration_tests/divert_nested_2.m4"));
+    let output = run_command(Path::new("fixtures/integration_tests/divert_nested_2.m4"));
 
     let test: TestSnapshot = read_test("fixtures/integration_tests/divert_nested_2.out");
     assert_eq!(
@@ -892,7 +892,7 @@ fn test_divert_nested_2() {
 #[test]
 fn test_divert_nested_3() {
     init();
-    let output = run_command(&Path::new("fixtures/integration_tests/divert_nested_3.m4"));
+    let output = run_command(Path::new("fixtures/integration_tests/divert_nested_3.m4"));
 
     let test: TestSnapshot = read_test("fixtures/integration_tests/divert_nested_3.out");
     assert_eq!(
@@ -917,7 +917,7 @@ fn test_divert_nested_3() {
 #[test]
 fn test_divert_nested_4() {
     init();
-    let output = run_command(&Path::new("fixtures/integration_tests/divert_nested_4.m4"));
+    let output = run_command(Path::new("fixtures/integration_tests/divert_nested_4.m4"));
 
     let test: TestSnapshot = read_test("fixtures/integration_tests/divert_nested_4.out");
     assert_eq!(
@@ -942,7 +942,7 @@ fn test_divert_nested_4() {
 #[test]
 fn test_dnl() {
     init();
-    let output = run_command(&Path::new("fixtures/integration_tests/dnl.m4"));
+    let output = run_command(Path::new("fixtures/integration_tests/dnl.m4"));
 
     let test: TestSnapshot = read_test("fixtures/integration_tests/dnl.out");
     assert_eq!(
@@ -967,7 +967,7 @@ fn test_dnl() {
 #[test]
 fn test_dnl_nested() {
     init();
-    let output = run_command(&Path::new("fixtures/integration_tests/dnl_nested.m4"));
+    let output = run_command(Path::new("fixtures/integration_tests/dnl_nested.m4"));
 
     let test: TestSnapshot = read_test("fixtures/integration_tests/dnl_nested.out");
     assert_eq!(
@@ -992,7 +992,7 @@ fn test_dnl_nested() {
 #[test]
 fn test_dumpdef() {
     init();
-    let output = run_command(&Path::new("fixtures/integration_tests/dumpdef.m4"));
+    let output = run_command(Path::new("fixtures/integration_tests/dumpdef.m4"));
 
     let test: TestSnapshot = read_test("fixtures/integration_tests/dumpdef.out");
     assert_eq!(
@@ -1017,7 +1017,7 @@ fn test_dumpdef() {
 #[test]
 fn test_dumpdef_notexist() {
     init();
-    let output = run_command(&Path::new("fixtures/integration_tests/dumpdef_notexist.m4"));
+    let output = run_command(Path::new("fixtures/integration_tests/dumpdef_notexist.m4"));
 
     let test: TestSnapshot = read_test("fixtures/integration_tests/dumpdef_notexist.out");
     assert_eq!(
@@ -1040,7 +1040,7 @@ fn test_dumpdef_notexist() {
 #[test]
 fn test_eval() {
     init();
-    let output = run_command(&Path::new("fixtures/integration_tests/eval.m4"));
+    let output = run_command(Path::new("fixtures/integration_tests/eval.m4"));
 
     let test: TestSnapshot = read_test("fixtures/integration_tests/eval.out");
     assert_eq!(
@@ -1065,7 +1065,7 @@ fn test_eval() {
 #[test]
 fn test_evaluation_order() {
     init();
-    let output = run_command(&Path::new("fixtures/integration_tests/evaluation_order.m4"));
+    let output = run_command(Path::new("fixtures/integration_tests/evaluation_order.m4"));
 
     let test: TestSnapshot = read_test("fixtures/integration_tests/evaluation_order.out");
     assert_eq!(
@@ -1090,7 +1090,7 @@ fn test_evaluation_order() {
 #[test]
 fn test_file() {
     init();
-    let output = run_command(&Path::new("fixtures/integration_tests/file.m4"));
+    let output = run_command(Path::new("fixtures/integration_tests/file.m4"));
 
     let test: TestSnapshot = read_test("fixtures/integration_tests/file.out");
     assert_eq!(
@@ -1115,7 +1115,7 @@ fn test_file() {
 #[test]
 fn test_forloop_nested() {
     init();
-    let output = run_command(&Path::new("fixtures/integration_tests/forloop_nested.m4"));
+    let output = run_command(Path::new("fixtures/integration_tests/forloop_nested.m4"));
 
     let test: TestSnapshot = read_test("fixtures/integration_tests/forloop_nested.out");
     assert_eq!(
@@ -1140,7 +1140,7 @@ fn test_forloop_nested() {
 #[test]
 fn test_forloop_simple() {
     init();
-    let output = run_command(&Path::new("fixtures/integration_tests/forloop_simple.m4"));
+    let output = run_command(Path::new("fixtures/integration_tests/forloop_simple.m4"));
 
     let test: TestSnapshot = read_test("fixtures/integration_tests/forloop_simple.out");
     assert_eq!(
@@ -1165,7 +1165,7 @@ fn test_forloop_simple() {
 #[test]
 fn test_ifdef() {
     init();
-    let output = run_command(&Path::new("fixtures/integration_tests/ifdef.m4"));
+    let output = run_command(Path::new("fixtures/integration_tests/ifdef.m4"));
 
     let test: TestSnapshot = read_test("fixtures/integration_tests/ifdef.out");
     assert_eq!(
@@ -1190,7 +1190,7 @@ fn test_ifdef() {
 #[test]
 fn test_ifelse() {
     init();
-    let output = run_command(&Path::new("fixtures/integration_tests/ifelse.m4"));
+    let output = run_command(Path::new("fixtures/integration_tests/ifelse.m4"));
 
     let test: TestSnapshot = read_test("fixtures/integration_tests/ifelse.out");
     assert_eq!(
@@ -1215,7 +1215,7 @@ fn test_ifelse() {
 #[test]
 fn test_include() {
     init();
-    let output = run_command(&Path::new("fixtures/integration_tests/include.m4"));
+    let output = run_command(Path::new("fixtures/integration_tests/include.m4"));
 
     let test: TestSnapshot = read_test("fixtures/integration_tests/include.out");
     assert_eq!(
@@ -1240,7 +1240,7 @@ fn test_include() {
 #[test]
 fn test_include_divert() {
     init();
-    let output = run_command(&Path::new("fixtures/integration_tests/include_divert.m4"));
+    let output = run_command(Path::new("fixtures/integration_tests/include_divert.m4"));
 
     let test: TestSnapshot = read_test("fixtures/integration_tests/include_divert.out");
     assert_eq!(
@@ -1265,7 +1265,7 @@ fn test_include_divert() {
 #[test]
 fn test_incr() {
     init();
-    let output = run_command(&Path::new("fixtures/integration_tests/incr.m4"));
+    let output = run_command(Path::new("fixtures/integration_tests/incr.m4"));
 
     let test: TestSnapshot = read_test("fixtures/integration_tests/incr.out");
     assert_eq!(
@@ -1290,7 +1290,7 @@ fn test_incr() {
 #[test]
 fn test_index() {
     init();
-    let output = run_command(&Path::new("fixtures/integration_tests/index.m4"));
+    let output = run_command(Path::new("fixtures/integration_tests/index.m4"));
 
     let test: TestSnapshot = read_test("fixtures/integration_tests/index.out");
     assert_eq!(
@@ -1315,7 +1315,7 @@ fn test_index() {
 #[test]
 fn test_index_too_few_args() {
     init();
-    let output = run_command(&Path::new(
+    let output = run_command(Path::new(
         "fixtures/integration_tests/index_too_few_args.m4",
     ));
 
@@ -1340,7 +1340,7 @@ fn test_index_too_few_args() {
 #[test]
 fn test_len() {
     init();
-    let output = run_command(&Path::new("fixtures/integration_tests/len.m4"));
+    let output = run_command(Path::new("fixtures/integration_tests/len.m4"));
 
     let test: TestSnapshot = read_test("fixtures/integration_tests/len.out");
     assert_eq!(
@@ -1365,7 +1365,7 @@ fn test_len() {
 #[test]
 fn test_m4exit_error() {
     init();
-    let output = run_command(&Path::new("fixtures/integration_tests/m4exit_error.m4"));
+    let output = run_command(Path::new("fixtures/integration_tests/m4exit_error.m4"));
 
     let test: TestSnapshot = read_test("fixtures/integration_tests/m4exit_error.out");
     assert_eq!(
@@ -1390,7 +1390,7 @@ fn test_m4exit_error() {
 #[test]
 fn test_m4exit_no_args() {
     init();
-    let output = run_command(&Path::new("fixtures/integration_tests/m4exit_no_args.m4"));
+    let output = run_command(Path::new("fixtures/integration_tests/m4exit_no_args.m4"));
 
     let test: TestSnapshot = read_test("fixtures/integration_tests/m4exit_no_args.out");
     assert_eq!(
@@ -1415,7 +1415,7 @@ fn test_m4exit_no_args() {
 #[test]
 fn test_m4exit_success() {
     init();
-    let output = run_command(&Path::new("fixtures/integration_tests/m4exit_success.m4"));
+    let output = run_command(Path::new("fixtures/integration_tests/m4exit_success.m4"));
 
     let test: TestSnapshot = read_test("fixtures/integration_tests/m4exit_success.out");
     assert_eq!(
@@ -1440,7 +1440,7 @@ fn test_m4exit_success() {
 #[test]
 fn test_m4wrap() {
     init();
-    let output = run_command(&Path::new("fixtures/integration_tests/m4wrap.m4"));
+    let output = run_command(Path::new("fixtures/integration_tests/m4wrap.m4"));
 
     let test: TestSnapshot = read_test("fixtures/integration_tests/m4wrap.out");
     assert_eq!(
@@ -1465,7 +1465,7 @@ fn test_m4wrap() {
 #[test]
 fn test_macro_errprint_evaluation() {
     init();
-    let output = run_command(&Path::new(
+    let output = run_command(Path::new(
         "fixtures/integration_tests/macro_errprint_evaluation.m4",
     ));
 
@@ -1492,7 +1492,7 @@ fn test_macro_errprint_evaluation() {
 #[test]
 fn test_macro_errprint_no_evaluation() {
     init();
-    let output = run_command(&Path::new(
+    let output = run_command(Path::new(
         "fixtures/integration_tests/macro_errprint_no_evaluation.m4",
     ));
 
@@ -1520,7 +1520,7 @@ fn test_macro_errprint_no_evaluation() {
 #[test]
 fn test_macro_errprint_no_evaluation_quoted() {
     init();
-    let output = run_command(&Path::new(
+    let output = run_command(Path::new(
         "fixtures/integration_tests/macro_errprint_no_evaluation_quoted.m4",
     ));
 
@@ -1548,7 +1548,7 @@ fn test_macro_errprint_no_evaluation_quoted() {
 #[test]
 fn test_maketemp() {
     init();
-    let output = run_command(&Path::new("fixtures/integration_tests/maketemp.m4"));
+    let output = run_command(Path::new("fixtures/integration_tests/maketemp.m4"));
 
     let test: TestSnapshot = read_test("fixtures/integration_tests/maketemp.out");
     assert_eq!(
@@ -1574,7 +1574,7 @@ fn test_maketemp() {
 #[test]
 fn test_mkstemp() {
     init();
-    let output = run_command(&Path::new("fixtures/integration_tests/mkstemp.m4"));
+    let output = run_command(Path::new("fixtures/integration_tests/mkstemp.m4"));
 
     let test: TestSnapshot = read_test("fixtures/integration_tests/mkstemp.out");
     assert_eq!(
@@ -1600,7 +1600,7 @@ fn test_mkstemp() {
 #[test]
 fn test_quoted_nested_eof_in_string() {
     init();
-    let output = run_command(&Path::new(
+    let output = run_command(Path::new(
         "fixtures/integration_tests/quoted_nested_eof_in_string.m4",
     ));
 
@@ -1626,7 +1626,7 @@ fn test_quoted_nested_eof_in_string() {
 #[test]
 fn test_recurse() {
     init();
-    let output = run_command(&Path::new("fixtures/integration_tests/recurse.m4"));
+    let output = run_command(Path::new("fixtures/integration_tests/recurse.m4"));
 
     let test: TestSnapshot = read_test("fixtures/integration_tests/recurse.out");
     assert_eq!(
@@ -1651,7 +1651,7 @@ fn test_recurse() {
 #[test]
 fn test_recursive_defines() {
     init();
-    let output = run_command(&Path::new(
+    let output = run_command(Path::new(
         "fixtures/integration_tests/recursive_defines.m4",
     ));
 
@@ -1678,7 +1678,7 @@ fn test_recursive_defines() {
 #[test]
 fn test_redefine_inbuilt() {
     init();
-    let output = run_command(&Path::new("fixtures/integration_tests/redefine_inbuilt.m4"));
+    let output = run_command(Path::new("fixtures/integration_tests/redefine_inbuilt.m4"));
 
     let test: TestSnapshot = read_test("fixtures/integration_tests/redefine_inbuilt.out");
     assert_eq!(
@@ -1703,7 +1703,7 @@ fn test_redefine_inbuilt() {
 #[test]
 fn test_reverse() {
     init();
-    let output = run_command(&Path::new("fixtures/integration_tests/reverse.m4"));
+    let output = run_command(Path::new("fixtures/integration_tests/reverse.m4"));
 
     let test: TestSnapshot = read_test("fixtures/integration_tests/reverse.out");
     assert_eq!(
@@ -1728,7 +1728,7 @@ fn test_reverse() {
 #[test]
 fn test_shift() {
     init();
-    let output = run_command(&Path::new("fixtures/integration_tests/shift.m4"));
+    let output = run_command(Path::new("fixtures/integration_tests/shift.m4"));
 
     let test: TestSnapshot = read_test("fixtures/integration_tests/shift.out");
     assert_eq!(
@@ -1753,7 +1753,7 @@ fn test_shift() {
 #[test]
 fn test_sinclude() {
     init();
-    let output = run_command(&Path::new("fixtures/integration_tests/sinclude.m4"));
+    let output = run_command(Path::new("fixtures/integration_tests/sinclude.m4"));
 
     let test: TestSnapshot = read_test("fixtures/integration_tests/sinclude.out");
     assert_eq!(
@@ -1778,7 +1778,7 @@ fn test_sinclude() {
 #[test]
 fn test_substr() {
     init();
-    let output = run_command(&Path::new("fixtures/integration_tests/substr.m4"));
+    let output = run_command(Path::new("fixtures/integration_tests/substr.m4"));
 
     let test: TestSnapshot = read_test("fixtures/integration_tests/substr.out");
     assert_eq!(
@@ -1804,7 +1804,7 @@ fn test_substr() {
 #[test]
 fn test_synclines_1() {
     init();
-    let output = run_command(&Path::new("fixtures/integration_tests/synclines_1.args"));
+    let output = run_command(Path::new("fixtures/integration_tests/synclines_1.args"));
 
     let test: TestSnapshot = read_test("fixtures/integration_tests/synclines_1.out");
     assert_eq!(
@@ -1830,7 +1830,7 @@ fn test_synclines_1() {
 #[test]
 fn test_synclines_2() {
     init();
-    let output = run_command(&Path::new("fixtures/integration_tests/synclines_2.args"));
+    let output = run_command(Path::new("fixtures/integration_tests/synclines_2.args"));
 
     let test: TestSnapshot = read_test("fixtures/integration_tests/synclines_2.out");
     assert_eq!(
@@ -1856,7 +1856,7 @@ fn test_synclines_2() {
 #[test]
 fn test_syscmd_sysval() {
     init();
-    let output = run_command(&Path::new("fixtures/integration_tests/syscmd_sysval.m4"));
+    let output = run_command(Path::new("fixtures/integration_tests/syscmd_sysval.m4"));
 
     let test: TestSnapshot = read_test("fixtures/integration_tests/syscmd_sysval.out");
     assert_eq!(
@@ -1881,7 +1881,7 @@ fn test_syscmd_sysval() {
 #[test]
 fn test_trace() {
     init();
-    let output = run_command(&Path::new("fixtures/integration_tests/trace.m4"));
+    let output = run_command(Path::new("fixtures/integration_tests/trace.m4"));
 
     let test: TestSnapshot = read_test("fixtures/integration_tests/trace.out");
     assert_eq!(
@@ -1906,7 +1906,7 @@ fn test_trace() {
 #[test]
 fn test_translit() {
     init();
-    let output = run_command(&Path::new("fixtures/integration_tests/translit.m4"));
+    let output = run_command(Path::new("fixtures/integration_tests/translit.m4"));
 
     let test: TestSnapshot = read_test("fixtures/integration_tests/translit.out");
     assert_eq!(
@@ -1931,7 +1931,7 @@ fn test_translit() {
 #[test]
 fn test_two_files() {
     init();
-    let output = run_command(&Path::new("fixtures/integration_tests/two_files.args"));
+    let output = run_command(Path::new("fixtures/integration_tests/two_files.args"));
 
     let test: TestSnapshot = read_test("fixtures/integration_tests/two_files.out");
     assert_eq!(
@@ -1956,7 +1956,7 @@ fn test_two_files() {
 #[test]
 fn test_undivert() {
     init();
-    let output = run_command(&Path::new("fixtures/integration_tests/undivert.m4"));
+    let output = run_command(Path::new("fixtures/integration_tests/undivert.m4"));
 
     let test: TestSnapshot = read_test("fixtures/integration_tests/undivert.out");
     assert_eq!(
@@ -1981,7 +1981,7 @@ fn test_undivert() {
 #[test]
 fn test_undivert_2() {
     init();
-    let output = run_command(&Path::new("fixtures/integration_tests/undivert_2.m4"));
+    let output = run_command(Path::new("fixtures/integration_tests/undivert_2.m4"));
 
     let test: TestSnapshot = read_test("fixtures/integration_tests/undivert_2.out");
     assert_eq!(
@@ -2006,7 +2006,7 @@ fn test_undivert_2() {
 #[test]
 fn test_undivert_current() {
     init();
-    let output = run_command(&Path::new("fixtures/integration_tests/undivert_current.m4"));
+    let output = run_command(Path::new("fixtures/integration_tests/undivert_current.m4"));
 
     let test: TestSnapshot = read_test("fixtures/integration_tests/undivert_current.out");
     assert_eq!(
@@ -2031,7 +2031,7 @@ fn test_undivert_current() {
 #[test]
 fn test_undivert_nested() {
     init();
-    let output = run_command(&Path::new("fixtures/integration_tests/undivert_nested.m4"));
+    let output = run_command(Path::new("fixtures/integration_tests/undivert_nested.m4"));
 
     let test: TestSnapshot = read_test("fixtures/integration_tests/undivert_nested.out");
     assert_eq!(

--- a/text/tests/join/mod.rs
+++ b/text/tests/join/mod.rs
@@ -36,7 +36,7 @@ fn simple_test() {
 
     let expected_output = "1 Alice HR\n2 Bob Finance\n3 Charlie IT\n";
 
-    run_test_join(&args, &expected_output, "", 0)
+    run_test_join(&args, expected_output, "", 0)
 }
 
 #[test]
@@ -48,7 +48,7 @@ fn a_test() {
 
     let expected_output = "1 Alice HR\n2 Bob Finance\n3 Charlie IT\n4 Kos\n";
 
-    run_test_join(&args, &expected_output, "", 0)
+    run_test_join(&args, expected_output, "", 0)
 }
 
 #[test]
@@ -60,7 +60,7 @@ fn v_test() {
 
     let expected_output = "4 Kos\n";
 
-    run_test_join(&args, &expected_output, "", 0)
+    run_test_join(&args, expected_output, "", 0)
 }
 
 #[test]
@@ -72,7 +72,7 @@ fn o_test() {
 
     let expected_output = "Alice 1 HR 1\nBob 2 Finance 2\nCharlie 3 IT 3\n";
 
-    run_test_join(&args, &expected_output, "", 0)
+    run_test_join(&args, expected_output, "", 0)
 }
 
 #[test]
@@ -91,7 +91,7 @@ fn e_test() {
 
     let expected_output = "Alice 1 HR\nBob 2 Finance\nCharlie 3 IT\nKos 4 Wandalen\n";
 
-    run_test_join(&args, &expected_output, "", 0)
+    run_test_join(&args, expected_output, "", 0)
 }
 
 #[test]
@@ -103,7 +103,7 @@ fn t_test() {
 
     let expected_output = "";
 
-    run_test_join(&args, &expected_output, "", 0)
+    run_test_join(&args, expected_output, "", 0)
 }
 
 #[test]
@@ -115,7 +115,7 @@ fn fields_test() {
 
     let expected_output = "1 Alice HR\n2 Bob Finance\n3 Charlie IT\n";
 
-    run_test_join(&args, &expected_output, "", 0)
+    run_test_join(&args, expected_output, "", 0)
 }
 
 #[test]
@@ -128,7 +128,7 @@ fn three_fields_test() {
     let expected_output =
         "1 Bob HR Director HR\n2 Charlie Finance Analyst Finance\n3 Alice Engineering Manager IT\n";
 
-    run_test_join(&args, &expected_output, "", 0)
+    run_test_join(&args, expected_output, "", 0)
 }
 
 #[test]
@@ -140,5 +140,5 @@ fn third_field_join_test() {
 
     let expected_output = "1 Bob HR Director HR\n2 Charlie Finance Analyst Finance\n";
 
-    run_test_join(&args, &expected_output, "", 0)
+    run_test_join(&args, expected_output, "", 0)
 }

--- a/text/tests/pr/mod.rs
+++ b/text/tests/pr/mod.rs
@@ -68,14 +68,14 @@ fn pr_single_column() {
         None,
         None,
     );
-    pr_test(&[&input], "", &output);
+    pr_test(&[input], "", &output);
 }
 
 #[test]
 fn pr_multi_column() {
     let input = "tests/pr/lorem_ipsum.txt";
     let output = pr_read_test_file("tests/pr/lorem_ipsum_output_9_cols.txt", input, None, None);
-    pr_test(&["-9", &input], "", &output);
+    pr_test(&["-9", input], "", &output);
 }
 
 #[test]
@@ -87,7 +87,7 @@ fn pr_multi_column_across() {
         None,
         None,
     );
-    pr_test(&["-2", "-a", &input], "", &output);
+    pr_test(&["-2", "-a", input], "", &output);
 }
 
 #[test]
@@ -103,7 +103,7 @@ fn pr_multi_column_merge() {
     // Apr 18 14:13 2024
 
     let input = "tests/pr/lorem_ipsum.txt";
-    let args = &["+1:1", "-m", &input, &input, &input];
+    let args = &["+1:1", "-m", input, input, input];
     let str_args: Vec<String> = args.iter().map(|s| String::from(*s)).collect();
 
     let test_plan = TestPlan {
@@ -143,7 +143,7 @@ fn pr_page_skip() {
         None,
         None,
     );
-    pr_test(&["-9", "+15", &input], "", &output);
+    pr_test(&["-9", "+15", input], "", &output);
 }
 
 #[test]
@@ -156,14 +156,14 @@ fn pr_header_replacement() {
         Some(header),
         None,
     );
-    pr_test(&["+1:1", "-h", header, &input], "", &output);
+    pr_test(&["+1:1", "-h", header, input], "", &output);
 }
 
 #[test]
 fn pr_limit_lines() {
     let input = "tests/pr/numbers.txt";
     let output = pr_read_test_file("tests/pr/numbers_output_l20.txt", input, None, None);
-    pr_test(&["+1:1", "-l20", &input], "", &output);
+    pr_test(&["+1:1", "-l20", input], "", &output);
 }
 
 #[test]
@@ -171,35 +171,35 @@ fn pr_limit_lines_trim() {
     // Lines <= 10 behave like -t is used
     let input = "tests/pr/numbers.txt";
     let output = pr_read_test_file("tests/pr/numbers_output_l10.txt", input, None, None);
-    pr_test(&["+1:1", "-l10", &input], "", &output);
+    pr_test(&["+1:1", "-l10", input], "", &output);
 }
 
 #[test]
 fn pr_omit_header() {
     let input = "tests/pr/numbers.txt";
     let output = pr_read_test_file("tests/pr/numbers_output_omit_header.txt", input, None, None);
-    pr_test(&["+1:1", "-l20", "-t", &input], "", &output);
+    pr_test(&["+1:1", "-l20", "-t", input], "", &output);
 }
 
 #[test]
 fn pr_offset() {
     let input = "tests/pr/numbers.txt";
     let output = pr_read_test_file("tests/pr/numbers_output_offset.txt", input, None, None);
-    pr_test(&["+1:1", "-o7", &input], "", &output);
+    pr_test(&["+1:1", "-o7", input], "", &output);
 }
 
 #[test]
 fn pr_width() {
     let input = "tests/pr/long_line.txt";
     let output = pr_read_test_file("tests/pr/long_line_output_w72.txt", input, None, None);
-    pr_test(&["-2", "-t", "-w72", &input], "", &output);
+    pr_test(&["-2", "-t", "-w72", input], "", &output);
 
     let output = pr_read_test_file("tests/pr/long_line_output_w200.txt", input, None, None);
-    pr_test(&["-2", "-t", "-w200", &input], "", &output);
+    pr_test(&["-2", "-t", "-w200", input], "", &output);
 
     // -s without -w causes the width to be 512
     let output = pr_read_test_file("tests/pr/long_line_output_s.txt", input, None, None);
-    pr_test(&["-2", "-t", "-s", &input], "", &output);
+    pr_test(&["-2", "-t", "-s", input], "", &output);
 }
 
 #[test]
@@ -211,7 +211,7 @@ fn pr_number_line() {
         None,
         None,
     );
-    pr_test(&["-9", "-n3", &input], "", &output);
+    pr_test(&["-9", "-n3", input], "", &output);
 }
 
 #[test]
@@ -223,5 +223,5 @@ fn pr_expand_and_replace() {
         None,
         None,
     );
-    pr_test(&["-i?3", "-e", "-t", &input], "", &output);
+    pr_test(&["-i?3", "-e", "-t", input], "", &output);
 }

--- a/tree/tests/cp/mod.rs
+++ b/tree/tests/cp/mod.rs
@@ -795,7 +795,7 @@ fn test_cp_part_symlink() {
 
         unix::fs::symlink(&reg_abs, &slink).unwrap();
 
-        cd_and_cp_test(&dir, &args, &err_str, err_code);
+        cd_and_cp_test(dir, &args, &err_str, err_code);
 
         fs::remove_dir_all(test_dir).unwrap();
         fs::remove_dir_all(other_dir).unwrap();
@@ -893,7 +893,7 @@ fn test_cp_special_bits() {
         if passwd.is_null() {
             panic!("{}", io::Error::last_os_error());
         }
-        let uid = (&*passwd).pw_uid;
+        let uid = (*passwd).pw_uid;
 
         // chown "$NON_ROOT_USERNAME" .
         let md = fs::metadata(test_dir).unwrap();

--- a/tree/tests/mv/mod.rs
+++ b/tree/tests/mv/mod.rs
@@ -1082,7 +1082,7 @@ fn test_mv_part_symlink() {
 
         unix::fs::symlink(&reg_abs, &slink).unwrap();
 
-        cd_and_mv_test(&dir, &args, &err_str, err_code);
+        cd_and_mv_test(dir, &args, &err_str, err_code);
 
         fs::remove_dir_all(test_dir).unwrap();
         fs::remove_dir_all(other_dir).unwrap();
@@ -1333,7 +1333,7 @@ fn test_mv_i_link_no() {
     fs::set_permissions(b_bar, Permissions::from_mode(mode & !write_all)).unwrap();
 
     // Not using -i so have to use a fake tty to enable the overwrite prompt
-    mv_test_fake_tty(&[a_bar, a_foo, b], "n\n", &script_output, 0);
+    mv_test_fake_tty(&[a_bar, a_foo, b], "n\n", script_output, 0);
 
     {
         let mut buf = Vec::new();
@@ -1406,7 +1406,7 @@ fn test_mv_sticky_to_xpart() {
         if passwd.is_null() {
             panic!("{}", io::Error::last_os_error());
         }
-        let uid = (&*passwd).pw_uid;
+        let uid = (*passwd).pw_uid;
 
         // chown "$NON_ROOT_USERNAME" "$other_partition_tmpdir"
         let md = fs::metadata(other_dir).unwrap();

--- a/tree/tests/rm/mod.rs
+++ b/tree/tests/rm/mod.rs
@@ -1087,7 +1087,7 @@ fn test_rm_fail_2eperm() {
         if passwd.is_null() {
             panic!("{}", io::Error::last_os_error());
         }
-        let uid = (&*passwd).pw_uid;
+        let uid = (*passwd).pw_uid;
 
         let test_dir_cstr = CString::new(test_dir.as_bytes()).unwrap();
 
@@ -1161,7 +1161,7 @@ fn test_rm_no_give_up() {
         if passwd.is_null() {
             panic!("{}", io::Error::last_os_error());
         }
-        let uid = (&*passwd).pw_uid;
+        let uid = (*passwd).pw_uid;
 
         // The two calls below to `libc::chown` is equivalent to:
         // chown -R $NON_ROOT_USERNAME d


### PR DESCRIPTION
Add result of auto-fixing with:
"cargo clippy --fix -- --allow 'clippy::all' --deny 'clippy::needless_borrow'"