### PR TITLE
time: Locales

### DIFF
--- a/datetime/tests/time/mod.rs
+++ b/datetime/tests/time/mod.rs
@@ -12,7 +12,7 @@ use std::{
     process::{Command, Output, Stdio},
 };
 
-use plib::TestPlan;
+use plib::testing::TestPlan;
 
 fn run_test_base(cmd: &str, args: &Vec<String>, stdin_data: &[u8]) -> Output {
     let relpath = if cfg!(debug_assertions) {
@@ -67,9 +67,34 @@ fn run_test_time(
         expected_exit_code,
     });
 
+    let stdout = String::from_utf8_lossy(&output.stdout);
     let stderr = String::from_utf8_lossy(&output.stderr);
 
+    assert_eq!(stdout, expected_output);
     assert!(stderr.contains(expected_error));
+}
+
+#[test]
+fn test_smoke_help() {
+    run_test_time(
+        &["--help"],
+        "\
+time - time a simple command or give resource usage
+
+Usage: time [OPTIONS] <UTILITY> [ARGUMENT]...
+
+Arguments:
+  <UTILITY>      The utility to be invoked
+  [ARGUMENT]...  Arguments for the utility
+
+Options:
+  -p, --posix    Write timing output to standard error in POSIX format
+  -h, --help     Print help
+  -V, --version  Print version
+",
+        "",
+        0,
+    );
 }
 
 #[test]

--- a/datetime/time.rs
+++ b/datetime/time.rs
@@ -20,9 +20,11 @@ use plib::PROJECT_NAME;
 
 #[derive(Parser)]
 #[command(
-    version,
     about = gettext("time - time a simple command or give resource usage"),
-    help_template = gettext("{about-with-newline}\nUsage: {usage}\n\nArguments:\n{positionals}\n\nOptions:\n{options}")
+    help_template = gettext("{about}\n\nUsage: {usage}\n\nArguments:\n{positionals}\n\nOptions:\n{options}"),
+    version = env!("CARGO_PKG_VERSION"),
+    disable_help_flag = true,
+    disable_version_flag = true,
 )]
 struct Args {
     #[arg(
@@ -41,6 +43,12 @@ struct Args {
         help = gettext("Arguments for the utility")
     )]
     arguments: Vec<String>,
+
+    #[arg(short, long, help = gettext("Print help"), action = clap::ArgAction::HelpLong)]
+    help: bool,
+
+    #[arg(short = 'V', long, help = gettext("Print version"), action = clap::ArgAction::Version)]
+    version: bool,
 }
 
 enum TimeError {


### PR DESCRIPTION
Current status:
```
$ LANG= target/debug/time --help
time - time a simple command or give resource usage

Usage: time [OPTIONS] <UTILITY> [ARGUMENT]...

Arguments:
  <UTILITY>      The utility to be invoked
  [ARGUMENT]...  Arguments for the utility

Options:
  -p, --posix    Write timing output to standard error in POSIX format
  -h, --help     Print help
  -V, --version  Print version
```

```
$ LANG="ru_RU.UTF-8" target/debug/time --help
time - время выполнения простой команды или получение подсказки по ресурсу

Использование: time [OPTIONS] <UTILITY> [ARGUMENT]...

Аргументы:
  <UTILITY>      Команда для запуска
  [ARGUMENT]...  Аргументы для передаче команде

Параметры:
  -p, --posix    При локали POSIX использовать точный традиционный формат
  -h, --help     Показать эту справку и выйти
  -V, --version  Показать информацию о версии и выйти
```

Unresolved issues:
```
$ LANG="ru_RU.UTF-8" target/debug/time --exists
error: unexpected argument '--exists' found

  tip: to pass '--exists' as a value, use '-- --exists'

Usage: time [OPTIONS] <UTILITY> [ARGUMENT]...

For more information, try '--help'.
```