### PR TITLE
tree: Move skip checks before directory creation in tests

### DIFF
--- a/tree/tests/cp/mod.rs
+++ b/tree/tests/cp/mod.rs
@@ -853,6 +853,11 @@ fn test_cp_proc_short_read() {
     ignore
 )]
 fn test_cp_special_bits() {
+    let Some(non_root) = option_env!("NON_ROOT_USERNAME") else {
+        eprintln!("Skipping: NON_ROOT_USERNAME not set");
+        return;
+    };
+
     let test_dir = &format!("{}/test_cp_special_bits", env!("CARGO_TARGET_TMPDIR"));
     let a = &format!("{test_dir}/a");
     let b = &format!("{test_dir}/b");
@@ -883,11 +888,6 @@ fn test_cp_special_bits() {
     #[allow(clippy::unnecessary_cast)]
     let mode_c = 0o554 | libc::S_ISUID as u32 | libc::S_ISGID as u32;
     fs::set_permissions(c, fs::Permissions::from_mode(mode_c)).unwrap();
-
-    let Some(non_root) = option_env!("NON_ROOT_USERNAME") else {
-        eprintln!("Skipping: NON_ROOT_USERNAME not set");
-        return;
-    };
 
     unsafe {
         let non_root_cstr = CString::new(non_root).unwrap();

--- a/tree/tests/mv/mod.rs
+++ b/tree/tests/mv/mod.rs
@@ -1375,6 +1375,11 @@ fn test_mv_i_link_no() {
     ignore
 )]
 fn test_mv_sticky_to_xpart() {
+    let Some(non_root) = option_env!("NON_ROOT_USERNAME") else {
+        eprintln!("Skipping: NON_ROOT_USERNAME not set");
+        return;
+    };
+
     let test_name = "test_mv_sticky_to_xpart";
     let test_dir = &format!("{}/{test_name}", env!("CARGO_TARGET_TMPDIR"));
     let t = &format!("{test_dir}/t");
@@ -1402,11 +1407,6 @@ fn test_mv_sticky_to_xpart() {
         option_env!("OTHER_PARTITION_TMPDIR").unwrap_or("/dev/shm")
     );
     fs::create_dir(other_dir).unwrap();
-
-    let Some(non_root) = option_env!("NON_ROOT_USERNAME") else {
-        eprintln!("Skipping: NON_ROOT_USERNAME not set");
-        return;
-    };
 
     unsafe {
         let non_root_cstr = CString::new(non_root).unwrap();

--- a/tree/tests/rm/mod.rs
+++ b/tree/tests/rm/mod.rs
@@ -1073,16 +1073,16 @@ fn test_rm_unreadable() {
     ignore
 )]
 fn test_rm_fail_2eperm() {
+    let Some(non_root) = option_env!("NON_ROOT_USERNAME") else {
+        eprintln!("Skipping: NON_ROOT_USERNAME not set");
+        return;
+    };
+
     let test_dir = &format!("{}/test_rm_fail_2eperm", env!("CARGO_TARGET_TMPDIR"));
     let a = &format!("{test_dir}/a");
     let a_b = &format!("{test_dir}/a/b");
 
     fs::create_dir(test_dir).unwrap();
-
-    let Some(non_root) = option_env!("NON_ROOT_USERNAME") else {
-        eprintln!("Skipping: NON_ROOT_USERNAME not set");
-        return;
-    };
 
     // chown $NON_ROOT_USERNAME $test_dir
     unsafe {
@@ -1145,17 +1145,16 @@ fn test_rm_fail_2eperm() {
     ignore
 )]
 fn test_rm_no_give_up() {
-    let test_dir = &format!("{}/test_rm_no_give_up", env!("CARGO_TARGET_TMPDIR"));
-    let d = &format!("{test_dir}/d");
-    let d_f = &format!("{test_dir}/d/f");
-
-    fs::create_dir(test_dir).unwrap();
-
     let Some(non_root) = option_env!("NON_ROOT_USERNAME") else {
         eprintln!("Skipping: NON_ROOT_USERNAME not set");
         return;
     };
 
+    let test_dir = &format!("{}/test_rm_no_give_up", env!("CARGO_TARGET_TMPDIR"));
+    let d = &format!("{test_dir}/d");
+    let d_f = &format!("{test_dir}/d/f");
+
+    fs::create_dir(test_dir).unwrap();
     fs::create_dir(d).unwrap();
     fs::File::create(d_f).unwrap();
 


### PR DESCRIPTION
Tests that skip via NON_ROOT_USERNAME were creating directories before checking skip conditions. When skipped, directories weren't cleaned up, causing "File exists" errors on subsequent CI runs.

Move skip checks to the start of test_cp_special_bits, test_mv_sticky_to_xpart, test_rm_fail_2eperm, and test_rm_no_give_up.