### PR TITLE
ci: Add Codecov token for protected branch uploads

### DIFF
--- a/.github/workflows/coverage-weekly.yml
+++ b/.github/workflows/coverage-weekly.yml
@@ -55,7 +55,4 @@ jobs:
         with:
           files: lcov.info
           fail_ci_if_error: true
-          # For public OSS + Codecov GitHub App, leave token unset.
-          # If Codecov ever complains "token required", add CODECOV_TOKEN
-          # in GitHub Secrets and uncomment:
-          # token: ${{ secrets.CODECOV_TOKEN }}
+          token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
Codecov now requires authentication tokens for uploads to protected branches. Enable the token parameter using the CODECOV_TOKEN secret.