### PR TITLE
sed: Create tmp directory before writing w command output

### DIFF
--- a/text/sed.rs
+++ b/text/sed.rs
@@ -2217,6 +2217,10 @@ impl Sed {
             || wfile.exists())
         {
             wfile = get_tmp_path(wfile);
+            // Ensure tmp directory exists
+            if let Some(parent) = wfile.parent() {
+                let _ = std::fs::create_dir_all(parent);
+            }
         }
 
         let _ = match std::fs::OpenOptions::new()


### PR DESCRIPTION
The w command redirects bare filenames to a tmp directory, but fails in coverage CI where the default ../target/tmp doesn't exist. Create the parent directory when using the tmp path.