### PR TITLE
cc: count every register a fixed parameter spends, and finish the va_…

### DIFF
--- a/cc/arch/aarch64/call.rs
+++ b/cc/arch/aarch64/call.rs
@@ -211,7 +211,19 @@ impl Aarch64CodeGen {
             let is_hfa_one = arg_type.is_some_and(|t| {
                 let abi =
                     crate::abi::get_abi_for_conv(crate::abi::CallingConv::C, &self.base.target);
-                matches!(abi.classify_param(t, types), ArgClass::Hfa { count: 1, .. })
+                // Only where the pseudo holds the *value*. Above a register's
+                // worth -- `struct { __float128 v; }` -- it holds an address,
+                // and that goes through the load below instead; moving it with
+                // `fmov` asks for a binary128 out of one X register, which does
+                // not exist.
+                types.size_bits(t) <= 64
+                    && matches!(abi.classify_param(t, types), ArgClass::Hfa { count: 1, .. })
+            });
+            let is_hfa_one_wide = arg_type.is_some_and(|t| {
+                let abi =
+                    crate::abi::get_abi_for_conv(crate::abi::CallingConv::C, &self.base.target);
+                types.size_bits(t) > 64
+                    && matches!(abi.classify_param(t, types), ArgClass::Hfa { count: 1, .. })
             });
             let is_fp = if is_hfa_one {
                 true
@@ -228,6 +240,16 @@ impl Aarch64CodeGen {
                 64
             };
 
+            if is_hfa_one_wide {
+                // One V register holding the whole aggregate, loaded from its
+                // address -- the same shape `setup_hfa2_arg` handles, with one
+                // element instead of two.
+                if fp_arg_idx < fp_arg_regs.len() {
+                    self.setup_hfa1_arg(arg, arg_type, fp_arg_regs[fp_arg_idx], types);
+                    fp_arg_idx += 1;
+                    continue;
+                }
+            }
             if uses_two_fp_regs {
                 if fp_arg_idx + 1 < fp_arg_regs.len() {
                     if is_hfa_two {
@@ -570,6 +592,42 @@ impl Aarch64CodeGen {
     }
 
     /// Set up an HFA-2 struct argument (two FP elements in consecutive V registers)
+    /// A one-element HFA wider than a register: load the whole aggregate into
+    /// one V register from its address. `setup_hfa2_arg` with a single element.
+    fn setup_hfa1_arg(
+        &mut self,
+        arg: PseudoId,
+        arg_type: Option<crate::types::TypeId>,
+        reg: VReg,
+        types: &TypeTable,
+    ) {
+        let arg_loc = self.get_location(arg);
+        let typ = arg_type.unwrap();
+        let abi = crate::abi::get_abi_for_conv(crate::abi::CallingConv::C, &self.base.target);
+        let fp_size = match abi.classify_param(typ, types) {
+            ArgClass::Hfa { base, .. } => match base {
+                HfaBase::Float16 => FpSize::Half,
+                HfaBase::Float32 => FpSize::Single,
+                HfaBase::Float64 => FpSize::Double,
+                HfaBase::Float128 => FpSize::Quad,
+            },
+            _ => FpSize::Double,
+        };
+        let addr = match arg_loc {
+            Loc::Stack(offset) => MemAddr::BaseOffset {
+                base: Reg::X29,
+                offset: self.stack_offset(offset),
+            },
+            Loc::Reg(r) => MemAddr::BaseOffset { base: r, offset: 0 },
+            _ => return,
+        };
+        self.push_lir(Aarch64Inst::LdrFp {
+            size: fp_size,
+            dst: reg,
+            addr,
+        });
+    }
+
     fn setup_hfa2_arg(
         &mut self,
         arg: PseudoId,

--- a/cc/arch/aarch64/call.rs
+++ b/cc/arch/aarch64/call.rs
@@ -201,7 +201,21 @@ impl Aarch64CodeGen {
                         }
                 });
             let uses_two_fp_regs = is_complex || is_hfa_two;
-            let is_fp = if let Some(typ) = arg_type {
+            // A one-element HFA -- `struct { float v; }`, and every shape that
+            // became one when arrays and half precision were admitted -- goes
+            // in a single V register, exactly as the bare scalar does. Only the
+            // two-element case was recognised here, so the rest went out in a
+            // general register while the callee, which does ask the ABI, read
+            // V0; and every floating argument after it was shifted a register
+            // along.
+            let is_hfa_one = arg_type.is_some_and(|t| {
+                let abi =
+                    crate::abi::get_abi_for_conv(crate::abi::CallingConv::C, &self.base.target);
+                matches!(abi.classify_param(t, types), ArgClass::Hfa { count: 1, .. })
+            });
+            let is_fp = if is_hfa_one {
+                true
+            } else if let Some(typ) = arg_type {
                 types.is_float(typ)
             } else {
                 let arg_loc = self.get_location(arg);

--- a/cc/arch/aarch64/codegen.rs
+++ b/cc/arch/aarch64/codegen.rs
@@ -368,14 +368,27 @@ impl Aarch64CodeGen {
             let mut ngrn = 0usize;
             let mut nsrn = 0usize;
             let mut named_stack = 0i32;
+            let abi = crate::abi::get_abi_for_conv(CallingConv::C, &self.base.target);
             for (_, typ) in &func.params {
-                let bank = if types.is_float(*typ) {
-                    &mut nsrn
-                } else {
-                    &mut ngrn
+                // Mirror `allocate_arguments`: it dispatches on the ABI class,
+                // and this has to agree with it or `va_start` skips the wrong
+                // number of slots. Asking `is_float` instead counted a
+                // `_Complex` -- two V registers -- as one general one, and an
+                // HFA of any size likewise.
+                let (bank, count) = match abi.classify_param(*typ, types) {
+                    ArgClass::Direct { ref classes, .. }
+                        if classes.len() == 1 && classes[0] == crate::abi::RegClass::Sse =>
+                    {
+                        (&mut nsrn, 1)
+                    }
+                    ArgClass::Hfa { count, .. } => (&mut nsrn, count as usize),
+                    _ if types.kind(*typ) == TypeKind::Int128 => (&mut ngrn, 2),
+                    // Everything else takes a single general register, which is
+                    // how this backend passes a struct: by pointer.
+                    _ => (&mut ngrn, 1),
                 };
-                if *bank < 8 {
-                    *bank += 1;
+                if *bank + count <= 8 {
+                    *bank += count;
                 } else {
                     let bytes = types.size_bits(*typ).div_ceil(8).max(1) as i32;
                     named_stack += (bytes + 7) & !7;

--- a/cc/arch/x86_64/codegen.rs
+++ b/cc/arch/x86_64/codegen.rs
@@ -1126,7 +1126,10 @@ impl X86_64CodeGen {
         let mut gp = 0usize;
         let mut fp = 0usize;
         for (_, typ) in &func.params {
+            let kind = types.kind(*typ);
             if let Some(classes) = crate::abi::struct_param_classes(*typ, types) {
+                // Nine to sixteen bytes: one register per eightbyte, from
+                // whichever file its class names.
                 for class in &classes {
                     if *class == crate::abi::RegClass::Sse {
                         fp += 1;
@@ -1134,8 +1137,21 @@ impl X86_64CodeGen {
                         gp += 1;
                     }
                 }
+            } else if let Some(n) = crate::abi::sse_struct_regs(*typ, types) {
+                // Eight bytes or fewer, all-SSE: one XMM.
+                fp += n;
+            } else if crate::abi::param_is_memory_class(*typ, types) {
+                // MEMORY class travels on the stack and spends no register.
+            } else if types.is_complex(*typ) {
+                // Two XMMs for `double _Complex`, one for `float _Complex`
+                // (both halves in one eightbyte), none for
+                // `long double _Complex`, which is COMPLEX_X87 and is passed
+                // in memory.
+                fp += complex_sse_regs(types, *typ);
+            } else if kind == TypeKind::Int128 {
+                gp += 2;
             } else if types.is_float(*typ) {
-                if types.kind(*typ) != crate::types::TypeKind::LongDouble {
+                if kind != TypeKind::LongDouble {
                     fp += 1;
                 }
             } else {

--- a/cc/arch/x86_64/codegen.rs
+++ b/cc/arch/x86_64/codegen.rs
@@ -1138,7 +1138,11 @@ impl X86_64CodeGen {
                     }
                 }
             } else if let Some(n) = crate::abi::sse_struct_regs(*typ, types) {
-                // Eight bytes or fewer, all-SSE: one XMM.
+                // An all-SSE aggregate: `n` XMM registers. Both the eight-byte
+                // and smaller shapes and the sixteen-byte SSE+SSEUP one -- a
+                // lone `__float128` -- land here, the latter because it answers
+                // a single class rather than the pair `struct_param_classes`
+                // above looks for.
                 fp += n;
             } else if crate::abi::param_is_memory_class(*typ, types) {
                 // MEMORY class travels on the stack and spends no register.

--- a/cc/arch/x86_64/features.rs
+++ b/cc/arch/x86_64/features.rs
@@ -384,10 +384,14 @@ impl X86_64CodeGen {
             .any(|p| p.id == ap_addr && matches!(&p.kind, crate::ir::PseudoKind::Sym(_)));
 
         let (base_reg, base_offset) = match &ap_loc {
-            // The slot *is* the va_list, so the base is the frame pointer and
-            // the displacement is the slot's own address -- not the slot index
-            // read as a displacement, which lands in the caller's frame.
-            Loc::Stack(ap_offset) if is_sym => (Reg::Rbp, -(*ap_offset + self.callee_saved_offset)),
+            // The slot *is* the va_list, so its own address is the base.
+            // Asking `stack_mem` rather than composing the displacement by hand
+            // is what keeps this right when locals are addressed off `%rsp`
+            // instead of `%rbp`, under dynamic stack alignment.
+            Loc::Stack(ap_offset) if is_sym => match self.stack_mem(*ap_offset) {
+                MemAddr::BaseOffset { base, offset } => (base, offset),
+                other => unreachable!("stack_mem gave a non-BaseOffset address: {other:?}"),
+            },
             Loc::Stack(ap_offset) => {
                 // Stack slot holds a pointer; load it into R11 first.
                 self.push_lir(X86Inst::Mov {

--- a/cc/ir/linearize.rs
+++ b/cc/ir/linearize.rs
@@ -934,7 +934,7 @@ impl<'a> Linearizer<'a> {
             && matches!(
                 get_abi_for_conv(self.current_calling_conv, self.target)
                     .classify_return(func.return_type, self.types),
-                crate::abi::ArgClass::X87 { .. } | crate::abi::ArgClass::Hfa { count: 1, .. }
+                crate::abi::ArgClass::X87 { .. } | crate::abi::ArgClass::Hfa { .. }
             );
         ir_func.ret_is_address = self.types.is_complex(func.return_type) || returns_x87_aggregate;
 
@@ -1423,7 +1423,12 @@ impl<'a> Linearizer<'a> {
         // registers was survivable on its own -- the backend put the halves
         // back together -- but the *inliner* then spliced a two-source `Ret`
         // into a caller expecting one value, and the top half came out zero.
-        let one_hfa_reg = matches!(ret_class, crate::abi::ArgClass::Hfa { count: 1, .. });
+        // Any HFA, not just a one-element one: the two-element form has the
+        // same hazard. Its `Ret` carried the halves as two general registers,
+        // and splicing that into a caller expecting one value dropped the
+        // second -- an inlined `struct { double a, b; }` return came back with
+        // its second half zeroed.
+        let one_hfa_reg = matches!(ret_class, crate::abi::ArgClass::Hfa { .. });
         if matches!(ret_class, crate::abi::ArgClass::X87 { .. }) || one_sse_reg || one_hfa_reg {
             let mut ret_insn = Instruction::ret_typed(Some(src_addr), ret_type, struct_size);
             ret_insn.abi_info = Some(Box::new(CallAbiInfo::new(vec![], ret_class)));

--- a/cc/ir/linearize.rs
+++ b/cc/ir/linearize.rs
@@ -990,7 +990,8 @@ impl<'a> Linearizer<'a> {
                     let abi = get_abi_for_conv(self.current_calling_conv, self.target);
                     matches!(
                         abi.classify_param(param.typ, self.types),
-                        crate::abi::ArgClass::Hfa { count, .. } if count >= 2
+                        crate::abi::ArgClass::Hfa { count, .. }
+                            if count >= 2 || size > 64
                     )
                 };
                 let is_two_fp_regs = is_hfa_param
@@ -999,13 +1000,12 @@ impl<'a> Linearizer<'a> {
                         let class = abi.classify_param(param.typ, self.types);
                         // Any all-SSE aggregate, whether that is two registers of
                         // eight bytes or one of sixteen.
-                        let all_sse =
-                            matches!(
-                                class,
-                                crate::abi::ArgClass::Direct { ref classes, .. }
-                                    if !classes.is_empty()
-                                        && classes.iter().all(|c| *c == crate::abi::RegClass::Sse)
-                            ) || matches!(class, crate::abi::ArgClass::Hfa { count: 2, .. });
+                        let all_sse = matches!(
+                            class,
+                            crate::abi::ArgClass::Direct { ref classes, .. }
+                                if !classes.is_empty()
+                                    && classes.iter().all(|c| *c == crate::abi::RegClass::Sse)
+                        ) || matches!(class, crate::abi::ArgClass::Hfa { .. });
                         // Two eightbytes of any classes -- both integer, or one of
                         // each -- arrive in two registers on x86-64 as well. The
                         // caller's half of this decision is gated the same way;
@@ -2917,13 +2917,12 @@ impl<'a> Linearizer<'a> {
                     // Medium struct (9-16 bytes): check ABI classification
                     let abi = get_abi_for_conv(self.current_calling_conv, self.target);
                     let class = abi.classify_param(arg_type, self.types);
-                    let is_two_fp_regs =
-                        matches!(
-                            class,
-                            crate::abi::ArgClass::Direct { ref classes, .. }
-                                if !classes.is_empty()
-                                    && classes.iter().all(|c| *c == crate::abi::RegClass::Sse)
-                        ) || matches!(class, crate::abi::ArgClass::Hfa { count: 2, .. });
+                    let is_two_fp_regs = matches!(
+                        class,
+                        crate::abi::ArgClass::Direct { ref classes, .. }
+                            if !classes.is_empty()
+                                && classes.iter().all(|c| *c == crate::abi::RegClass::Sse)
+                    ) || matches!(class, crate::abi::ArgClass::Hfa { .. });
                     // MEMORY class means the bytes go on the stack by value,
                     // exactly as an over-sixteen-byte struct already does.
                     // Reachable at this size only when an eightbyte holds a

--- a/cc/tests/codegen/cross_abi.rs
+++ b/cc/tests/codegen/cross_abi.rs
@@ -1334,3 +1334,49 @@ long v_cx(double _Complex z, ...)
         "__vr_offs must be -96 (two V registers taken):\n{body}"
     );
 }
+
+/// A one-element HFA argument goes in a V register on aarch64.
+///
+/// The caller recognised only the two-element case, so every shape that is an
+/// HFA of *one* element -- `struct { float v; }`, and everything that became
+/// one when array members and half precision were admitted -- went out in a
+/// general register. The callee does ask the ABI, so it read V0; and each
+/// floating argument after it was shifted a register along, which is how a
+/// variadic call whose named parameter was such a struct went wrong.
+#[test]
+fn codegen_aarch64_one_element_hfa_argument_uses_a_v_register() {
+    let src = r#"
+struct F1 { float v; };
+struct D1 { double v; };
+struct I1 { int v; };            /* control: not an HFA */
+
+extern long sink_f1(struct F1, double);
+extern long sink_d1(struct D1, double);
+extern long sink_i1(struct I1, double);
+
+long c_f1(struct F1 s) { return sink_f1(s, 5.0); }
+long c_d1(struct D1 s) { return sink_d1(s, 5.0); }
+long c_i1(struct I1 s) { return sink_i1(s, 5.0); }
+"#;
+    let asm = asm_for("aarch64_hfa1_arg", AARCH64_LINUX, src);
+
+    // The struct takes V0, so the double that follows it takes V1.
+    for (name, first) in [("c_f1", "s0"), ("c_d1", "d0")] {
+        let body = body_of(&asm, name);
+        assert!(
+            body.contains(&format!("fmov {first},")),
+            "{name} passes its HFA argument in V0:\n{body}"
+        );
+        assert!(
+            body.contains("d1,"),
+            "{name} passes the following double in V1:\n{body}"
+        );
+    }
+    // A non-HFA struct still goes in a general register, and the double after
+    // it is then the first floating argument.
+    let i1 = body_of(&asm, "c_i1");
+    assert!(
+        !i1.contains("d1,"),
+        "an integer struct leaves V0 for the double after it:\n{i1}"
+    );
+}

--- a/cc/tests/codegen/cross_abi.rs
+++ b/cc/tests/codegen/cross_abi.rs
@@ -1293,3 +1293,44 @@ struct D2 mkd2(void) { struct D2 r; r.a = 1.5; r.b = 2.5; return r; }
         );
     }
 }
+
+/// aarch64 `va_start` skips exactly the registers the named parameters took.
+///
+/// The counting loop asked `is_float`, which is false for a `_Complex` -- so a
+/// `double _Complex` named parameter, which arrives in *two* V registers, was
+/// counted as one general register and none floating. `va_start` then recorded
+/// the wrong `__gr_offs`/`__vr_offs` and the first variadic argument came from
+/// the wrong slot. The allocator dispatches on the ABI class; this now does
+/// too, so the two cannot disagree.
+///
+/// For `void f(double _Complex z, ...)` the named parameter takes no general
+/// register and two of eight V registers, so the offsets are -(8-0)*8 = -64 and
+/// -(8-2)*16 = -96. They are materialised as 16-bit immediates.
+#[test]
+fn codegen_aarch64_va_start_counts_named_registers() {
+    let src = r#"
+#include <stdarg.h>
+long v_cx(double _Complex z, ...)
+{
+    va_list ap; va_start(ap, z);
+    long a = va_arg(ap, long);
+    va_end(ap);
+    (void)z;
+    return a;
+}
+"#;
+    let asm = asm_for("aarch64_va_named_regs", AARCH64_LINUX, src);
+    let body = body_of(&asm, "v_cx");
+
+    // -64 and -96 as unsigned 16-bit halves.
+    let gr = (-64i32 as u32) & 0xffff;
+    let vr = (-96i32 as u32) & 0xffff;
+    assert!(
+        body.contains(&format!("#{gr}")),
+        "__gr_offs must be -64 (no general register taken):\n{body}"
+    );
+    assert!(
+        body.contains(&format!("#{vr}")),
+        "__vr_offs must be -96 (two V registers taken):\n{body}"
+    );
+}

--- a/cc/tests/codegen/misc.rs
+++ b/cc/tests/codegen/misc.rs
@@ -7168,3 +7168,77 @@ int main(void)
         0
     );
 }
+
+/// `va_start` counts every register a fixed parameter actually spends.
+///
+/// The register-save-area indices are derived from how many general and SSE
+/// registers the fixed parameters occupy. Counting each one as a single
+/// general register put those indices out, so the first variadic argument was
+/// read from the wrong slot -- for a `_Complex` (two XMMs), an `__int128` (two
+/// general registers), an all-SSE struct of eight bytes or fewer (one XMM,
+/// since that shape started travelling in one), a nine-to-sixteen-byte struct
+/// (one register per eightbyte), and a MEMORY-class one (none at all).
+#[test]
+fn codegen_va_start_counts_fixed_parameter_registers() {
+    let code = r#"
+#include <stdarg.h>
+
+struct LL  { long a, b; };
+struct DD  { double a, b; };
+struct F1  { float v; };
+struct DI  { double a; int b; };
+struct BIG { long a, b, c; };
+
+#define VA(name, type)                                                      \
+    __attribute__((noinline)) static long name(type s, ...)                 \
+    {                                                                       \
+        va_list ap; va_start(ap, s);                                        \
+        long a = va_arg(ap, long);                                          \
+        double b = va_arg(ap, double);                                      \
+        va_end(ap);                                                         \
+        (void)s;                                                            \
+        return a + (long)b;                                                 \
+    }
+
+VA(v_cx,   double _Complex)
+VA(v_i128, __int128)
+VA(v_f1,   struct F1)
+VA(v_dd,   struct DD)
+VA(v_ll,   struct LL)
+VA(v_di,   struct DI)
+VA(v_big,  struct BIG)
+VA(v_ld,   long double)
+VA(v_int,  int)
+VA(v_dbl,  double)
+
+int main(void)
+{
+    struct LL  ll  = { 1, 2 };
+    struct DD  dd  = { 1, 2 };
+    struct F1  f1  = { 1 };
+    struct DI  di  = { 1, 2 };
+    struct BIG big = { 1, 2, 3 };
+    __int128 q = 1;
+
+    if (v_cx(__builtin_complex(1.0, 2.0), 10L, 5.0) != 15) return 1;
+    if (v_i128(q, 10L, 5.0) != 15) return 2;
+    if (v_f1(f1, 10L, 5.0) != 15) return 3;
+    if (v_dd(dd, 10L, 5.0) != 15) return 4;
+    if (v_ll(ll, 10L, 5.0) != 15) return 5;
+    if (v_di(di, 10L, 5.0) != 15) return 6;
+    if (v_big(big, 10L, 5.0) != 15) return 7;
+    if (v_ld(1.0L, 10L, 5.0) != 15) return 8;
+
+    /* Controls: the two shapes that always cost exactly one register. */
+    if (v_int(1, 10L, 5.0) != 15) return 9;
+    if (v_dbl(1.0, 10L, 5.0) != 15) return 10;
+
+    return 0;
+}
+"#;
+    assert_eq!(compile_and_run("codegen_va_start_fixed_regs", code, &[]), 0);
+    assert_eq!(
+        compile_and_run_optimized("codegen_va_start_fixed_regs_opt", code),
+        0
+    );
+}

--- a/cc/tests/codegen/misc.rs
+++ b/cc/tests/codegen/misc.rs
@@ -7211,6 +7211,13 @@ VA(v_ld,   long double)
 VA(v_int,  int)
 VA(v_dbl,  double)
 
+/* Sixteen bytes, SSE+SSEUP: one XMM, not the register pair the shapes above
+   take. Only where the type exists -- Apple arm64 has no runtime for it. */
+#ifdef __FLT128_MANT_DIG__
+struct Q { __float128 v; };
+VA(v_q, struct Q)
+#endif
+
 int main(void)
 {
     struct LL  ll  = { 1, 2 };
@@ -7232,6 +7239,12 @@ int main(void)
     /* Controls: the two shapes that always cost exactly one register. */
     if (v_int(1, 10L, 5.0) != 15) return 9;
     if (v_dbl(1.0, 10L, 5.0) != 15) return 10;
+
+#ifdef __FLT128_MANT_DIG__
+    struct Q qs;
+    qs.v = 1.0q;
+    if (v_q(qs, 10L, 5.0) != 15) return 11;
+#endif
 
     return 0;
 }

--- a/cc/tests/codegen/misc.rs
+++ b/cc/tests/codegen/misc.rs
@@ -3437,11 +3437,8 @@ int main(void) {
     return 0;
 }
 "#;
-    // Use extra_opts to force -O0 only (optimization needs further work for 2-SSE structs)
-    assert_eq!(
-        compile_and_run("two_sse_struct_abi", code, &["-O0".to_string()]),
-        0
-    );
+    assert_eq!(compile_and_run("two_sse_struct_abi", code, &[]), 0);
+    assert_eq!(compile_and_run_optimized("two_sse_struct_abi_opt", code), 0);
 }
 
 // ============================================================================


### PR DESCRIPTION
…list stores

Three findings from review, all fair.

`va_start` derives the register-save-area indices from how many general and SSE registers the fixed parameters occupy, and the count treated all but a nine-to-sixteen-byte struct as one general register. So the first variadic argument came from the wrong slot after a `_Complex` (two XMMs), an `__int128` (two general registers), or an all-SSE struct of eight bytes or fewer -- that last one broken by the change that started passing those in an XMM, which moved the register they spend without moving the count. Three of eight shapes were wrong; MEMORY-class structs, which spend nothing, are counted now too.

`emit_va_start` wrote gp_offset through a hand-composed `%rbp` displacement while the three fields beside it went through `stack_field`. The conversion that moved the others missed it because that one names the field in shorthand.

And the `va_arg` path composed its base by hand as well, which is wrong under dynamic stack alignment, where locals are addressed off `%rsp`. It asks `stack_mem` now, like everything else.

The `__int128` probe for this turned up a separate pre-existing crash -- `(__int128)1` as a call argument panics the compiler in `int128_lo_mem_loc` -- which is not touched here.