### PR TITLE
cc/arch: give -g output line information a debugger can use

### DIFF
--- a/cc/arch/aarch64/frame.rs
+++ b/cc/arch/aarch64/frame.rs
@@ -218,6 +218,10 @@ impl Aarch64CodeGen {
         if self.base.emit_unwind_tables {
             self.push_lir(Aarch64Inst::Directive(Directive::CfiEndProc));
         }
+
+        // `.size f, .-f`: without it the symbol records st_size = 0 and a
+        // debugger cannot tell which function owns an address inside it.
+        self.push_lir(Aarch64Inst::Directive(Directive::size_to_here(&func.name)));
     }
 
     /// Emit function header directives (text section, visibility, alignment, label, CFI start)
@@ -261,6 +265,11 @@ impl Aarch64CodeGen {
 
         // Function label
         self.push_lir(Aarch64Inst::Directive(Directive::global_label(name)));
+
+        // The line the prologue belongs to, before the procedure starts --
+        // otherwise the function's entry address has no row in the line table
+        // and a debugger cannot place a breakpoint on the function at all.
+        self.base.emit_function_entry_loc(func);
 
         // CFI: Start procedure (enables stack unwinding for this function)
         if self.base.emit_unwind_tables {

--- a/cc/arch/codegen.rs
+++ b/cc/arch/codegen.rs
@@ -266,6 +266,37 @@ impl<I: LirInst + EmitAsm> CodeGenBase<I> {
         false
     }
 
+    /// Emit the `.loc` that covers a function's prologue.
+    ///
+    /// `emit_loc` runs per instruction as the blocks are emitted, so the first
+    /// `.loc` of a function landed *after* the prologue -- and a function's
+    /// entry address then had no row in the line table at all. `break f` asks
+    /// for exactly that address, so gdb answered "No line number information
+    /// available" and gave up on the whole function, even though every later
+    /// address in it was covered.
+    ///
+    /// gcc emits the opening line before `.cfi_startproc` for this reason. The
+    /// position comes from the first instruction that carries one, which is the
+    /// same position the old first `.loc` used; `emit_loc`'s own de-duplication
+    /// keeps it from being repeated once the blocks start.
+    pub fn emit_function_entry_loc(&mut self, func: &Function) {
+        if !self.emit_debug {
+            return;
+        }
+        let Some(pos) = func
+            .blocks
+            .iter()
+            .flat_map(|b| b.insns.iter())
+            .find_map(|i| i.pos.as_ref())
+        else {
+            return;
+        };
+        let file = pos.stream + 1; // DWARF file indices start at 1
+        self.push_directive(Directive::loc(file.into(), pos.line, pos.col.into()));
+        self.last_debug_line = pos.line;
+        self.last_debug_file = file;
+    }
+
     /// `.weak` and visibility for symbols this unit only declares.
     ///
     /// A defined symbol carries these on its own definition; a declared one has

--- a/cc/arch/dwarf.rs
+++ b/cc/arch/dwarf.rs
@@ -131,8 +131,16 @@ pub fn generate_debug_info<I: LirInst + EmitAsm>(
     // DW_AT_comp_dir (compilation directory)
     base.push_directive(Directive::Asciz(comp_dir.to_string()));
 
-    // DW_AT_stmt_list (offset into .debug_line, 0 to reference start)
-    base.push_directive(Directive::Long(0));
+    // DW_AT_stmt_list: this unit's own line program.
+    //
+    // A relocatable reference, not a literal 0. The assembler builds one line
+    // program per object from the `.loc` directives, and the linker packs them
+    // into `.debug_line` one after another -- so only the first object's
+    // program sits at offset 0. Every unit claiming 0 made every unit share the
+    // first one's line table: in a 56-unit link of sparse, exactly one file
+    // resolved to source lines and the other 55 reported none, which reads
+    // like missing debug info rather than a misdirected offset.
+    base.push_directive(Directive::LongSym(Symbol::local(".Ldebug_line0")));
 
     // DW_AT_low_pc (start of code)
     // Use 0 for data-only files with no code section
@@ -152,4 +160,10 @@ pub fn generate_debug_info<I: LirInst + EmitAsm>(
 
     // End label for unit length computation
     base.push_directive(Directive::local_label(".Ldebug_info_end"));
+
+    // The label `DW_AT_stmt_list` names. Entering the section is enough to
+    // anchor it at the start of this object's contribution; the assembler
+    // appends the line program it builds from the `.loc` directives after it.
+    base.push_directive(Directive::DebugLine);
+    base.push_directive(Directive::local_label(".Ldebug_line0"));
 }

--- a/cc/arch/lir.rs
+++ b/cc/arch/lir.rs
@@ -756,6 +756,12 @@ pub enum Directive {
 
     /// .quad symbol - emit 64-bit symbol address (for relocations)
     QuadSym(Symbol),
+    /// A relocatable four-byte symbol reference: `.long sym`.
+    ///
+    /// Needed for DWARF section offsets, which are 32-bit even on a 64-bit
+    /// target -- `DW_AT_stmt_list` names this unit's line program, and the
+    /// linker has to relocate it as the units are combined.
+    LongSym(Symbol),
 
     /// .quad symbol+offset - emit 64-bit symbol address with offset (for member pointers)
     QuadSymOffset(Symbol, i64),
@@ -768,6 +774,8 @@ pub enum Directive {
 
     /// .cfi_endproc - end procedure CFI
     CfiEndProc,
+    /// `.size sym, .-sym` -- see [`Directive::size_to_here`].
+    SizeToHere { sym: Symbol },
 
     /// .cfi_def_cfa register, offset - set CFA to register + offset
     CfiDefCfa { reg: String, offset: i32 },
@@ -798,6 +806,10 @@ pub enum Directive {
 
     /// .section .debug_abbrev (ELF) or __DWARF,__debug_abbrev (Mach-O)
     DebugAbbrev,
+    /// The `.debug_line` section. Only ever entered to place the label that
+    /// `DW_AT_stmt_list` names -- the line program itself is built by the
+    /// assembler from the `.loc` directives.
+    DebugLine,
 
     /// .uleb128 value - unsigned LEB128 encoding for DWARF
     Uleb128(u64),
@@ -893,6 +905,18 @@ impl Directive {
         Directive::Size {
             sym: Symbol::global(name),
             size,
+        }
+    }
+
+    /// `.size sym, .-sym`: the symbol runs from its label to here.
+    ///
+    /// A function's size is not known when its label is emitted, so it is
+    /// spelled as the distance to the current position rather than a number.
+    /// Without it the symbol records `st_size = 0`, and a debugger asked about
+    /// an address inside the function cannot tell which function owns it.
+    pub fn size_to_here(name: impl Into<String>) -> Self {
+        Directive::SizeToHere {
+            sym: Symbol::global(name),
         }
     }
 
@@ -1102,6 +1126,13 @@ impl EmitAsm for Directive {
                     let _ = writeln!(out, ".size {}, {}", sym.format_for_target(target), size);
                 }
             }
+            Directive::SizeToHere { sym } => {
+                // ELF only - Mach-O has no .size
+                if !matches!(target.os, Os::MacOS) {
+                    let name = sym.format_for_target(target);
+                    let _ = writeln!(out, ".size {}, .-{}", name, name);
+                }
+            }
             Directive::Comm { sym, size, align } => {
                 // macOS uses log2(alignment) for .comm, Linux uses byte alignment
                 let align_value = match target.os {
@@ -1196,6 +1227,9 @@ impl EmitAsm for Directive {
             Directive::QuadSym(sym) => {
                 let _ = writeln!(out, "    .quad {}", sym.format_for_target(target));
             }
+            Directive::LongSym(sym) => {
+                let _ = writeln!(out, "    .long {}", sym.format_for_target(target));
+            }
             Directive::QuadSymOffset(sym, offset) => {
                 if *offset >= 0 {
                     let _ = writeln!(
@@ -1254,6 +1288,15 @@ impl EmitAsm for Directive {
                 _ => {
                     // ELF format
                     let _ = writeln!(out, ".section .debug_abbrev,\"\",@progbits");
+                }
+            },
+            Directive::DebugLine => match target.os {
+                Os::MacOS => {
+                    let _ = writeln!(out, ".section __DWARF,__debug_line,regular,debug");
+                }
+                _ => {
+                    // ELF format
+                    let _ = writeln!(out, ".section .debug_line,\"\",@progbits");
                 }
             },
             Directive::Uleb128(v) => {

--- a/cc/arch/x86_64/frame.rs
+++ b/cc/arch/x86_64/frame.rs
@@ -223,6 +223,10 @@ impl X86_64CodeGen {
         if self.base.emit_unwind_tables {
             self.push_lir(X86Inst::Directive(Directive::CfiEndProc));
         }
+
+        // `.size f, .-f`: without it the symbol records st_size = 0 and a
+        // debugger cannot tell which function owns an address inside it.
+        self.push_lir(X86Inst::Directive(Directive::size_to_here(&func.name)));
     }
 
     /// Emit function header directives (text section, visibility, type, label, CFI start)
@@ -263,6 +267,11 @@ impl X86_64CodeGen {
 
         // Function label
         self.push_lir(X86Inst::Directive(Directive::global_label(name)));
+
+        // The line the prologue belongs to, before the procedure starts --
+        // otherwise the function's entry address has no row in the line table
+        // and a debugger cannot place a breakpoint on the function at all.
+        self.base.emit_function_entry_loc(func);
 
         // CFI: Start procedure (enables stack unwinding for this function)
         if self.base.emit_unwind_tables {

--- a/cc/tests/codegen/debug_info.rs
+++ b/cc/tests/codegen/debug_info.rs
@@ -1,0 +1,111 @@
+//
+// Copyright (c) 2025-2026 Jeff Garzik
+//
+// This file is part of the posixutils-rs project covered under
+// the MIT License.  For the full license text, please see the LICENSE
+// file in the root directory of this project.
+// SPDX-License-Identifier: MIT
+//
+// What `-g` has to put in the assembly for a debugger to be able to use it.
+//
+// These are assembly assertions rather than a debugger session: gdb is not a
+// build dependency, and the properties below are exactly the ones whose absence
+// left a c17-built binary showing symbol names and no source lines.
+//
+
+use super::asm_probe::{asm_for_with, body_of, AARCH64_LINUX, X86_64_LINUX};
+
+const DARWIN: &str = "aarch64-apple-darwin";
+
+/// A function's prologue carries a `.loc`, so its entry address has a line.
+///
+/// `.loc` is emitted per instruction as the blocks are walked, so the first one
+/// of a function used to land *after* the prologue -- leaving the function's
+/// entry address with no row in the line table at all. `break f` asks for
+/// exactly that address, so gdb answered "No line number information available"
+/// and gave up on the whole function, though every later address in it was
+/// covered. gcc emits the opening line before `.cfi_startproc` for this reason.
+#[test]
+fn codegen_debug_prologue_has_a_line() {
+    let src = "int add(int a, int b)\n{\n\tint c = a + b;\n\treturn c;\n}\n";
+
+    for triple in [X86_64_LINUX, AARCH64_LINUX] {
+        let asm = asm_for_with("debug_prologue_loc", triple, src, &["-g", "-O0"]);
+        let body = body_of(&asm, "add");
+        let first = body
+            .lines()
+            .map(str::trim)
+            .find(|l| l.starts_with(".loc ") || l.starts_with(".cfi_startproc"))
+            .unwrap_or_else(|| panic!("{triple}: neither .loc nor .cfi_startproc in:\n{body}"));
+        assert!(
+            first.starts_with(".loc "),
+            "{triple}: the first thing in the function must be a .loc, so the \
+             entry address has a line; found {first:?} in:\n{body}"
+        );
+    }
+}
+
+/// Each function records its size, so a debugger can tell which one owns an
+/// address. Without `.size` the symbol carries `st_size = 0`.
+#[test]
+fn codegen_debug_functions_have_a_size() {
+    let src = "int add(int a, int b) { return a + b; }\nint main(void) { return add(1, 2) - 3; }\n";
+
+    for triple in [X86_64_LINUX, AARCH64_LINUX] {
+        let asm = asm_for_with("debug_size", triple, src, &["-g", "-O0"]);
+        for f in ["add", "main"] {
+            assert!(
+                asm.contains(&format!(".size {f}, .-{f}")),
+                "{triple}: {f} needs `.size {f}, .-{f}`:\n{asm}"
+            );
+        }
+    }
+
+    // Mach-O has no `.size`; emitting one is an assembler error there.
+    let asm = asm_for_with("debug_size_macho", DARWIN, src, &["-g", "-O0"]);
+    assert!(
+        !asm.contains(".size"),
+        "Mach-O has no .size directive:\n{asm}"
+    );
+}
+
+/// `DW_AT_stmt_list` names *this* unit's line program, not offset zero.
+///
+/// The assembler builds one line program per object from the `.loc` directives
+/// and the linker packs them into `.debug_line` one after another, so only the
+/// first object's program sits at offset 0. Emitting a literal 0 made every
+/// unit share the first one's line table: linking sparse's 56 units gave source
+/// lines for exactly one file and none for the other 55, which reads like
+/// missing debug info rather than a misdirected offset.
+///
+/// A single-unit program cannot show this -- its line program really is at 0 --
+/// which is why it survived every small test.
+#[test]
+fn codegen_debug_stmt_list_is_relocatable() {
+    let src = "int f(void) { return 1; }\n";
+
+    for triple in [X86_64_LINUX, AARCH64_LINUX, DARWIN] {
+        let asm = asm_for_with("debug_stmt_list", triple, src, &["-g", "-O0"]);
+        assert!(
+            asm.contains(".long .Ldebug_line0"),
+            "{triple}: DW_AT_stmt_list must reference this unit's line program:\n{asm}"
+        );
+        assert!(
+            asm.contains(".Ldebug_line0:"),
+            "{triple}: the label DW_AT_stmt_list names must be defined, at the \
+             start of this object's .debug_line contribution:\n{asm}"
+        );
+    }
+}
+
+/// `-g` is what turns all of this on; without it none of it appears.
+#[test]
+fn codegen_debug_directives_need_dash_g() {
+    let src = "int f(void) { return 1; }\n";
+    let asm = asm_for_with("debug_off", X86_64_LINUX, src, &["-O0"]);
+    assert!(!asm.contains(".loc "), "no .loc without -g:\n{asm}");
+    assert!(
+        !asm.contains(".Ldebug_line0"),
+        "no line-program label without -g:\n{asm}"
+    );
+}

--- a/cc/tests/codegen/mod.rs
+++ b/cc/tests/codegen/mod.rs
@@ -14,6 +14,7 @@
 pub mod asm_probe;
 mod atomics_asm;
 mod cross_abi;
+mod debug_info;
 mod inline_asm;
 mod misc;
 mod pic;


### PR DESCRIPTION
Three defects, each of which alone left a c17-built binary showing symbol names and no source lines.

**The prologue had no line.** `.loc` is emitted per instruction as the blocks are walked, so a function's first one landed *after* the prologue and its entry address had no row in the line table at all. `break f` asks for exactly that address, so gdb answered "No line number information available" and gave up on the whole function -- although every later address in it was covered. gcc emits the opening line before `.cfi_startproc` for this reason, and now so does c17.

**Functions had no size.** No `.size f, .-f`, so every function symbol recorded `st_size = 0` and a debugger could not tell which function owns an address inside it. `Directive::Size` takes a number, which a function's size is not when its label is emitted; `size_to_here` spells it as the distance to here. Mach-O has no `.size` and is skipped, as the existing directive already does.

**Every unit claimed the same line program.** `DW_AT_stmt_list` was a literal 0. The assembler builds one line program per object from the `.loc` directives and the linker packs them into `.debug_line` one after another, so only the first object's program sits at offset 0 -- every other unit was reading the first one's line table. Linking sparse's 56 units gave source lines for exactly one file and none for the other 55. It is now a relocatable reference to a label at the start of this object's own contribution, which is what gcc emits.

A single-unit program cannot show that last one -- its line program really is at offset 0 -- which is why it survived every small test. What it looks like from the outside, on a c17-built sparse:

    before:  #0  0x00005555555a65ec in do_preprocess ()
             #4  0x0000555555566d02 in main () at sparse.c:330

    after:   #0  do_preprocess () at pre-process.c:2221
             #1  preprocess () at pre-process.c:2269
             #2  sparse_tokenstream () at lib.c:302
             #3  sparse_initialize () at lib.c:377
             #4  main () at sparse.c:330

Still absent: `DW_TAG_subprogram` DIEs, so frames show no parameter values (`do_preprocess ()` where gcc gives `do_preprocess (list=0x...)`). That is variable and type debug information rather than line information, and is left for its own change.