### PR TITLE
fix(pax): emit path= record for any path the ustar fields can't hold

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -102,9 +102,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
 
 [[package]]
 name = "ar"
@@ -131,6 +131,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "base64"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b25655df2c3cdd83c5e5b293b88acd880332b2ddadd7c30ac43144fdc0033da9"
+
+[[package]]
 name = "bigdecimal"
 version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -149,7 +155,7 @@ version = "0.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f49d8fed880d473ea71efb9bf597651e77201bdd4893efe54c9e5d65ae04ce6f"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "cexpr",
  "clang-sys",
  "itertools",
@@ -160,7 +166,7 @@ dependencies = [
  "regex",
  "rustc-hash",
  "shlex 1.3.0",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -210,28 +216,19 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.13.0"
+version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
-
-[[package]]
-name = "block-buffer"
-version = "0.10.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
-dependencies = [
- "generic-array",
-]
+checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
 
 [[package]]
 name = "bstr"
-version = "1.12.1"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63044e1ae8e69f3b5a92c736ca6269b8d12fa7efe39bf34ddb06d102cf0e2cab"
+checksum = "1f7dc094d718f2e1c1559ad110e27eeaae14a5465d3d56dd6dbd793079fbd530"
 dependencies = [
  "memchr",
  "regex-automata",
- "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -242,22 +239,22 @@ checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
 name = "bytemuck"
-version = "1.25.0"
+version = "1.25.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
+checksum = "95832e849adfb21180ccb6826a99da14e5d266ae5c2e668e1602cf234f153797"
 dependencies = [
  "bytemuck_derive",
 ]
 
 [[package]]
 name = "bytemuck_derive"
-version = "1.10.2"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9abbd1bc6865053c427f7198e6af43bfdedc55ab791faed4fbd361d789575ff"
+checksum = "f65693059b6b9c588b9f62fed1cedbf0a8b805631457ea162d68f0de186f3de5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -268,15 +265,15 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.11.1"
+version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
 
 [[package]]
 name = "cc"
-version = "1.2.64"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dad887fd958be91b5098c0248def011f4523ab786cd411be668777e55063501f"
+checksum = "5add81bb678e6cb321aff7fa0dc7689ad82b112dbc032cea19f91d6b8e3582b9"
 dependencies = [
  "find-msvc-tools",
  "shlex 2.0.1",
@@ -329,9 +326,9 @@ dependencies = [
 
 [[package]]
 name = "clang-sys"
-version = "1.8.1"
+version = "1.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
+checksum = "157a8ba7b480713b56f4c09fd13fc3e0a22a5dfab8097ba61cbc5feef950788a"
 dependencies = [
  "glob",
  "libc",
@@ -340,9 +337,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.6.1"
+version = "4.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
+checksum = "d91e0c145792ef73a6ad36d27c75ac09f1832222a3c209689d90f534685ee5b7"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -350,9 +347,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.6.0"
+version = "4.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
+checksum = "f09628afdcc538b57f3c6341e9c8e9970f18e4a481690a64974d7023bd33548b"
 dependencies = [
  "anstyle",
  "clap_lex",
@@ -360,14 +357,14 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.6.1"
+version = "4.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
+checksum = "d012d2b9d65aca7f18f4d9878a045bc17899bba951561ba5ec3c2ba1eed9a061"
 dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -437,15 +434,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7704b5fdd17b18ae31c4c1da5a2e0305a2bf17b5249300a9ee9ed7b72114c636"
 
 [[package]]
-name = "cpufeatures"
-version = "0.2.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "crc32fast"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -456,9 +444,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-deque"
-version = "0.8.6"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+checksum = "5181e0de7b61eb03a81e347d6dd8797bae9da5146707b51077e2d71a54ec0ceb"
 dependencies = [
  "crossbeam-epoch",
  "crossbeam-utils",
@@ -466,34 +454,55 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.21"
+version = "0.8.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
-
-[[package]]
-name = "crypto-common"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
-dependencies = [
- "generic-array",
- "typenum",
-]
+checksum = "61803da095bee82a81bb1a452ecc25d3b2f1416d1897eb86430c6159ef717c17"
 
 [[package]]
 name = "dary_heap"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b1e3a325bc115f096c8b77bbf027a7c2592230e70be2d985be950d3d5e60ebe"
+
+[[package]]
+name = "defmt"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2953bfe4f93bbd20cc71198842756f77d161884c99ebbabc41d80231ded88d1"
+dependencies = [
+ "bitflags 1.3.2",
+ "defmt-macros",
+]
+
+[[package]]
+name = "defmt-macros"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bad9c72e7ca2137e0dc3813245a0d282fd6daad32fd800af018306a9169b5fe8"
+dependencies = [
+ "defmt-parser",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "defmt-parser"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10d60334b3b2e7c9d91ef8150abfb6fa4c1c39ebbcf4a81c2e346aad939fee3e"
+dependencies = [
+ "thiserror 2.0.19",
+]
 
 [[package]]
 name = "deranged"
@@ -509,7 +518,7 @@ checksum = "6edb4b64a43d977b8e99788fe3a04d483834fba1215a7e02caa415b626497f7f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -517,16 +526,6 @@ name = "diff"
 version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
-
-[[package]]
-name = "digest"
-version = "0.10.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
-dependencies = [
- "block-buffer",
- "crypto-common",
-]
 
 [[package]]
 name = "dirs"
@@ -577,9 +576,9 @@ checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
 
 [[package]]
 name = "either"
-version = "1.16.0"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
+checksum = "9e5e8f6c15a24b9a3ee5efec809ccd006d3b30e8b3bb63c39af737c7f87daa1d"
 
 [[package]]
 name = "encode_unicode"
@@ -596,7 +595,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -607,14 +606,14 @@ checksum = "ba7795da175654fe16979af73f81f26a8ea27638d8d9823d317016888a63dc4c"
 dependencies = [
  "num-traits",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "env_filter"
-version = "1.0.1"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32e90c2accc4b07a8456ea0debdc2e7587bdd890680d71173a15d4ae604f6eef"
+checksum = "900d271a03799a1ee8d1ca9b19893b48ca674a9284fefcfb85f05e74ed314217"
 dependencies = [
  "log",
  "regex",
@@ -622,9 +621,9 @@ dependencies = [
 
 [[package]]
 name = "env_logger"
-version = "0.11.10"
+version = "0.11.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0621c04f2196ac3f488dd583365b9c09be011a4ab8b9f37248ffcc8f6198b56a"
+checksum = "de671bd27a75a797dc9ae289ba1e77276e75e2026408aab65185384e2d5cd3f6"
 dependencies = [
  "anstream",
  "anstyle",
@@ -666,9 +665,9 @@ checksum = "dea2df4cf52843e0452895c455a1a2cfbb842a1e7329671acf418fdc53ed4c59"
 
 [[package]]
 name = "fastrand"
-version = "2.4.1"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
 
 [[package]]
 name = "filedescriptor"
@@ -715,12 +714,6 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "foldhash"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
-
-[[package]]
-name = "foldhash"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
@@ -731,32 +724,32 @@ version = "0.8.0"
 dependencies = [
  "errno",
  "libc",
- "rand 0.8.6",
+ "rand 0.8.7",
  "tempfile",
 ]
 
 [[package]]
 name = "futures-core"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+checksum = "2cd50c473c80f6d7c3670a752354b8e569b1a7cbfdc0419ec88e5edad85e0dc7"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
+checksum = "2d6d3cde68c518367be28956066ddfef33813991b77a55005a69dae04bf3b10b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "futures-task"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+checksum = "b231ed28831efb4a61a08580c4bc233ec56bc009f4cd8f52da2c3cb97df0c109"
 
 [[package]]
 name = "futures-timer"
@@ -766,25 +759,15 @@ checksum = "af43fadb8a98512d547e37b4e92e0ced13e205c061b87b4623eff01d918d6968"
 
 [[package]]
 name = "futures-util"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+checksum = "a77a90a256fce34da66415271e30f94ee91c57b04b8a2c042d9cf3220179deaa"
 dependencies = [
  "futures-core",
  "futures-macro",
  "futures-task",
  "pin-project-lite",
  "slab",
-]
-
-[[package]]
-name = "generic-array"
-version = "0.14.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
-dependencies = [
- "typenum",
- "version_check",
 ]
 
 [[package]]
@@ -812,15 +795,13 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
 dependencies = [
  "cfg-if",
  "libc",
  "r-efi 6.0.0",
- "wasip2",
- "wasip3",
 ]
 
 [[package]]
@@ -832,9 +813,9 @@ dependencies = [
 
 [[package]]
 name = "glob"
-version = "0.3.3"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+checksum = "e4eba85ea1d0a966a983acd07deee566e67395d2d96b6fb39e62b5a833f1eb0b"
 
 [[package]]
 name = "hashbrown"
@@ -847,22 +828,13 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.15.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
-dependencies = [
- "foldhash 0.1.5",
-]
-
-[[package]]
-name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 dependencies = [
  "allocator-api2",
  "equivalent",
- "foldhash 0.2.0",
+ "foldhash",
 ]
 
 [[package]]
@@ -890,9 +862,9 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "1.4.2"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6970f50e31d6fc17d3fa27329444bfa74e196cf62e95052a3f6fee181dba6425"
+checksum = "918d3568bebf352712bc2ef3d46a8bcf1a75b373be6539de198e9105cbbf9ce0"
 dependencies = [
  "bytes",
  "itoa",
@@ -929,12 +901,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "id-arena"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
-
-[[package]]
 name = "indexmap"
 version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -942,8 +908,6 @@ checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
  "hashbrown 0.17.1",
- "serde",
- "serde_core",
 ]
 
 [[package]]
@@ -952,14 +916,14 @@ version = "5.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04c123c0ee550cedc10474ccb5ed10da580eaf015ef48a63b72991653a3fec69"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "enum-as-inner",
  "enum-primitive-derive",
  "http",
  "log",
  "num-traits",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "ureq",
 ]
 
@@ -986,10 +950,12 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jiff"
-version = "0.2.28"
+version = "0.2.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4603d3033e49e2b0e31229fcab20a5d40089c607d975cd9c80551dc69eed9102"
+checksum = "668b7183bd07af9a4885f5c35b0cc5c83c4607a913c16b7e17291832910d2dcc"
 dependencies = [
+ "defmt",
+ "jiff-core",
  "jiff-static",
  "log",
  "portable-atomic",
@@ -998,21 +964,31 @@ dependencies = [
 ]
 
 [[package]]
-name = "jiff-static"
-version = "0.2.28"
+name = "jiff-core"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "782d32378dddf207193ac91cefb848ad41abb58195c95168e1291227a0832b47"
+checksum = "7feca88439efe53da3754500c1851dedf3cb36c524dd5cf8225cc0794de95d09"
 dependencies = [
+ "defmt",
+]
+
+[[package]]
+name = "jiff-static"
+version = "0.2.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a69dcb3a21cfb32ce1cd056169337ca284af0766dd766e7878819b251a49204"
+dependencies = [
+ "jiff-core",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "js-sys"
-version = "0.3.102"
+version = "0.3.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03d04c30968dffe80775bd4d7fb676131cd04a1fb46d2686dbffbaec2d9dfd31"
+checksum = "53b44bfcdb3f8d5837a46dae1ca9660a837176eee74a28b229bc626816589102"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -1039,12 +1015,6 @@ name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
-
-[[package]]
-name = "leb128fmt"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "lexical"
@@ -1114,9 +1084,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.186"
+version = "0.2.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
 
 [[package]]
 name = "libcrypt-rs"
@@ -1126,9 +1096,9 @@ checksum = "39b3d7c612f85d15ec030b01eb7e6e89cee1dfe04ce9ba7c09f01958f54489ac"
 
 [[package]]
 name = "libflate"
-version = "2.3.0"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd96e993e5f3368b0cb8497dae6c860c22af8ff18388c61c6c0b86c58d86b5df"
+checksum = "a4da9b700e758e57152a1fd1c52cbdc5727c1aa6d8743dc1acda917398f1d76c"
 dependencies = [
  "adler32",
  "crc32fast",
@@ -1166,9 +1136,9 @@ checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libredox"
-version = "0.1.17"
+version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f02ab6bace2054fb888a3c16f990117b579d14a3088e472d63c6011fa185c9d3"
+checksum = "c943259e342f1e06ff2da7a83eabdfe7f92ce10262688dbf1895ff0b3e6e4652"
 dependencies = [
  "libc",
 ]
@@ -1181,9 +1151,9 @@ checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "log"
-version = "0.4.32"
+version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "953f07c43838f8e6f9758cab68bf5bed85465e7587ebe0b823f1bcd81978ad3a"
+checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
 name = "match_cfg"
@@ -1202,9 +1172,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.8.2"
+version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
+checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "memoffset"
@@ -1237,7 +1207,7 @@ version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab2156c4fce2f8df6c499cc1c763e4394b7482525bf2a9701c9d79d215f519e4"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "cfg-if",
  "cfg_aliases",
  "libc",
@@ -1273,9 +1243,9 @@ dependencies = [
 
 [[package]]
 name = "num-bigint"
-version = "0.4.6"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+checksum = "c89e69e7e0f03bea5ef08013795c25018e101932225a656383bd384495ecc367"
 dependencies = [
  "num-integer",
  "num-traits",
@@ -1366,9 +1336,9 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "pest"
-version = "2.8.6"
+version = "2.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0848c601009d37dfa3430c4666e147e49cdcf1b92ecd3e63657d8a5f19da662"
+checksum = "7df728be843c7070fab6ab7c328c4e9e9d78e23bf749c0669c86ee7ebfa050a2"
 dependencies = [
  "memchr",
  "ucd-trie",
@@ -1376,9 +1346,9 @@ dependencies = [
 
 [[package]]
 name = "pest_derive"
-version = "2.8.6"
+version = "2.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11f486f1ea21e6c10ed15d5a7c77165d0ee443402f0780849d1768e7d9d6fe77"
+checksum = "9e2dd6fc3b26b3462ee188aac870f5a41d398f1cd5e2408d16531bd71c9591fd"
 dependencies = [
  "pest",
  "pest_generator",
@@ -1386,25 +1356,24 @@ dependencies = [
 
 [[package]]
 name = "pest_generator"
-version = "2.8.6"
+version = "2.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8040c4647b13b210a963c1ed407c1ff4fdfa01c31d6d2a098218702e6664f94f"
+checksum = "6a7a9205cfb6f596a9e8b689c0a15f9ceb7a1aafae7aaf788150ac65b29975b6"
 dependencies = [
  "pest",
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "pest_meta"
-version = "2.8.6"
+version = "2.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89815c69d36021a140146f26659a81d6c2afa33d216d736dd4be5381a7362220"
+checksum = "85abd351c0de1e8384fc791a0737111a350394937e92b956b743dac12429f57c"
 dependencies = [
  "pest",
- "sha2",
 ]
 
 [[package]]
@@ -1442,7 +1411,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
 dependencies = [
  "phf_shared 0.11.3",
- "rand 0.8.6",
+ "rand 0.8.7",
 ]
 
 [[package]]
@@ -1482,9 +1451,9 @@ dependencies = [
 
 [[package]]
 name = "portable-atomic"
-version = "1.13.1"
+version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
+checksum = "3d20d5497ef88037a52ff98267d066e7f11fcc5e99bbfbd58a42336193aacec3"
 
 [[package]]
 name = "portable-atomic-util"
@@ -1527,7 +1496,7 @@ dependencies = [
  "pest",
  "pest_derive",
  "plib",
- "rand 0.8.6",
+ "rand 0.8.7",
  "tempfile",
 ]
 
@@ -1548,7 +1517,7 @@ dependencies = [
 name = "posixutils-cc"
 version = "0.8.0"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "clap",
  "gettext-rs",
  "plib",
@@ -1658,7 +1627,7 @@ dependencies = [
  "quote",
  "strum",
  "strum_macros",
- "syn 2.0.117",
+ "syn 2.0.119",
  "tempfile",
 ]
 
@@ -1837,7 +1806,7 @@ dependencies = [
  "libc",
  "plib",
  "proptest",
- "rand 0.8.6",
+ "rand 0.8.7",
  "regex",
  "thiserror 1.0.69",
 ]
@@ -1889,7 +1858,7 @@ dependencies = [
 name = "posixutils-xform"
 version = "0.8.0"
 dependencies = [
- "base64",
+ "base64 0.23.0",
  "clap",
  "flate2",
  "gettext-rs",
@@ -1929,7 +1898,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1943,9 +1912,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.106"
+version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
+checksum = "985e7ec9bb745e6ce6535b544d84d6cd6f7ad8bd711c398938ae983b91a766d9"
 dependencies = [
  "unicode-ident",
 ]
@@ -1958,9 +1927,9 @@ checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
 dependencies = [
  "bit-set",
  "bit-vec",
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "num-traits",
- "rand 0.9.4",
+ "rand 0.9.5",
  "rand_chacha 0.9.0",
  "rand_xorshift",
  "regex-syntax",
@@ -1983,9 +1952,9 @@ checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quote"
-version = "1.0.45"
+version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
+checksum = "1fbf4db142a473a8d80c26bbf18454ed458bf8d26c8219c331daecfdbd079001"
 dependencies = [
  "proc-macro2",
 ]
@@ -2004,9 +1973,9 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
-version = "0.8.6"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
+checksum = "22f6172bdec972074665ed81ed53b71da00bfc44b65a753cfde883ec4c702a1a"
 dependencies = [
  "libc",
  "rand_chacha 0.3.1",
@@ -2015,9 +1984,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.4"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
+checksum = "b9ef1d0d795eb7d84685bca4f72f3649f064e6641543d3a8c415898726a57b41"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.5",
@@ -2103,9 +2072,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.12.4"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1292b7759ae1cb9ec195452d1390a074f0cd8541ab7a5a8c31cd6db45d4a6ba"
+checksum = "f020237b6c8eed93db2e2cb53c00c60a8e1bc73da7d073199a1180401450218d"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -2115,9 +2084,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.14"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+checksum = "8fcfdb36bda0c880c5931cdc7a2bcdc8ba4556847b9d912bca70bc94708711ad"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -2150,9 +2119,9 @@ checksum = "3582f63211428f83597b51b2ddb88e2a91a9d52d12831f9d08f5e624e8977422"
 
 [[package]]
 name = "rowan"
-version = "0.15.18"
+version = "0.15.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62f509095fc8cc0c8c8564016771d458079c11a8d857e65861f045145c0d3208"
+checksum = "a2441aaccb50f4267d4f0f58b21e0138e96a449f361ed57a2673a83c9bca0772"
 dependencies = [
  "countme",
  "hashbrown 0.14.5",
@@ -2187,7 +2156,7 @@ dependencies = [
  "regex",
  "relative-path",
  "rustc_version",
- "syn 2.0.117",
+ "syn 2.0.119",
  "unicode-ident",
 ]
 
@@ -2212,7 +2181,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -2221,9 +2190,9 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.22"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
 
 [[package]]
 name = "rusty-fork"
@@ -2243,7 +2212,7 @@ version = "14.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7803e8936da37efd9b6d4478277f4b2b9bb5cdb37a113e8d63222e58da647e63"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "cfg-if",
  "clipboard-win",
  "libc",
@@ -2283,45 +2252,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
-name = "serde"
-version = "1.0.228"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
-dependencies = [
- "serde_core",
-]
-
-[[package]]
 name = "serde_core"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+checksum = "67dca2c9c51e58a4791a4b1ed58308b39c64224d349a935ab5039aa360942a48"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "serde_json"
-version = "1.0.150"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
-dependencies = [
- "itoa",
- "memchr",
- "serde",
- "serde_core",
- "zmij",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -2333,17 +2280,6 @@ dependencies = [
  "cfg-if",
  "libc",
  "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "sha2"
-version = "0.10.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
-dependencies = [
- "cfg-if",
- "cpufeatures",
- "digest",
 ]
 
 [[package]]
@@ -2385,9 +2321,9 @@ checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "simd-adler32"
-version = "0.3.9"
+version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
+checksum = "3a219298ac11a56ea9a6d2120044824d6f01aeb034955e7af7bc16858527deea"
 
 [[package]]
 name = "similar"
@@ -2443,7 +2379,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2459,9 +2395,20 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.117"
+version = "2.0.119"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
+checksum = "872831b642d1a07999a962a351ed35b955ea2cfc8f3862091e2a240a84f17297"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2502,7 +2449,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.2",
+ "getrandom 0.4.3",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
@@ -2571,7 +2518,7 @@ checksum = "c26ef8b00e4d382e59f6a8ddb3cd790b3a5bb29f21a358a9a69ea2f29f13f27b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2580,7 +2527,7 @@ version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "944ad38adcbb71eaa682c56bceeb079e4ca82b4b3edc2a0fde5cb297b77dac8d"
 dependencies = [
- "syn 2.0.117",
+ "syn 2.0.119",
  "test-log-core",
 ]
 
@@ -2601,11 +2548,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.18"
+version = "2.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+checksum = "09a43598840e33d5b0331f38c5e30d13bb11c11210a4b58f0d9b18a5a5eefcd9"
 dependencies = [
- "thiserror-impl 2.0.18",
+ "thiserror-impl 2.0.19",
 ]
 
 [[package]]
@@ -2616,34 +2563,34 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.18"
+version = "2.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
+checksum = "43cbfe0cf76104d42a574802844187e84a305e531ed54455f11fbde0f10541cd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 3.0.3",
 ]
 
 [[package]]
 name = "thread_local"
-version = "1.1.9"
+version = "1.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+checksum = "1ad99c4c6d32803332c548b1af0540b357b3f5fc0be8f6c6bfe8b2e6ae784070"
 dependencies = [
  "cfg-if",
 ]
 
 [[package]]
 name = "time"
-version = "0.3.49"
+version = "0.3.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "711a53c2d47bbd818258c498c8dbfe186a2526c631495cfe7e078567f86b8469"
+checksum = "3e1d5e639ff6bab73cb6885cc7e7b1de96c3f32c68ec55f3952614bec1092244"
 dependencies = [
  "deranged",
  "libc",
@@ -2663,9 +2610,9 @@ checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
 
 [[package]]
 name = "time-macros"
-version = "0.2.29"
+version = "0.2.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71c652a3727a9cbb9a02f707f530b618ce00d0ccd762009c8c23bd191df3c17d"
+checksum = "7e689342a48d2ea927c87ea50cabf8594854bf940e9310208848d680d668ed85"
 dependencies = [
  "num-conv",
  "time-core",
@@ -2682,9 +2629,9 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.25.12+spec-1.1.0"
+version = "0.25.13+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2153edc6955a6c354fad8f5efd38b6a8769bdccf9fe50f8e1329f81b0baa5d7"
+checksum = "6975367e4d2ef766d86af01ffad14b622fecc8d4357a998fbc4deb6e9bacaf9b"
 dependencies = [
  "indexmap",
  "toml_datetime",
@@ -2694,9 +2641,9 @@ dependencies = [
 
 [[package]]
 name = "toml_parser"
-version = "1.1.2+spec-1.1.0"
+version = "1.1.3+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
+checksum = "1d38ac1cf9b95face32296c0a3ede1fdc270627c9d9c02a7274dd6d960dc4d56"
 dependencies = [
  "winnow",
 ]
@@ -2759,12 +2706,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "typenum"
-version = "1.20.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
-
-[[package]]
 name = "ucd-trie"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2806,7 +2747,7 @@ version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dea7109cdcd5864d4eeb1b58a1648dc9bf520360d7af16ec26d0a9354bafcfc0"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "log",
  "percent-encoding",
  "ureq-proto",
@@ -2819,7 +2760,7 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e994ba84b0bd1b1b0cf92878b7ef898a5c1760108fe7b6010327e274917a808c"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "http",
  "httparse",
  "log",
@@ -2880,23 +2821,14 @@ version = "1.0.4+wasi-0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b67efb37e106e55ce722a510d6b5f9c17f083e5fc79afc2badeb12cc313d9487"
 dependencies = [
- "wit-bindgen 0.57.1",
-]
-
-[[package]]
-name = "wasip3"
-version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
-dependencies = [
- "wit-bindgen 0.51.0",
+ "wit-bindgen",
 ]
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.125"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ddb3f79143bced6de84270411622a2699cee572fc0875aeaf1e7867cf9fca1a"
+checksum = "4b067c0c11094aef6b7a801c1e34a26affafdf3d051dba08456b868789aaf9a4"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -2907,9 +2839,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.125"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e21a184b13fb19e157296e2c46056aec9092264fab83e4ba59e68c61b323c3d"
+checksum = "167ce5e579f6bcf889c4f7175a8a5a585de84e8ff93976ce393efa5f2837aab1"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -2917,58 +2849,24 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.125"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fecefd9c35bd935a20fc3fc344b5f29138961e4f47fb03297d88f2587afb5ebd"
+checksum = "f3997c7839262f4ef12cf90b818d6340c18e80f263f1a94bf157d0ec4420380e"
 dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.125"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23939e44bb9a5d7576fa2b563dc2e136628f1224e88a8deed09e04858b77871f"
+checksum = "dc1b4cb0cc549fcf58d7dfc081778139b3d283a081644e833e84682ad71cea24"
 dependencies = [
  "unicode-ident",
-]
-
-[[package]]
-name = "wasm-encoder"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
-dependencies = [
- "leb128fmt",
- "wasmparser",
-]
-
-[[package]]
-name = "wasm-metadata"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
-dependencies = [
- "anyhow",
- "indexmap",
- "wasm-encoder",
- "wasmparser",
-]
-
-[[package]]
-name = "wasmparser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
-dependencies = [
- "bitflags 2.13.0",
- "hashbrown 0.15.5",
- "indexmap",
- "semver",
 ]
 
 [[package]]
@@ -3045,7 +2943,7 @@ checksum = "9107ddc059d5b6fbfbffdfa7a7fe3e22a226def0b2608f72e9d552763d3e1ad7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -3056,7 +2954,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -3067,7 +2965,7 @@ checksum = "29bee4b38ea3cde66011baa44dba677c432a78593e202392d1e9070cf2a7fca7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -3078,7 +2976,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -3273,9 +3171,9 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
+checksum = "23b97319f7b8343df12cc98938e5c3eb436064524c8d2b4e30a1d3a36eecdf81"
 dependencies = [
  "memchr",
 ]
@@ -3291,97 +3189,9 @@ dependencies = [
 
 [[package]]
 name = "wit-bindgen"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
-dependencies = [
- "wit-bindgen-rust-macro",
-]
-
-[[package]]
-name = "wit-bindgen"
 version = "0.57.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
-
-[[package]]
-name = "wit-bindgen-core"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
-dependencies = [
- "anyhow",
- "heck",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-bindgen-rust"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
-dependencies = [
- "anyhow",
- "heck",
- "indexmap",
- "prettyplease",
- "syn 2.0.117",
- "wasm-metadata",
- "wit-bindgen-core",
- "wit-component",
-]
-
-[[package]]
-name = "wit-bindgen-rust-macro"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
-dependencies = [
- "anyhow",
- "prettyplease",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
- "wit-bindgen-core",
- "wit-bindgen-rust",
-]
-
-[[package]]
-name = "wit-component"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
-dependencies = [
- "anyhow",
- "bitflags 2.13.0",
- "indexmap",
- "log",
- "serde",
- "serde_derive",
- "serde_json",
- "wasm-encoder",
- "wasm-metadata",
- "wasmparser",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-parser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
-dependencies = [
- "anyhow",
- "id-arena",
- "indexmap",
- "log",
- "semver",
- "serde",
- "serde_derive",
- "serde_json",
- "unicode-xid",
- "wasmparser",
-]
 
 [[package]]
 name = "yansi"
@@ -3391,26 +3201,20 @@ checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
 
 [[package]]
 name = "zerocopy"
-version = "0.8.52"
+version = "0.8.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce1022995ff5ff5d841ad7d994facc23098cd40152f2c1d11cd607c6f530653f"
+checksum = "b5a105cd7b140f6eeec8acff2ea38135d3cab283ada58540f629fe51e46696eb"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.52"
+version = "0.8.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ae7f38b72ec2a254e2b87ef277cf2cd4fb97cbebf944faa6f33354da0867930"
+checksum = "0fe976fb70c78cd64cccfe3a6fc142244e8a77b70959b30faf9d0ac37ee228eb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
-
-[[package]]
-name = "zmij"
-version = "1.0.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"

--- a/awk/interpreter/builtins.rs
+++ b/awk/interpreter/builtins.rs
@@ -483,7 +483,7 @@ pub(crate) fn print_to_string(
     }
     let mut output = String::new();
     values.iter().skip(1).rev().fold(&mut output, |acc, elem| {
-        write!(acc, "{}{}", elem, &global_env.ofs).expect("error writing to string");
+        write!(acc, "{}{}", elem, global_env.ofs).expect("error writing to string");
         acc
     });
     // there has to be at least an element

--- a/awk/interpreter/record.rs
+++ b/awk/interpreter/record.rs
@@ -264,7 +264,7 @@ impl Record {
                 let field_str = (*cell.get())
                     .clone()
                     .scalar_to_string(&global_env.convfmt)?;
-                write!(new_record, "{}{}", field_str, &global_env.ofs)
+                write!(new_record, "{}{}", field_str, global_env.ofs)
                     .expect("error writing to string");
             }
             let last_field_str = (*fields[last_field].get())

--- a/calc/bc_util/parser.rs
+++ b/calc/bc_util/parser.rs
@@ -443,7 +443,7 @@ fn is_incomplete(text: &str, error: &PestError) -> bool {
     // - the error occurs at the start of an incomplete comment
     // - the error occurs at the start of an incomplete string
     pos == text.len()
-        || text.as_bytes()[pos..text.len().min(pos + 2)] == [b'/', b'*']
+        || text.as_bytes()[pos..text.len().min(pos + 2)] == *b"/*"
         || text.as_bytes()[pos] == b'"'
 }
 

--- a/cc/ir/linearize.rs
+++ b/cc/ir/linearize.rs
@@ -3031,7 +3031,7 @@ impl<'a> Linearizer<'a> {
             // Check if this is a static local (sentinel value)
             if local.sym.0 == u32::MAX {
                 // Static local - look up the global name and treat as global
-                let key = format!("{}.{}", self.current_func_name, &name_str);
+                let key = format!("{}.{}", self.current_func_name, name_str);
                 if let Some(static_info) = self.static_locals.get(&key).cloned() {
                     let sym_id = self.alloc_pseudo();
                     let pseudo = Pseudo::sym(sym_id, static_info.global_name);

--- a/cc/ir/linearize_stmt.rs
+++ b/cc/ir/linearize_stmt.rs
@@ -1463,23 +1463,17 @@ impl<'a> super::linearize::Linearizer<'a> {
                     match element {
                         OffsetOfPath::Field(field_id) => {
                             let struct_type = self.resolve_struct_type(current_type);
-                            if let Some(member_info) =
-                                self.types.find_member(struct_type, *field_id)
-                            {
-                                offset += member_info.offset as u64;
-                                current_type = member_info.typ;
-                            } else {
-                                return None; // Field not found
-                            }
+                            // None if the field is not found
+                            let member_info = self.types.find_member(struct_type, *field_id)?;
+                            offset += member_info.offset as u64;
+                            current_type = member_info.typ;
                         }
                         OffsetOfPath::Index(index) => {
-                            if let Some(elem_type) = self.types.base_type(current_type) {
-                                let elem_size = self.types.size_bytes(elem_type);
-                                offset += (*index as u64) * (elem_size as u64);
-                                current_type = elem_type;
-                            } else {
-                                return None; // Not an array type
-                            }
+                            // None if this is not an array type
+                            let elem_type = self.types.base_type(current_type)?;
+                            let elem_size = self.types.size_bytes(elem_type);
+                            offset += (*index as u64) * (elem_size as u64);
+                            current_type = elem_type;
                         }
                     }
                 }

--- a/cc/parse/expression.rs
+++ b/cc/parse/expression.rs
@@ -919,21 +919,18 @@ impl<'a> Parser<'a> {
                     if self.is_special(b'(') {
                         // Type specifier form: _Atomic(type-name)
                         self.advance(); // consume '('
-                        if let Some(inner_type) = self.try_parse_type_name() {
-                            if !self.is_special(b')') {
-                                return None;
-                            }
-                            self.advance(); // consume ')'
-                            let inner = self.types.get(inner_type).clone();
-                            let result = Type {
-                                modifiers: modifiers | inner.modifiers | TypeModifiers::ATOMIC,
-                                ..inner
-                            };
-                            let result_id = self.types.intern(result);
-                            return Some(self.parse_pointer_chain(result_id));
-                        } else {
+                        let inner_type = self.try_parse_type_name()?;
+                        if !self.is_special(b')') {
                             return None;
                         }
+                        self.advance(); // consume ')'
+                        let inner = self.types.get(inner_type).clone();
+                        let result = Type {
+                            modifiers: modifiers | inner.modifiers | TypeModifiers::ATOMIC,
+                            ..inner
+                        };
+                        let result_id = self.types.intern(result);
+                        return Some(self.parse_pointer_chain(result_id));
                     } else {
                         // Qualifier form: just _Atomic
                         modifiers |= TypeModifiers::ATOMIC;

--- a/cc/parse/parser.rs
+++ b/cc/parse/parser.rs
@@ -3875,23 +3875,17 @@ impl Parser<'_> {
                 for element in path {
                     match element {
                         OffsetOfPath::Field(field_id) => {
-                            if let Some(member_info) =
-                                self.types.find_member(current_type, *field_id)
-                            {
-                                offset += member_info.offset as i128;
-                                current_type = member_info.typ;
-                            } else {
-                                return None;
-                            }
+                            // None if the field is not found
+                            let member_info = self.types.find_member(current_type, *field_id)?;
+                            offset += member_info.offset as i128;
+                            current_type = member_info.typ;
                         }
                         OffsetOfPath::Index(index) => {
-                            if let Some(elem_type) = self.types.base_type(current_type) {
-                                let elem_size = self.types.size_bytes(elem_type);
-                                offset += *index as i128 * (elem_size as i128);
-                                current_type = elem_type;
-                            } else {
-                                return None;
-                            }
+                            // None if this is not an array type
+                            let elem_type = self.types.base_type(current_type)?;
+                            let elem_size = self.types.size_bytes(elem_type);
+                            offset += *index as i128 * (elem_size as i128);
+                            current_type = elem_type;
                         }
                     }
                 }

--- a/cc/token/lexer.rs
+++ b/cc/token/lexer.rs
@@ -2140,7 +2140,7 @@ mod tests {
 
     #[test]
     fn test_char_table_hex_letters() {
-        for c in [b'A', b'B', b'C', b'D', b'F', b'a', b'b', b'c', b'd', b'f'] {
+        for c in *b"ABCDFabcdf" {
             let cl = char_class(c);
             assert_eq!(cl & LETTER, LETTER, "hex letter {}", c as char);
             assert_eq!(cl & HEX, HEX, "hex flag {}", c as char);
@@ -2149,7 +2149,7 @@ mod tests {
 
     #[test]
     fn test_char_table_exp_letters() {
-        for c in [b'E', b'e', b'P', b'p'] {
+        for c in *b"EePp" {
             let cl = char_class(c);
             assert_eq!(cl & EXP, EXP, "exp {}", c as char);
             assert_eq!(cl & LETTER, LETTER, "exp letter {}", c as char);
@@ -2194,7 +2194,7 @@ mod tests {
 
     #[test]
     fn test_char_table_valid_second() {
-        for c in [b'=', b'+', b'-', b'>', b'<', b'&', b'|', b'#'] {
+        for c in *b"=+-><&|#" {
             assert_ne!(
                 char_class(c) & VALID_SECOND,
                 0,

--- a/cron/spool.rs
+++ b/cron/spool.rs
@@ -107,7 +107,7 @@ pub fn at(
 
     let user = User::current().ok_or("Failed to get current user")?;
     if !is_user_allowed(&user.name) {
-        return Err(format!("Access denied for user: {}", &user.name).into());
+        return Err(format!("Access denied for user: {}", user.name).into());
     }
 
     let job = Job::new(&user, std::env::current_dir()?, std::env::vars(), cmd, mail).into_script();

--- a/editors/ed/buffer.rs
+++ b/editors/ed/buffer.rs
@@ -197,7 +197,7 @@ impl Buffer {
 
         // Update marks
         self.marks.retain(|_, line| *line < start || *line > end);
-        for (_, line) in self.marks.iter_mut() {
+        for line in self.marks.values_mut() {
             if *line > end {
                 *line -= end - start + 1;
             }

--- a/file/cmp.rs
+++ b/file/cmp.rs
@@ -101,7 +101,7 @@ fn cmp_main(args: &Args) -> io::Result<u8> {
                         // Don't print anything
                     } else if args.verbose {
                         // `{:o}` for the required octal representation output
-                        println!("{} {:o} {:o}", &bytes, c1, c2);
+                        println!("{} {:o} {:o}", bytes, c1, c2);
                     } else {
                         println!(
                             "{} {} differ: {} {}, {} {}",

--- a/make/src/parser/preprocessor.rs
+++ b/make/src/parser/preprocessor.rs
@@ -446,10 +446,9 @@ fn substitute(source: &str, table: &HashMap<String, String>) -> Result<(String, 
 fn parse_include_directive(line: &str) -> Option<(&str, bool)> {
     let (rest, ignore_missing) = if let Some(rest) = line.strip_prefix("-include") {
         (rest, true)
-    } else if let Some(rest) = line.strip_prefix("include") {
-        (rest, false)
     } else {
-        return None;
+        let rest = line.strip_prefix("include")?;
+        (rest, false)
     };
     if rest.starts_with([' ', '\t']) {
         Some((rest.trim(), ignore_missing))

--- a/man/man_util/formatter.rs
+++ b/man/man_util/formatter.rs
@@ -3680,7 +3680,7 @@ impl MdocFormatter {
     }
 
     fn format_fn_synopsis(&mut self, funcname: &str, macro_node: MacroNode) -> String {
-        format!("{};\n", &self.format_fn(funcname, macro_node))
+        format!("{};\n", self.format_fn(funcname, macro_node))
     }
 
     fn format_fr(&mut self, macro_node: MacroNode) -> String {
@@ -3835,7 +3835,7 @@ impl MdocFormatter {
         format!(
             "{}\\[pfmacroescape]{}",
             prefix,
-            &self.format_inline_macro(macro_node)
+            self.format_inline_macro(macro_node)
         )
     }
 

--- a/pax/formats/pax.rs
+++ b/pax/formats/pax.rs
@@ -409,10 +409,15 @@ impl ExtendedHeader {
     pub fn from_entry(entry: &ArchiveEntry, include_times: bool) -> Self {
         let mut header = ExtendedHeader::new();
 
-        // Path needs extended header if too long for ustar
-        let path_str = entry.path.to_string_lossy();
-        if path_str.len() > NAME_LEN + PREFIX_LEN + 1 {
-            header.path = Some(path_str.to_string());
+        // Path needs an extended header whenever it cannot be represented
+        // exactly by the ustar name/prefix pair. Length alone is not the test:
+        // a path under NAME_LEN + PREFIX_LEN + 1 bytes still fails to split
+        // when it has no '/' at a position that leaves a <= NAME_LEN tail
+        // (e.g. a 190-byte "dir/<185-byte-basename>"). Without this record the
+        // ustar fallback in split_path() silently truncates the name.
+        let path_str = ustar_path_string(entry);
+        if try_split_path(&path_str).is_none() {
+            header.path = Some(entry.path.to_string_lossy().into_owned());
         }
 
         // Link path needs extended header if too long
@@ -1065,11 +1070,9 @@ fn build_ustar_header(entry: &ArchiveEntry) -> PaxResult<[u8; BLOCK_SIZE]> {
     // Linkname
     if let Some(ref target) = entry.link_target {
         let link_str = target.to_string_lossy();
-        let truncated = if link_str.len() > LINKNAME_LEN {
-            &link_str[..LINKNAME_LEN]
-        } else {
-            &link_str
-        };
+        // Truncate on a char boundary; the full target is in the `linkpath`
+        // extended record whenever it exceeds LINKNAME_LEN.
+        let truncated = &link_str[..floor_char_boundary(&link_str, LINKNAME_LEN)];
         write_string(&mut header[LINKNAME_OFF..], truncated, LINKNAME_LEN);
     }
 
@@ -1099,45 +1102,66 @@ fn build_ustar_header(entry: &ArchiveEntry) -> PaxResult<[u8; BLOCK_SIZE]> {
     Ok(header)
 }
 
-/// Split path into name (max 100) and prefix (max 155)
-fn split_path(entry: &ArchiveEntry) -> PaxResult<(String, String)> {
+/// The path as it is written to the ustar name/prefix fields: directories
+/// carry a trailing slash. Shared by split_path() and ExtendedHeader so both
+/// judge "does this fit in ustar?" against the identical string.
+fn ustar_path_string(entry: &ArchiveEntry) -> String {
     let path_str = entry.path.to_string_lossy();
-
-    // Add trailing slash for directories
-    let path_str = if entry.is_dir() && !path_str.ends_with('/') {
+    if entry.is_dir() && !path_str.ends_with('/') {
         format!("{}/", path_str)
     } else {
-        path_str.to_string()
-    };
+        path_str.into_owned()
+    }
+}
 
+/// Split a path into ustar name (max 100) and prefix (max 155) fields.
+///
+/// Returns `None` if the path cannot be represented exactly, in which case the
+/// caller must emit a `path=` extended header record.
+fn try_split_path(path_str: &str) -> Option<(String, String)> {
     if path_str.len() <= NAME_LEN {
-        return Ok((path_str, String::new()));
+        return Some((path_str.to_string(), String::new()));
     }
 
-    // Try to split at a '/' within bounds
-    if path_str.len() <= NAME_LEN + PREFIX_LEN + 1 {
-        for i in (1..=PREFIX_LEN).rev() {
-            if i >= path_str.len() {
-                continue;
-            }
-            if path_str.as_bytes()[i] == b'/' {
-                let prefix = &path_str[..i];
-                let name = &path_str[i + 1..];
-                if name.len() <= NAME_LEN {
-                    return Ok((name.to_string(), prefix.to_string()));
-                }
-            }
+    // Split at the highest '/' that leaves a name of at most NAME_LEN bytes.
+    // '/' is ASCII, so an index holding it is always a char boundary.
+    for i in (1..=PREFIX_LEN.min(path_str.len().saturating_sub(1))).rev() {
+        if path_str.as_bytes()[i] == b'/' && path_str.len() - (i + 1) <= NAME_LEN {
+            return Some((path_str[i + 1..].to_string(), path_str[..i].to_string()));
         }
     }
 
-    // For pax format, if path is too long, we use extended headers
-    // Just truncate for the ustar header (extended header will have full path)
-    let truncated = if path_str.len() > NAME_LEN {
-        path_str[..NAME_LEN].to_string()
-    } else {
-        path_str
-    };
-    Ok((truncated, String::new()))
+    None
+}
+
+/// Split path into name (max 100) and prefix (max 155)
+fn split_path(entry: &ArchiveEntry) -> PaxResult<(String, String)> {
+    let path_str = ustar_path_string(entry);
+
+    if let Some(split) = try_split_path(&path_str) {
+        return Ok(split);
+    }
+
+    // The path does not fit; ExtendedHeader::from_entry has recorded the real
+    // path in a `path=` record, so the ustar fields are only a fallback for
+    // readers that ignore extended headers. Truncate on a UTF-8 char boundary
+    // so a multi-byte character straddling NAME_LEN does not panic.
+    Ok((
+        path_str[..floor_char_boundary(&path_str, NAME_LEN)].to_string(),
+        String::new(),
+    ))
+}
+
+/// Largest index `<= max` that lies on a UTF-8 character boundary of `s`.
+fn floor_char_boundary(s: &str, max: usize) -> usize {
+    if max >= s.len() {
+        return s.len();
+    }
+    let mut end = max;
+    while !s.is_char_boundary(end) {
+        end -= 1;
+    }
+    end
 }
 
 /// Convert EntryType to typeflag

--- a/pax/tests/archive/mod.rs
+++ b/pax/tests/archive/mod.rs
@@ -12,6 +12,7 @@
 use crate::common::*;
 use std::fs::{self, File};
 use std::io::Write;
+use std::path::{Path, PathBuf};
 use std::process::Command;
 use tempfile::TempDir;
 
@@ -792,4 +793,209 @@ fn test_symlink_tar_no_damaged_warning() {
     assert!(link_path.is_symlink(), "Symlink was not created");
     let target = fs::read_link(&link_path).unwrap();
     assert_eq!(target.to_string_lossy(), "hello.txt");
+}
+
+/// Write `src_dir` to a pax archive, extract it into a fresh directory, and
+/// return that directory plus the raw archive bytes. Fails loudly if pax
+/// panics on either leg.
+fn pax_roundtrip(temp: &TempDir, src_dir: &Path, tag: &str) -> (PathBuf, Vec<u8>) {
+    let archive = temp.path().join(format!("{}.tar", tag));
+    let dst_dir = temp.path().join(format!("dest-{}", tag));
+
+    let output = run_pax_in_dir(
+        &["-w", "-x", "pax", "-f", archive.to_str().unwrap(), "."],
+        src_dir,
+    );
+    assert!(
+        !stderr_str(&output).contains("panicked"),
+        "pax -w panicked ({}): {}",
+        tag,
+        stderr_str(&output)
+    );
+    assert_success(&output, "pax write");
+
+    fs::create_dir(&dst_dir).unwrap();
+    let output = run_pax_in_dir(&["-r", "-f", archive.to_str().unwrap()], &dst_dir);
+    assert!(
+        !stderr_str(&output).contains("panicked"),
+        "pax -r panicked ({}): {}",
+        tag,
+        stderr_str(&output)
+    );
+    assert_success(&output, "pax read");
+
+    (dst_dir, fs::read(&archive).unwrap())
+}
+
+/// Count pax extended-header records for `keyword`. Records are serialized as
+/// "<len> <keyword>=<value>\n", so the leading space anchors the match.
+fn count_pax_records(archive: &[u8], keyword: &str) -> usize {
+    let needle = format!(" {}=", keyword).into_bytes();
+    archive
+        .windows(needle.len())
+        .filter(|w| *w == needle.as_slice())
+        .count()
+}
+
+/// Sorted list of file names directly under `dir`.
+fn file_names_in(dir: &Path) -> Vec<String> {
+    let mut names: Vec<String> = fs::read_dir(dir)
+        .unwrap()
+        .map(|e| e.unwrap().file_name().to_string_lossy().into_owned())
+        .collect();
+    names.sort();
+    names
+}
+
+/// Issue #616: `pax -w` panicked on a name longer than the 100-byte ustar
+/// name field whose multi-byte character straddled the truncation point.
+/// The panic was only the visible half of the bug: such names were never
+/// given a `path=` extended header record at all, so they were silently
+/// truncated in the archive. Both halves are checked here.
+#[test]
+fn test_long_multibyte_name_roundtrip() {
+    let temp = TempDir::new().unwrap();
+    let src_dir = temp.path().join("source");
+    let nested = src_dir.join("test");
+    fs::create_dir_all(&nested).unwrap();
+
+    // "test/" + 90 * 'Я' (180 bytes) + suffix -> byte 100 lands inside a 'Я'.
+    let base: String = "\u{42f}".repeat(90);
+    let mut expected = Vec::new();
+    for i in 1..=12 {
+        let name = format!("{}{}.txt", base, i);
+        // The archive member path is "./test/<name>"; byte 100 of it must
+        // land inside a 'Я' for this to reproduce the reported panic.
+        assert!(
+            !format!("./test/{}", name).is_char_boundary(100),
+            "test setup: byte 100 must fall inside a multi-byte character"
+        );
+        File::create(nested.join(&name))
+            .unwrap()
+            .write_all(format!("contents {}", i).as_bytes())
+            .unwrap();
+        expected.push(name);
+    }
+    expected.sort();
+
+    let (dst_dir, archive) = pax_roundtrip(&temp, &src_dir, "multibyte");
+
+    // Each unrepresentable name must carry its own `path=` record; without
+    // them the ustar name field alone would silently lose the tail.
+    assert_eq!(
+        count_pax_records(&archive, "path"),
+        12,
+        "expected one path= record per over-long name"
+    );
+    assert_eq!(
+        file_names_in(&dst_dir.join("test")),
+        expected,
+        "long multi-byte names were not preserved through the archive"
+    );
+    for i in 1..=12 {
+        let name = format!("{}{}.txt", base, i);
+        assert_eq!(
+            fs::read_to_string(dst_dir.join("test").join(&name)).unwrap(),
+            format!("contents {}", i),
+            "content mismatch for name {}",
+            i
+        );
+    }
+}
+
+/// The same defect with no multi-byte character in sight: a 190-byte path
+/// that cannot be split at a '/' into ustar name/prefix got no `path=`
+/// record, so it was silently truncated to 100 bytes with no panic and no
+/// diagnostic. A char-boundary-only fix would leave this corruption in place.
+#[test]
+fn test_long_ascii_name_not_truncated() {
+    let temp = TempDir::new().unwrap();
+    let src_dir = temp.path().join("source");
+    let nested = src_dir.join("ascii");
+    fs::create_dir_all(&nested).unwrap();
+
+    // "./ascii/" + 180 'a' + ".txt": too long for the name field, and the
+    // only '/' leaves a 184-byte tail, so no ustar split exists.
+    let name = format!("{}.txt", "a".repeat(180));
+    File::create(nested.join(&name))
+        .unwrap()
+        .write_all(b"payload")
+        .unwrap();
+
+    let (dst_dir, archive) = pax_roundtrip(&temp, &src_dir, "ascii");
+
+    assert_eq!(
+        count_pax_records(&archive, "path"),
+        1,
+        "an unsplittable 190-byte path must get a path= record"
+    );
+    assert_eq!(file_names_in(&dst_dir.join("ascii")), vec![name.clone()]);
+    assert_eq!(
+        fs::read_to_string(dst_dir.join("ascii").join(&name)).unwrap(),
+        "payload"
+    );
+}
+
+/// A symlink target longer than the 100-byte linkname field, with a
+/// multi-byte character on the boundary, hit the identical slicing panic in
+/// the ustar fallback.
+#[cfg(unix)]
+#[test]
+fn test_long_multibyte_symlink_target() {
+    let temp = TempDir::new().unwrap();
+    let src_dir = temp.path().join("source");
+    fs::create_dir_all(&src_dir).unwrap();
+
+    // Leading 'a' shifts the 'Я' run so byte 100 falls inside a character.
+    let target = format!("a{}", "\u{42f}".repeat(90));
+    assert!(!target.is_char_boundary(100));
+    std::os::unix::fs::symlink(&target, src_dir.join("link")).unwrap();
+
+    let (dst_dir, archive) = pax_roundtrip(&temp, &src_dir, "symlink");
+
+    assert_eq!(
+        count_pax_records(&archive, "linkpath"),
+        1,
+        "an over-long symlink target must get a linkpath= record"
+    );
+    assert_eq!(
+        fs::read_link(dst_dir.join("link"))
+            .unwrap()
+            .to_string_lossy(),
+        target,
+        "long symlink target was not preserved"
+    );
+}
+
+/// Guard against over-correcting: a long path that *does* split cleanly at a
+/// '/' must keep using the ustar name/prefix fields and still round-trip.
+#[test]
+fn test_long_splittable_path_roundtrip() {
+    let temp = TempDir::new().unwrap();
+    let src_dir = temp.path().join("source");
+    let dir_name = "d".repeat(60);
+    let nested = src_dir.join(&dir_name);
+    fs::create_dir_all(&nested).unwrap();
+
+    let name = format!("{}.txt", "f".repeat(60));
+    File::create(nested.join(&name))
+        .unwrap()
+        .write_all(b"splittable")
+        .unwrap();
+
+    let (dst_dir, archive) = pax_roundtrip(&temp, &src_dir, "splittable");
+
+    // The whole point: this 127-byte path splits at '/' into a 62-byte prefix
+    // and a 64-byte name, so it must ride in the ustar fields with no `path=`
+    // record at all. A fix that widened the extended-header trigger too far
+    // would show up here as a spurious record.
+    assert_eq!(
+        count_pax_records(&archive, "path"),
+        0,
+        "a prefix-splittable path must not need an extended header"
+    );
+    assert_eq!(
+        fs::read_to_string(dst_dir.join(&dir_name).join(&name)).unwrap(),
+        "splittable"
+    );
 }

--- a/sh/builtin/dot.rs
+++ b/sh/builtin/dot.rs
@@ -33,7 +33,7 @@ impl SpecialBuiltinUtility for Dot {
         let file_path = if let Some(file_path) = find_command(&args[0], path) {
             file_path
         } else {
-            return Err(format!("dot: {}, no such file or directory\n", &args[0]).into());
+            return Err(format!("dot: {}, no such file or directory\n", args[0]).into());
         };
 
         std::mem::swap(&mut shell.opened_files, opened_files);

--- a/sh/parse/command.rs
+++ b/sh/parse/command.rs
@@ -180,7 +180,7 @@ impl Display for CaseItem {
             write!(f, " | {}", pattern.as_string)?;
         }
         write!(f, ")")?;
-        write!(f, " {}", &self.body)?;
+        write!(f, " {}", self.body)?;
         write!(f, "{}", if self.fallthrough { ";&" } else { ";;" })
     }
 }

--- a/text/nl.rs
+++ b/text/nl.rs
@@ -272,7 +272,7 @@ fn nl_main(args: &Args) -> io::Result<()> {
                 // Reference `nl` unconditionally adds a newline even on files
                 // not ending on a newline
                 line_buffer.push('\n');
-                print!("{}", &line_buffer);
+                print!("{}", line_buffer);
             }
 
             if non_text {

--- a/text/paste.rs
+++ b/text/paste.rs
@@ -170,7 +170,7 @@ fn parse_delimiters_argument(delimiters: Option<String>) -> Result<Box<[Box<[u8]
 
     let Some(delimiters_string) = delimiters else {
         // Default when no delimiter argument is provided
-        return Ok(Box::new([Box::new([b'\t'])]));
+        return Ok(Box::new([Box::new(*b"\t")]));
     };
 
     let mut buffer = [0_u8; 4];

--- a/text/pr.rs
+++ b/text/pr.rs
@@ -236,7 +236,7 @@ fn write_line_content(
         // that column alignment/truncation be suppressed: cells are emitted
         // as their raw transformed content with the user's separator
         // character between them.
-        write!(output_line, "{}", &tmp).into_io_result()?;
+        write!(output_line, "{}", tmp).into_io_result()?;
     } else {
         let mut width = column_width;
 
@@ -252,7 +252,7 @@ fn write_line_content(
         }
 
         // Pad or truncate
-        write!(output_line, "{:width$.width$}", &tmp).into_io_result()?;
+        write!(output_line, "{:width$.width$}", tmp).into_io_result()?;
     }
 
     Ok(())

--- a/tree/ls.rs
+++ b/tree/ls.rs
@@ -798,14 +798,14 @@ fn display_entries(entries: &mut [Entry], config: &Config, dir_path: Option<&str
                             for output in &stream_outputs[start..i] {
                                 print!("{}, ", output);
                             }
-                            println!("{},", &stream_outputs[i]);
+                            println!("{},", stream_outputs[i]);
 
                             start = i + 1;
                         } else {
                             // Long file name that exceeds
                             // `terminal_width` by itself
                             if start == i {
-                                println!("{}", &stream_outputs[i]);
+                                println!("{}", stream_outputs[i]);
                                 start = i + 1;
 
                             // `start..i` fits in `terminal_width`
@@ -813,7 +813,7 @@ fn display_entries(entries: &mut [Entry], config: &Config, dir_path: Option<&str
                                 for output in &stream_outputs[start..(i - 1)] {
                                     print!("{}, ", output);
                                 }
-                                println!("{},", &stream_outputs[i - 1]);
+                                println!("{},", stream_outputs[i - 1]);
 
                                 start = i;
                             }
@@ -826,7 +826,7 @@ fn display_entries(entries: &mut [Entry], config: &Config, dir_path: Option<&str
                     print!("{}, ", output);
                 }
                 // No comma on the very last file name
-                println!("{}", &stream_outputs[stream_outputs.len() - 1]);
+                println!("{}", stream_outputs[stream_outputs.len() - 1]);
 
                 break;
             }


### PR DESCRIPTION
ExtendedHeader::from_entry emitted a `path=` extended record only when a path exceeded NAME_LEN + PREFIX_LEN + 1 bytes, but split_path truncated whenever it could not split at a '/' leaving a tail of at most NAME_LEN. Paths in the 101..=256 byte gap were therefore truncated into the ustar name field with no record to recover them: `pax -x pax -w` on a 190-byte "dir/<185-byte-basename>" silently produced an archive holding a 94-byte name, and GNU tar read back the same truncated name.

Issue #616 is the UTF-8 flavour of that gap. When the 100-byte cut landed inside a multi-byte character, `path_str[..NAME_LEN]` panicked instead of truncating, which is why it surfaced first.

Give both sites one predicate and one string: try_split_path() reports whether a path fits the name/prefix pair, and ustar_path_string() builds the exact form both judge (directories carry a trailing slash; the two sites previously disagreed on that too). from_entry now records `path=` whenever try_split_path returns None. The residual ustar truncation is kept as a fallback for readers that ignore extended headers, but now cuts on a UTF-8 char boundary.

Fix the same slicing panic at the linkname field, where `&link_str[..LINKNAME_LEN]` aborted on an over-long symlink target whose multi-byte character straddled byte 100.

`-x ustar` is unaffected: it already diagnoses "Path too long" and skips the entry rather than truncating.

Tests: four integration tests in pax/tests/archive/mod.rs covering the reported multi-byte name, the pure-ASCII truncation that panics nothing and corrupts silently, the symlink target, and a guard asserting that a prefix-splittable path still needs no extended header. Each asserts on the archive's actual path=/linkpath= record counts. Three fail before this change; the guard passes both ways by design.

Fixes #616 
Supercedes #617 