### PR TITLE
Fix test target directory detection for cargo-llvm-cov coverage builds

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,5 +56,7 @@ thiserror = "1"
 pest = { version = "2", default-features = false }
 pest_derive = "2"
 
-[workspace.lints]
+[workspace.lints.rust]
+# Allow `cfg(coverage)` which is set by cargo-llvm-cov during coverage builds
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(coverage)'] }
 

--- a/datetime/tests/time/mod.rs
+++ b/datetime/tests/time/mod.rs
@@ -16,9 +16,16 @@ use plib::testing::TestPlan;
 
 fn run_test_base(cmd: &str, args: &Vec<String>, stdin_data: &[u8]) -> Output {
     // Determine the target directory - cargo-llvm-cov uses a custom target dir
+    // When built with cargo-llvm-cov, cfg(coverage) is set and target is in llvm-cov-target subdir
     let target_dir = std::env::var("CARGO_TARGET_DIR")
         .or_else(|_| std::env::var("CARGO_LLVM_COV_TARGET_DIR"))
-        .unwrap_or_else(|_| String::from("target"));
+        .unwrap_or_else(|_| {
+            if cfg!(coverage) {
+                String::from("target/llvm-cov-target")
+            } else {
+                String::from("target")
+            }
+        });
 
     let profile = if cfg!(debug_assertions) {
         "debug"

--- a/file/tests/find/mod.rs
+++ b/file/tests/find/mod.rs
@@ -31,9 +31,16 @@ fn run_test_find_sorted(
 ) {
     let project_root = env!("CARGO_MANIFEST_DIR");
     // Determine the target directory - cargo-llvm-cov uses a custom target dir
+    // When built with cargo-llvm-cov, cfg(coverage) is set and target is in llvm-cov-target subdir
     let target_dir = std::env::var("CARGO_TARGET_DIR")
         .or_else(|_| std::env::var("CARGO_LLVM_COV_TARGET_DIR"))
-        .unwrap_or_else(|_| String::from("target"));
+        .unwrap_or_else(|_| {
+            if cfg!(coverage) {
+                String::from("target/llvm-cov-target")
+            } else {
+                String::from("target")
+            }
+        });
     let profile = if cfg!(debug_assertions) {
         "debug"
     } else {
@@ -271,9 +278,16 @@ fn find_newer_test() {
 fn run_test_find_print0_sorted(args: &[&str], expected_paths: &[&str], expected_exit_code: i32) {
     let project_root = env!("CARGO_MANIFEST_DIR");
     // Determine the target directory - cargo-llvm-cov uses a custom target dir
+    // When built with cargo-llvm-cov, cfg(coverage) is set and target is in llvm-cov-target subdir
     let target_dir = std::env::var("CARGO_TARGET_DIR")
         .or_else(|_| std::env::var("CARGO_LLVM_COV_TARGET_DIR"))
-        .unwrap_or_else(|_| String::from("target"));
+        .unwrap_or_else(|_| {
+            if cfg!(coverage) {
+                String::from("target/llvm-cov-target")
+            } else {
+                String::from("target")
+            }
+        });
     let profile = if cfg!(debug_assertions) {
         "debug"
     } else {

--- a/make/tests/integration.rs
+++ b/make/tests/integration.rs
@@ -97,9 +97,16 @@ fn run_test_helper_with_setup_and_destruct(
 
 fn manual_test_helper(args: &[&str]) -> Child {
     // Determine the target directory - cargo-llvm-cov uses a custom target dir
+    // When built with cargo-llvm-cov, cfg(coverage) is set and target is in llvm-cov-target subdir
     let target_dir = env::var("CARGO_TARGET_DIR")
         .or_else(|_| env::var("CARGO_LLVM_COV_TARGET_DIR"))
-        .unwrap_or_else(|_| String::from("target"));
+        .unwrap_or_else(|_| {
+            if cfg!(coverage) {
+                String::from("target/llvm-cov-target")
+            } else {
+                String::from("target")
+            }
+        });
 
     let profile = if cfg!(debug_assertions) {
         "debug"

--- a/plib/src/testing.rs
+++ b/plib/src/testing.rs
@@ -41,9 +41,16 @@ pub fn run_test_base_with_env(
     env_vars: &[(&str, &str)],
 ) -> Output {
     // Determine the target directory - cargo-llvm-cov uses a custom target dir
+    // When built with cargo-llvm-cov, cfg(coverage) is set and target is in llvm-cov-target subdir
     let target_dir = std::env::var("CARGO_TARGET_DIR")
         .or_else(|_| std::env::var("CARGO_LLVM_COV_TARGET_DIR"))
-        .unwrap_or_else(|_| String::from("target"));
+        .unwrap_or_else(|_| {
+            if cfg!(coverage) {
+                String::from("target/llvm-cov-target")
+            } else {
+                String::from("target")
+            }
+        });
 
     let profile = if cfg!(debug_assertions) {
         "debug"

--- a/process/tests/kill/mod.rs
+++ b/process/tests/kill/mod.rs
@@ -43,9 +43,17 @@ fn run_kill_test_exact(
 
 // Helper to get the test binary path
 fn get_kill_binary_path() -> std::path::PathBuf {
+    // Determine the target directory - cargo-llvm-cov uses a custom target dir
+    // When built with cargo-llvm-cov, cfg(coverage) is set and target is in llvm-cov-target subdir
     let target_dir = std::env::var("CARGO_TARGET_DIR")
         .or_else(|_| std::env::var("CARGO_LLVM_COV_TARGET_DIR"))
-        .unwrap_or_else(|_| String::from("target"));
+        .unwrap_or_else(|_| {
+            if cfg!(coverage) {
+                String::from("target/llvm-cov-target")
+            } else {
+                String::from("target")
+            }
+        });
 
     let profile = if cfg!(debug_assertions) {
         "debug"

--- a/process/tests/timeout/mod.rs
+++ b/process/tests/timeout/mod.rs
@@ -28,9 +28,16 @@ pub struct TestPlan {
 
 fn run_test_base(cmd: &str, args: &Vec<String>, stdin_data: &[u8]) -> (Output, i32) {
     // Determine the target directory - cargo-llvm-cov uses a custom target dir
+    // When built with cargo-llvm-cov, cfg(coverage) is set and target is in llvm-cov-target subdir
     let target_dir = std::env::var("CARGO_TARGET_DIR")
         .or_else(|_| std::env::var("CARGO_LLVM_COV_TARGET_DIR"))
-        .unwrap_or_else(|_| String::from("target"));
+        .unwrap_or_else(|_| {
+            if cfg!(coverage) {
+                String::from("target/llvm-cov-target")
+            } else {
+                String::from("target")
+            }
+        });
 
     let profile = if cfg!(debug_assertions) {
         "debug"

--- a/uucp/tests/uustat/mod.rs
+++ b/uucp/tests/uustat/mod.rs
@@ -135,9 +135,16 @@ impl SpoolEnv {
 
     fn run_uucp(&self, args: &[&str]) -> std::process::Output {
         // Determine the target directory - cargo-llvm-cov uses a custom target dir
+        // When built with cargo-llvm-cov, cfg(coverage) is set and target is in llvm-cov-target subdir
         let target_dir = std::env::var("CARGO_TARGET_DIR")
             .or_else(|_| std::env::var("CARGO_LLVM_COV_TARGET_DIR"))
-            .unwrap_or_else(|_| String::from("target"));
+            .unwrap_or_else(|_| {
+                if cfg!(coverage) {
+                    String::from("target/llvm-cov-target")
+                } else {
+                    String::from("target")
+                }
+            });
         let profile = if cfg!(debug_assertions) {
             "debug"
         } else {
@@ -160,9 +167,16 @@ impl SpoolEnv {
 
     fn run_uustat(&self, args: &[&str]) -> std::process::Output {
         // Determine the target directory - cargo-llvm-cov uses a custom target dir
+        // When built with cargo-llvm-cov, cfg(coverage) is set and target is in llvm-cov-target subdir
         let target_dir = std::env::var("CARGO_TARGET_DIR")
             .or_else(|_| std::env::var("CARGO_LLVM_COV_TARGET_DIR"))
-            .unwrap_or_else(|_| String::from("target"));
+            .unwrap_or_else(|_| {
+                if cfg!(coverage) {
+                    String::from("target/llvm-cov-target")
+                } else {
+                    String::from("target")
+                }
+            });
         let profile = if cfg!(debug_assertions) {
             "debug"
         } else {

--- a/xform/build.rs
+++ b/xform/build.rs
@@ -30,24 +30,17 @@ fn main() {
 fn create_symlinks() {
     use std::os::unix::fs::symlink;
 
-    // Get the target directory from environment
-    // CARGO_TARGET_DIR or default to "target"
-    let target_dir = env::var("CARGO_TARGET_DIR")
-        .or_else(|_| env::var("CARGO_LLVM_COV_TARGET_DIR"))
-        .unwrap_or_else(|_| String::from("target"));
-
-    // Get the profile (debug or release)
-    let profile = env::var("PROFILE").unwrap_or_else(|_| String::from("debug"));
-
-    // Get the workspace root (CARGO_MANIFEST_DIR points to xform/, go up one level)
-    let manifest_dir = env::var("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR not set");
-    let workspace_root = PathBuf::from(&manifest_dir)
-        .parent()
-        .expect("Could not find workspace root")
-        .to_path_buf();
-
-    // Build path to target directory
-    let bin_dir = workspace_root.join(&target_dir).join(&profile);
+    // Use OUT_DIR to determine the actual target directory
+    // OUT_DIR is like: <target_dir>/<profile>/build/<crate>-<hash>/out
+    // We need to go up to: <target_dir>/<profile>/
+    let out_dir = env::var("OUT_DIR").expect("OUT_DIR not set");
+    let bin_dir = PathBuf::from(&out_dir)
+        .parent() // out
+        .and_then(|p| p.parent()) // <crate>-<hash>
+        .and_then(|p| p.parent()) // build
+        .and_then(|p| p.parent()) // <profile>
+        .map(|p| p.to_path_buf())
+        .expect("Could not determine target directory from OUT_DIR");
 
     // Create the target directory if it doesn't exist
     // (it may not exist on first build)


### PR DESCRIPTION
cargo-llvm-cov uses target/llvm-cov-target as its build directory but does not set any environment variable that tests can detect at runtime. Tests were failing to find binaries because they looked in target/ instead.

Fix by using cfg!(coverage) which cargo-llvm-cov sets at compile time to detect coverage builds and use the correct target directory path. Also update build.rs files to use OUT_DIR which is always correct regardless of target directory configuration.

Fixes weekly coverage CI failures where all integration tests failed with 'failed to spawn command' errors.