### PR TITLE
Fix build.rs symlink paths and use plib::testing in cron tests

### DIFF
--- a/cron/tests/crontab/mod.rs
+++ b/cron/tests/crontab/mod.rs
@@ -7,85 +7,39 @@
 // SPDX-License-Identifier: MIT
 //
 
-use std::io::Write;
-use std::process::{Command, Output, Stdio};
-use std::thread;
-use std::time::Duration;
+use plib::testing::run_test_base;
+use std::process::Output;
 
-fn run_test_base(cmd: &str, args: &Vec<String>, stdin_data: &[u8]) -> Output {
-    let relpath = if cfg!(debug_assertions) {
-        format!("target/debug/{}", cmd)
-    } else {
-        format!("target/release/{}", cmd)
-    };
-    let test_bin_path = std::env::current_dir()
-        .unwrap()
-        .parent()
-        .unwrap() // Move up to the workspace root from the current package directory
-        .join(relpath); // Adjust the path to the binary
-
-    let mut command = Command::new(test_bin_path);
-    let mut child = command
-        .args(args)
-        .stdin(Stdio::piped())
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .spawn()
-        .unwrap_or_else(|_| panic!("failed to spawn command {}", cmd));
-
-    // Separate the mutable borrow of stdin from the child process
-    if let Some(mut stdin) = child.stdin.take() {
-        let chunk_size = 1024; // Arbitrary chunk size, adjust if needed
-        for chunk in stdin_data.chunks(chunk_size) {
-            // Write each chunk
-            if let Err(e) = stdin.write_all(chunk) {
-                eprintln!("Error writing to stdin: {}", e);
-                break;
-            }
-            // Flush after writing each chunk
-            if let Err(e) = stdin.flush() {
-                eprintln!("Error flushing stdin: {}", e);
-                break;
-            }
-
-            // Sleep briefly to avoid CPU spinning
-            thread::sleep(Duration::from_millis(10));
-        }
-        // Explicitly drop stdin to close the pipe
-        drop(stdin);
-    }
-
-    // Ensure we wait for the process to complete after writing to stdin
-
-    child.wait_with_output().expect("failed to wait for child")
+fn run_cron_test(cmd: &str, args: &Vec<String>, stdin_data: &[u8]) -> Output {
+    run_test_base(cmd, args, stdin_data)
 }
 
 #[test]
 fn no_args() {
-    let output = run_test_base("crontab", &vec![], b"");
+    let output = run_cron_test("crontab", &vec![], b"");
     assert_eq!(output.status.code(), Some(1));
 }
 
 #[test]
 fn dash_e() {
-    let output = run_test_base("crontab", &vec!["-e".to_string()], b"");
+    let output = run_cron_test("crontab", &vec!["-e".to_string()], b"");
     assert_eq!(output.status.code(), Some(1));
 }
 
 #[test]
 fn dash_l() {
-    let output = run_test_base("crontab", &vec!["-l".to_string()], b"");
+    let output = run_cron_test("crontab", &vec!["-l".to_string()], b"");
     assert_eq!(output.status.code(), Some(1));
 }
 
 #[test]
 fn dash_r() {
-    let output = run_test_base("crontab", &vec!["-r".to_string()], b"");
+    let output = run_cron_test("crontab", &vec!["-r".to_string()], b"");
     assert_eq!(output.status.code(), Some(1));
 }
 
 #[test]
 fn too_many_args() {
-    let output = run_test_base("crontab", &vec!["-erl".to_string()], b"");
+    let output = run_cron_test("crontab", &vec!["-erl".to_string()], b"");
     assert_eq!(output.status.code(), Some(1));
 }

--- a/editors/build.rs
+++ b/editors/build.rs
@@ -33,10 +33,9 @@ fn create_ex_symlink() {
     // We need to go up to: <target_dir>/<profile>/
     let out_dir = env::var("OUT_DIR").expect("OUT_DIR not set");
     let bin_dir = PathBuf::from(&out_dir)
-        .parent() // out
-        .and_then(|p| p.parent()) // <crate>-<hash>
-        .and_then(|p| p.parent()) // build
-        .and_then(|p| p.parent()) // <profile>
+        .parent() // out -> <crate>-<hash>
+        .and_then(|p| p.parent()) // <crate>-<hash> -> build
+        .and_then(|p| p.parent()) // build -> <profile> (e.g., debug)
         .map(|p| p.to_path_buf())
         .expect("Could not determine target directory from OUT_DIR");
 

--- a/xform/build.rs
+++ b/xform/build.rs
@@ -35,10 +35,9 @@ fn create_symlinks() {
     // We need to go up to: <target_dir>/<profile>/
     let out_dir = env::var("OUT_DIR").expect("OUT_DIR not set");
     let bin_dir = PathBuf::from(&out_dir)
-        .parent() // out
-        .and_then(|p| p.parent()) // <crate>-<hash>
-        .and_then(|p| p.parent()) // build
-        .and_then(|p| p.parent()) // <profile>
+        .parent() // out -> <crate>-<hash>
+        .and_then(|p| p.parent()) // <crate>-<hash> -> build
+        .and_then(|p| p.parent()) // build -> <profile> (e.g., debug)
         .map(|p| p.to_path_buf())
         .expect("Could not determine target directory from OUT_DIR");
 


### PR DESCRIPTION
- editors/build.rs, xform/build.rs: Fix OFF-BY-ONE error in OUT_DIR path traversal - was going up 4 parents instead of 3, causing symlinks (ex, uncompress, zcat) to be created in target/ instead of target/debug/ or target/release/

- cron/tests: Replace duplicated run_test_base with plib::testing functions to properly handle cargo-llvm-cov target directories