### PR TITLE
Add missing chgrp module in tree-tests.rs

### DIFF
--- a/tree/tests/tree-tests.rs
+++ b/tree/tests/tree-tests.rs
@@ -7,6 +7,7 @@
 // SPDX-License-Identifier: MIT
 //
 
+mod chgrp;
 mod cp;
 mod link;
 mod ls;


### PR DESCRIPTION
I think I missed this file during the rebase. My apologies for the oversight.