### PR TITLE
testing: Centralize target directory detection logic

### DIFF
--- a/file/tests/find/mod.rs
+++ b/file/tests/find/mod.rs
@@ -2,7 +2,7 @@ use std::fs::{remove_file, File};
 use std::io::Write;
 use std::process::{Command, Stdio};
 
-use plib::testing::{run_test, TestPlan};
+use plib::testing::{get_binary_path, run_test, TestPlan};
 
 fn run_test_find(
     args: &[&str],
@@ -29,24 +29,7 @@ fn run_test_find_sorted(
     expected_error: &str,
     expected_exit_code: i32,
 ) {
-    let project_root = env!("CARGO_MANIFEST_DIR");
-    // Determine the target directory - cargo-llvm-cov uses a custom target dir
-    // When built with cargo-llvm-cov, cfg(coverage) is set and target is in llvm-cov-target subdir
-    let target_dir = std::env::var("CARGO_TARGET_DIR")
-        .or_else(|_| std::env::var("CARGO_LLVM_COV_TARGET_DIR"))
-        .unwrap_or_else(|_| {
-            if cfg!(coverage) {
-                String::from("target/llvm-cov-target")
-            } else {
-                String::from("target")
-            }
-        });
-    let profile = if cfg!(debug_assertions) {
-        "debug"
-    } else {
-        "release"
-    };
-    let find_path = format!("{}/../{}/{}/find", project_root, target_dir, profile);
+    let find_path = get_binary_path("find");
 
     let output = Command::new(&find_path)
         .args(args)
@@ -276,24 +259,7 @@ fn find_newer_test() {
 
 /// Run find and compare null-delimited output (for -print0 testing)
 fn run_test_find_print0_sorted(args: &[&str], expected_paths: &[&str], expected_exit_code: i32) {
-    let project_root = env!("CARGO_MANIFEST_DIR");
-    // Determine the target directory - cargo-llvm-cov uses a custom target dir
-    // When built with cargo-llvm-cov, cfg(coverage) is set and target is in llvm-cov-target subdir
-    let target_dir = std::env::var("CARGO_TARGET_DIR")
-        .or_else(|_| std::env::var("CARGO_LLVM_COV_TARGET_DIR"))
-        .unwrap_or_else(|_| {
-            if cfg!(coverage) {
-                String::from("target/llvm-cov-target")
-            } else {
-                String::from("target")
-            }
-        });
-    let profile = if cfg!(debug_assertions) {
-        "debug"
-    } else {
-        "release"
-    };
-    let find_path = format!("{}/../{}/{}/find", project_root, target_dir, profile);
+    let find_path = get_binary_path("find");
 
     let output = Command::new(&find_path)
         .args(args)

--- a/make/tests/integration.rs
+++ b/make/tests/integration.rs
@@ -12,7 +12,7 @@ use std::fs::{remove_file, File};
 use std::io::Write;
 use std::process::{Child, Command, Stdio};
 
-use plib::testing::{run_test, run_test_base, TestPlan};
+use plib::testing::{get_binary_path, run_test, run_test_base, TestPlan};
 
 use posixutils_make::error_code::ErrorCode;
 
@@ -96,32 +96,7 @@ fn run_test_helper_with_setup_and_destruct(
 }
 
 fn manual_test_helper(args: &[&str]) -> Child {
-    // Determine the target directory - cargo-llvm-cov uses a custom target dir
-    // When built with cargo-llvm-cov, cfg(coverage) is set and target is in llvm-cov-target subdir
-    let target_dir = env::var("CARGO_TARGET_DIR")
-        .or_else(|_| env::var("CARGO_LLVM_COV_TARGET_DIR"))
-        .unwrap_or_else(|_| {
-            if cfg!(coverage) {
-                String::from("target/llvm-cov-target")
-            } else {
-                String::from("target")
-            }
-        });
-
-    let profile = if cfg!(debug_assertions) {
-        "debug"
-    } else {
-        "release"
-    };
-
-    let relpath = format!("{}/{}/{}", target_dir, profile, "make");
-
-    // Build the full path to the binary
-    let test_bin_path = env::current_dir()
-        .expect("failed to get current directory")
-        .parent()
-        .expect("failed to get parent directory")
-        .join(relpath);
+    let test_bin_path = get_binary_path("make");
 
     // Create and spawn the command
     Command::new(test_bin_path)

--- a/process/tests/kill/mod.rs
+++ b/process/tests/kill/mod.rs
@@ -7,7 +7,7 @@
 // SPDX-License-Identifier: MIT
 //
 
-use plib::testing::{run_test, run_test_with_checker, TestPlan};
+use plib::testing::{get_binary_path, run_test, run_test_with_checker, TestPlan};
 use std::process::{Command, Output, Stdio};
 use std::thread;
 use std::time::Duration;
@@ -43,29 +43,7 @@ fn run_kill_test_exact(
 
 // Helper to get the test binary path
 fn get_kill_binary_path() -> std::path::PathBuf {
-    // Determine the target directory - cargo-llvm-cov uses a custom target dir
-    // When built with cargo-llvm-cov, cfg(coverage) is set and target is in llvm-cov-target subdir
-    let target_dir = std::env::var("CARGO_TARGET_DIR")
-        .or_else(|_| std::env::var("CARGO_LLVM_COV_TARGET_DIR"))
-        .unwrap_or_else(|_| {
-            if cfg!(coverage) {
-                String::from("target/llvm-cov-target")
-            } else {
-                String::from("target")
-            }
-        });
-
-    let profile = if cfg!(debug_assertions) {
-        "debug"
-    } else {
-        "release"
-    };
-
-    std::env::current_dir()
-        .unwrap()
-        .parent()
-        .unwrap()
-        .join(format!("{}/{}/kill", target_dir, profile))
+    get_binary_path("kill")
 }
 
 // ============================================

--- a/process/tests/timeout/mod.rs
+++ b/process/tests/timeout/mod.rs
@@ -14,6 +14,7 @@ use std::{
     time::Duration,
 };
 
+use plib::testing::get_binary_path;
 use sysinfo::System;
 
 pub struct TestPlan {
@@ -27,30 +28,7 @@ pub struct TestPlan {
 }
 
 fn run_test_base(cmd: &str, args: &Vec<String>, stdin_data: &[u8]) -> (Output, i32) {
-    // Determine the target directory - cargo-llvm-cov uses a custom target dir
-    // When built with cargo-llvm-cov, cfg(coverage) is set and target is in llvm-cov-target subdir
-    let target_dir = std::env::var("CARGO_TARGET_DIR")
-        .or_else(|_| std::env::var("CARGO_LLVM_COV_TARGET_DIR"))
-        .unwrap_or_else(|_| {
-            if cfg!(coverage) {
-                String::from("target/llvm-cov-target")
-            } else {
-                String::from("target")
-            }
-        });
-
-    let profile = if cfg!(debug_assertions) {
-        "debug"
-    } else {
-        "release"
-    };
-
-    let relpath = format!("{}/{}/{}", target_dir, profile, cmd);
-    let test_bin_path = std::env::current_dir()
-        .unwrap()
-        .parent()
-        .unwrap() // Move up to the workspace root from the current package directory
-        .join(relpath); // Adjust the path to the binary
+    let test_bin_path = get_binary_path(cmd);
 
     let mut command = Command::new(test_bin_path);
     let mut child = command

--- a/uucp/tests/uustat/mod.rs
+++ b/uucp/tests/uustat/mod.rs
@@ -7,7 +7,7 @@
 // SPDX-License-Identifier: MIT
 //
 
-use plib::testing::{run_test_with_checker, TestPlan};
+use plib::testing::{get_binary_path, run_test_with_checker, TestPlan};
 use std::fs;
 use std::process::Output;
 
@@ -134,28 +134,7 @@ impl SpoolEnv {
     }
 
     fn run_uucp(&self, args: &[&str]) -> std::process::Output {
-        // Determine the target directory - cargo-llvm-cov uses a custom target dir
-        // When built with cargo-llvm-cov, cfg(coverage) is set and target is in llvm-cov-target subdir
-        let target_dir = std::env::var("CARGO_TARGET_DIR")
-            .or_else(|_| std::env::var("CARGO_LLVM_COV_TARGET_DIR"))
-            .unwrap_or_else(|_| {
-                if cfg!(coverage) {
-                    String::from("target/llvm-cov-target")
-                } else {
-                    String::from("target")
-                }
-            });
-        let profile = if cfg!(debug_assertions) {
-            "debug"
-        } else {
-            "release"
-        };
-        let relpath = format!("{}/{}/uucp", target_dir, profile);
-        let test_bin_path = std::env::current_dir()
-            .unwrap()
-            .parent()
-            .unwrap()
-            .join(relpath);
+        let test_bin_path = get_binary_path("uucp");
 
         std::process::Command::new(test_bin_path)
             .args(args)
@@ -166,28 +145,7 @@ impl SpoolEnv {
     }
 
     fn run_uustat(&self, args: &[&str]) -> std::process::Output {
-        // Determine the target directory - cargo-llvm-cov uses a custom target dir
-        // When built with cargo-llvm-cov, cfg(coverage) is set and target is in llvm-cov-target subdir
-        let target_dir = std::env::var("CARGO_TARGET_DIR")
-            .or_else(|_| std::env::var("CARGO_LLVM_COV_TARGET_DIR"))
-            .unwrap_or_else(|_| {
-                if cfg!(coverage) {
-                    String::from("target/llvm-cov-target")
-                } else {
-                    String::from("target")
-                }
-            });
-        let profile = if cfg!(debug_assertions) {
-            "debug"
-        } else {
-            "release"
-        };
-        let relpath = format!("{}/{}/uustat", target_dir, profile);
-        let test_bin_path = std::env::current_dir()
-            .unwrap()
-            .parent()
-            .unwrap()
-            .join(relpath);
+        let test_bin_path = get_binary_path("uustat");
 
         std::process::Command::new(test_bin_path)
             .args(args)


### PR DESCRIPTION
Add get_target_dir(), get_profile(), and get_binary_path() helpers to plib/src/testing.rs to eliminate duplicated target directory detection code across test files. Update run_test_base_with_env to use the new helpers.

Updated test files:
- datetime/tests/time/mod.rs: Use plib::testing::run_test_base
- process/tests/timeout/mod.rs: Use get_binary_path in local run_test_base
- process/tests/kill/mod.rs: Delegate to get_binary_path("kill")
- file/tests/find/mod.rs: Use get_binary_path("find") in sorted test fns
- make/tests/integration.rs: Use get_binary_path("make")
- uucp/tests/uustat/mod.rs: Use get_binary_path in run_uucp/run_uustat