### PR TITLE
cc/arch: describe functions and their variables in DWARF

### DIFF
--- a/cc/arch/aarch64/codegen.rs
+++ b/cc/arch/aarch64/codegen.rs
@@ -1366,14 +1366,15 @@ impl CodeGenerator for Aarch64CodeGen {
             };
 
             super::super::dwarf::generate_abbrev_table(&mut self.base);
-            super::super::dwarf::generate_debug_info(
-                &mut self.base,
-                &producer,
+            let fns = std::mem::take(&mut self.base.fn_dies);
+            let unit = super::super::dwarf::UnitInfo {
+                producer: &producer,
                 source_name,
                 comp_dir,
-                low_pc,
-                high_pc,
-            );
+                low_pc_label: low_pc,
+                high_pc_label: high_pc,
+            };
+            super::super::dwarf::generate_debug_info(&mut self.base, &unit, &fns, types);
         }
 
         // Emit .note.GNU-stack section to mark stack as non-executable (ELF only)

--- a/cc/arch/aarch64/frame.rs
+++ b/cc/arch/aarch64/frame.rs
@@ -219,9 +219,72 @@ impl Aarch64CodeGen {
             self.push_lir(Aarch64Inst::Directive(Directive::CfiEndProc));
         }
 
+        // The label `DW_AT_high_pc` names, before `.size` so it marks the end
+        // of the code rather than a point after the directive.
+        if self.base.emit_debug {
+            let end = format!(".Lfunc_end_{}", self.base.current_fn);
+            self.push_lir(Aarch64Inst::Directive(Directive::local_label(&end)));
+            self.collect_fn_die(func, types, end);
+        }
+
         // `.size f, .-f`: without it the symbol records st_size = 0 and a
         // debugger cannot tell which function owns an address inside it.
         self.push_lir(Aarch64Inst::Directive(Directive::size_to_here(&func.name)));
+    }
+
+    /// Record what `-g` has to say about this function.
+    ///
+    /// Only here can it be said: a variable's home is the register allocator's
+    /// answer for *this* function, and `self.locations` is overwritten by the
+    /// next one. A local with no stack slot -- promoted to a register, or gone
+    /// entirely -- gets no location rather than a made-up one.
+    fn collect_fn_die(&mut self, func: &Function, types: &TypeTable, end_label: String) {
+        let params: std::collections::HashSet<&str> =
+            func.params.iter().map(|(n, _)| n.as_str()).collect();
+        let mut names: Vec<&String> = func.locals.keys().collect();
+        names.sort();
+
+        let mut vars = Vec::new();
+        for name in names {
+            let local = &func.locals[name];
+            // Compiler-introduced storage has no name a debugger should show.
+            if name.starts_with("__") || name.starts_with('.') {
+                continue;
+            }
+            let loc = self
+                .locations
+                .get(local.sym)
+                .and_then(|l| self.loc_addr_parts(&l))
+                .map(|(reg, off)| crate::arch::dwarf::VarLocation {
+                    reg: reg.dwarf_number(),
+                    offset: off as i64,
+                });
+            vars.push(crate::arch::dwarf::VarDie {
+                name: name.clone(),
+                typ: local.typ,
+                decl_line: 0,
+                is_param: params.contains(name.as_str()),
+                loc,
+            });
+        }
+
+        let ret_typ = (types.kind(func.return_type) != TypeKind::Void).then_some(func.return_type);
+        let decl_line = func
+            .blocks
+            .iter()
+            .flat_map(|b| b.insns.iter())
+            .find_map(|i| i.pos.as_ref())
+            .map(|p| p.line)
+            .unwrap_or(0);
+
+        self.base.fn_dies.push(crate::arch::dwarf::FnDie {
+            name: func.name.clone(),
+            external: !func.is_static,
+            decl_line,
+            end_label,
+            ret_typ,
+            vars,
+        });
     }
 
     /// Emit function header directives (text section, visibility, alignment, label, CFI start)

--- a/cc/arch/aarch64/regalloc.rs
+++ b/cc/arch/aarch64/regalloc.rs
@@ -174,6 +174,52 @@ impl Reg {
         }
     }
 
+    /// This register's DWARF number, for debug location expressions.
+    ///
+    /// AAPCS64 numbers `x0`-`x30` as 0-30 and `sp` as 31. Spelled out rather
+    /// than taken from the discriminant: **x18 is absent from this enum** --
+    /// it is platform-reserved and the compiler never allocates it -- so every
+    /// variant after `X17` sits one below its register number. Reading the
+    /// discriminant made the frame pointer `x29` come out as 28, and gdb
+    /// resolved every local against the wrong register.
+    pub fn dwarf_number(&self) -> u16 {
+        match self {
+            Reg::X0 => 0,
+            Reg::X1 => 1,
+            Reg::X2 => 2,
+            Reg::X3 => 3,
+            Reg::X4 => 4,
+            Reg::X5 => 5,
+            Reg::X6 => 6,
+            Reg::X7 => 7,
+            Reg::X8 => 8,
+            Reg::X9 => 9,
+            Reg::X10 => 10,
+            Reg::X11 => 11,
+            Reg::X12 => 12,
+            Reg::X13 => 13,
+            Reg::X14 => 14,
+            Reg::X15 => 15,
+            Reg::X16 => 16,
+            Reg::X17 => 17,
+            Reg::X19 => 19,
+            Reg::X20 => 20,
+            Reg::X21 => 21,
+            Reg::X22 => 22,
+            Reg::X23 => 23,
+            Reg::X24 => 24,
+            Reg::X25 => 25,
+            Reg::X26 => 26,
+            Reg::X27 => 27,
+            Reg::X28 => 28,
+            Reg::X29 => 29,
+            Reg::X30 => 30,
+            Reg::SP => 31,
+            // The zero register has no DWARF number; nothing is ever located
+            // relative to it.
+            Reg::Xzr => 31,
+        }
+    }
     pub fn is_callee_saved(&self) -> bool {
         matches!(
             self,

--- a/cc/arch/codegen.rs
+++ b/cc/arch/codegen.rs
@@ -136,6 +136,13 @@ pub struct CodeGenBase<I: LirInst> {
     /// buffer lets `emit_all` append it to the line it has just written,
     /// without a new field on either enum or a change to any `emit` arm.
     pub lir_comments: std::collections::HashMap<usize, String>,
+    /// What `-g` needs to say about each function: its extent, and the
+    /// parameters and locals inside it with where they live.
+    ///
+    /// Collected as the functions are emitted, because that is the only point
+    /// at which a variable's home is known -- the register allocator's decision
+    /// is per-function and is not kept afterwards.
+    pub fn_dies: Vec<super::dwarf::FnDie>,
 }
 
 impl<I: LirInst + EmitAsm> CodeGenBase<I> {
@@ -153,6 +160,7 @@ impl<I: LirInst + EmitAsm> CodeGenBase<I> {
             shared_mode: false,
             verbose_asm: false,
             lir_comments: std::collections::HashMap::new(),
+            fn_dies: Vec::new(),
         }
     }
 

--- a/cc/arch/dwarf.rs
+++ b/cc/arch/dwarf.rs
@@ -11,6 +11,8 @@
 
 use super::codegen::CodeGenBase;
 use super::lir::{Directive, EmitAsm, LirInst, Symbol};
+use crate::types::{TypeId, TypeKind, TypeTable};
+use std::collections::HashMap;
 
 // DWARF Constants (DWARF Version 2)
 
@@ -36,66 +38,546 @@ pub const DW_LANG_C99: u64 = 0x0c;
 
 // DWARF Children flag
 pub const DW_CHILDREN_NO: u64 = 0x00;
+pub const DW_CHILDREN_YES: u64 = 0x01;
+
+// Tags for the DIEs that describe functions and the things inside them.
+pub const DW_TAG_ARRAY_TYPE: u64 = 0x01;
+pub const DW_TAG_FORMAL_PARAMETER: u64 = 0x05;
+pub const DW_TAG_POINTER_TYPE: u64 = 0x0f;
+pub const DW_TAG_STRUCTURE_TYPE: u64 = 0x13;
+pub const DW_TAG_UNION_TYPE: u64 = 0x17;
+pub const DW_TAG_BASE_TYPE: u64 = 0x24;
+pub const DW_TAG_SUBPROGRAM: u64 = 0x2e;
+pub const DW_TAG_VARIABLE: u64 = 0x34;
+pub const DW_TAG_SUBRANGE_TYPE: u64 = 0x21;
+
+pub const DW_AT_BYTE_SIZE: u64 = 0x0b;
+pub const DW_AT_ENCODING: u64 = 0x3e;
+pub const DW_AT_EXTERNAL: u64 = 0x3f;
+pub const DW_AT_LOCATION: u64 = 0x02;
+pub const DW_AT_UPPER_BOUND: u64 = 0x2f;
+pub const DW_AT_DECL_FILE: u64 = 0x3a;
+pub const DW_AT_DECL_LINE: u64 = 0x3b;
+pub const DW_AT_TYPE: u64 = 0x49;
+
+pub const DW_FORM_BLOCK1: u64 = 0x0a;
+pub const DW_FORM_DATA1: u64 = 0x0b;
+pub const DW_FORM_FLAG: u64 = 0x0c;
+pub const DW_FORM_REF4: u64 = 0x13;
+
+// Base-type encodings (DW_ATE_*)
+pub const DW_ATE_BOOLEAN: u64 = 0x02;
+pub const DW_ATE_FLOAT: u64 = 0x04;
+pub const DW_ATE_SIGNED: u64 = 0x05;
+pub const DW_ATE_SIGNED_CHAR: u64 = 0x06;
+pub const DW_ATE_UNSIGNED: u64 = 0x07;
+pub const DW_ATE_UNSIGNED_CHAR: u64 = 0x08;
+
+/// `DW_OP_breg0` -- register N's value plus a signed offset.
+pub const DW_OP_BREG0: i64 = 0x70;
+
+// Abbreviation codes. One per DIE shape; `.debug_info` stores the code and the
+// attribute values, and this table says which attributes follow.
+const ABBREV_CU: u64 = 1;
+const ABBREV_SUBPROGRAM_TYPED: u64 = 2;
+const ABBREV_SUBPROGRAM_VOID: u64 = 3;
+const ABBREV_PARAM_LOC: u64 = 4;
+const ABBREV_PARAM_NOLOC: u64 = 5;
+const ABBREV_VAR_LOC: u64 = 6;
+const ABBREV_VAR_NOLOC: u64 = 7;
+const ABBREV_BASE_TYPE: u64 = 8;
+const ABBREV_POINTER: u64 = 9;
+const ABBREV_POINTER_VOID: u64 = 10;
+const ABBREV_ARRAY: u64 = 11;
+const ABBREV_SUBRANGE: u64 = 12;
+const ABBREV_STRUCT: u64 = 13;
+const ABBREV_UNION: u64 = 14;
+
+/// Where a variable lives, as the code generator computed it: a register and a
+/// byte offset from it.
+///
+/// Taken from the same address computation the loads and stores use, rather
+/// than re-derived from the frame layout here. That is what makes it right for
+/// an over-aligned frame, whose locals are not addressed from the frame
+/// pointer at all -- and it means a location can never disagree with the code.
+#[derive(Debug, Clone, Copy)]
+pub struct VarLocation {
+    /// The DWARF register number of the base.
+    pub reg: u16,
+    /// Byte displacement from that register.
+    pub offset: i64,
+}
+
+/// A parameter or local a debugger should be able to name.
+#[derive(Debug, Clone)]
+pub struct VarDie {
+    pub name: String,
+    pub typ: TypeId,
+    pub decl_line: u32,
+    pub is_param: bool,
+    /// `None` when the variable has no stack home -- promoted to a register,
+    /// or optimized away. Emitting a location then would be a lie, and gdb
+    /// says "optimized out" on its own when there is none.
+    pub loc: Option<VarLocation>,
+}
+
+/// A function a debugger should be able to enter.
+#[derive(Debug, Clone)]
+pub struct FnDie {
+    pub name: String,
+    pub external: bool,
+    pub decl_line: u32,
+    /// Label marking the first byte past the function, for `DW_AT_high_pc`.
+    pub end_label: String,
+    /// `None` for a `void` function.
+    pub ret_typ: Option<TypeId>,
+    pub vars: Vec<VarDie>,
+}
 
 // DWARF Generation Functions
 
 /// Generate the abbreviation table for a minimal compile unit.
 /// This defines the structure of DIEs (Debug Information Entries).
+/// One abbreviation: its code, tag, whether it has children, and the
+/// (attribute, form) pairs that follow in `.debug_info`.
+fn abbrev<I: LirInst + EmitAsm>(
+    base: &mut CodeGenBase<I>,
+    code: u64,
+    tag: u64,
+    children: u64,
+    attrs: &[(u64, u64)],
+) {
+    base.push_directive(Directive::Uleb128(code));
+    base.push_directive(Directive::Uleb128(tag));
+    base.push_directive(Directive::Byte(children as i64));
+    for (at, form) in attrs {
+        base.push_directive(Directive::Uleb128(*at));
+        base.push_directive(Directive::Uleb128(*form));
+    }
+    // (0, 0) ends the attribute list.
+    base.push_directive(Directive::Uleb128(0));
+    base.push_directive(Directive::Uleb128(0));
+}
+
+/// Generate the abbreviation table: the shapes of DIE that `.debug_info` uses.
+///
+/// This was a single entry -- a compile unit with no children -- so a c17
+/// binary described its files and nothing inside them. gdb fell back to the
+/// ELF symbol table for function names, which is why backtraces named
+/// functions but `info args`, `info locals` and `ptype` all came back empty.
+///
+/// Several shapes come in pairs because DWARF has no "absent" value: a
+/// function with no return type and one with a return type are different
+/// shapes, as are a variable that has a location and one that does not.
 pub fn generate_abbrev_table<I: LirInst + EmitAsm>(base: &mut CodeGenBase<I>) {
-    // Switch to .debug_abbrev section
     base.push_directive(Directive::DebugAbbrev);
     base.push_directive(Directive::local_label(".Ldebug_abbrev0"));
 
-    // Abbreviation 1: DW_TAG_compile_unit (no children)
-    base.push_directive(Directive::Uleb128(1)); // Abbreviation code
-    base.push_directive(Directive::Uleb128(DW_TAG_COMPILE_UNIT));
-    base.push_directive(Directive::Byte(DW_CHILDREN_NO as i64));
+    abbrev(
+        base,
+        ABBREV_CU,
+        DW_TAG_COMPILE_UNIT,
+        DW_CHILDREN_YES,
+        &[
+            (DW_AT_PRODUCER, DW_FORM_STRING),
+            (DW_AT_LANGUAGE, DW_FORM_DATA4),
+            (DW_AT_NAME, DW_FORM_STRING),
+            (DW_AT_COMP_DIR, DW_FORM_STRING),
+            (DW_AT_STMT_LIST, DW_FORM_DATA4),
+            (DW_AT_LOW_PC, DW_FORM_ADDR),
+            (DW_AT_HIGH_PC, DW_FORM_ADDR),
+        ],
+    );
 
-    // Attribute: DW_AT_producer (string)
-    base.push_directive(Directive::Uleb128(DW_AT_PRODUCER));
-    base.push_directive(Directive::Uleb128(DW_FORM_STRING));
+    let subprogram_attrs: &[(u64, u64)] = &[
+        (DW_AT_EXTERNAL, DW_FORM_FLAG),
+        (DW_AT_NAME, DW_FORM_STRING),
+        (DW_AT_DECL_FILE, DW_FORM_DATA1),
+        (DW_AT_DECL_LINE, DW_FORM_DATA4),
+        (DW_AT_LOW_PC, DW_FORM_ADDR),
+        (DW_AT_HIGH_PC, DW_FORM_ADDR),
+    ];
+    let mut typed: Vec<(u64, u64)> = subprogram_attrs.to_vec();
+    typed.push((DW_AT_TYPE, DW_FORM_REF4));
+    abbrev(
+        base,
+        ABBREV_SUBPROGRAM_TYPED,
+        DW_TAG_SUBPROGRAM,
+        DW_CHILDREN_YES,
+        &typed,
+    );
+    abbrev(
+        base,
+        ABBREV_SUBPROGRAM_VOID,
+        DW_TAG_SUBPROGRAM,
+        DW_CHILDREN_YES,
+        subprogram_attrs,
+    );
 
-    // Attribute: DW_AT_language (4-byte data)
-    base.push_directive(Directive::Uleb128(DW_AT_LANGUAGE));
-    base.push_directive(Directive::Uleb128(DW_FORM_DATA4));
+    // A parameter and a local differ only by tag; both come with and without a
+    // location.
+    let var_attrs: &[(u64, u64)] = &[
+        (DW_AT_NAME, DW_FORM_STRING),
+        (DW_AT_DECL_FILE, DW_FORM_DATA1),
+        (DW_AT_DECL_LINE, DW_FORM_DATA4),
+        (DW_AT_TYPE, DW_FORM_REF4),
+    ];
+    let mut with_loc: Vec<(u64, u64)> = var_attrs.to_vec();
+    with_loc.push((DW_AT_LOCATION, DW_FORM_BLOCK1));
+    for (code_loc, code_noloc, tag) in [
+        (
+            ABBREV_PARAM_LOC,
+            ABBREV_PARAM_NOLOC,
+            DW_TAG_FORMAL_PARAMETER,
+        ),
+        (ABBREV_VAR_LOC, ABBREV_VAR_NOLOC, DW_TAG_VARIABLE),
+    ] {
+        abbrev(base, code_loc, tag, DW_CHILDREN_NO, &with_loc);
+        abbrev(base, code_noloc, tag, DW_CHILDREN_NO, var_attrs);
+    }
 
-    // Attribute: DW_AT_name (string)
-    base.push_directive(Directive::Uleb128(DW_AT_NAME));
-    base.push_directive(Directive::Uleb128(DW_FORM_STRING));
+    abbrev(
+        base,
+        ABBREV_BASE_TYPE,
+        DW_TAG_BASE_TYPE,
+        DW_CHILDREN_NO,
+        &[
+            (DW_AT_NAME, DW_FORM_STRING),
+            (DW_AT_BYTE_SIZE, DW_FORM_DATA1),
+            (DW_AT_ENCODING, DW_FORM_DATA1),
+        ],
+    );
+    abbrev(
+        base,
+        ABBREV_POINTER,
+        DW_TAG_POINTER_TYPE,
+        DW_CHILDREN_NO,
+        &[(DW_AT_BYTE_SIZE, DW_FORM_DATA1), (DW_AT_TYPE, DW_FORM_REF4)],
+    );
+    // `void *` has no pointee DIE to name.
+    abbrev(
+        base,
+        ABBREV_POINTER_VOID,
+        DW_TAG_POINTER_TYPE,
+        DW_CHILDREN_NO,
+        &[(DW_AT_BYTE_SIZE, DW_FORM_DATA1)],
+    );
+    abbrev(
+        base,
+        ABBREV_ARRAY,
+        DW_TAG_ARRAY_TYPE,
+        DW_CHILDREN_YES,
+        &[(DW_AT_TYPE, DW_FORM_REF4)],
+    );
+    abbrev(
+        base,
+        ABBREV_SUBRANGE,
+        DW_TAG_SUBRANGE_TYPE,
+        DW_CHILDREN_NO,
+        &[(DW_AT_UPPER_BOUND, DW_FORM_DATA4)],
+    );
+    // Aggregates carry their size but no members: a member's *name* is a
+    // `StringId`, and no string table reaches the backend. gdb lists a variable
+    // of such a type and knows how big it is, and prints it as an aggregate
+    // whose fields it cannot name.
+    for (code, tag) in [
+        (ABBREV_STRUCT, DW_TAG_STRUCTURE_TYPE),
+        (ABBREV_UNION, DW_TAG_UNION_TYPE),
+    ] {
+        abbrev(
+            base,
+            code,
+            tag,
+            DW_CHILDREN_NO,
+            &[(DW_AT_BYTE_SIZE, DW_FORM_DATA4)],
+        );
+    }
 
-    // Attribute: DW_AT_comp_dir (string)
-    base.push_directive(Directive::Uleb128(DW_AT_COMP_DIR));
-    base.push_directive(Directive::Uleb128(DW_FORM_STRING));
-
-    // Attribute: DW_AT_stmt_list (4-byte offset to .debug_line)
-    base.push_directive(Directive::Uleb128(DW_AT_STMT_LIST));
-    base.push_directive(Directive::Uleb128(DW_FORM_DATA4));
-
-    // Attribute: DW_AT_low_pc (address)
-    base.push_directive(Directive::Uleb128(DW_AT_LOW_PC));
-    base.push_directive(Directive::Uleb128(DW_FORM_ADDR));
-
-    // Attribute: DW_AT_high_pc (address)
-    base.push_directive(Directive::Uleb128(DW_AT_HIGH_PC));
-    base.push_directive(Directive::Uleb128(DW_FORM_ADDR));
-
-    // End of attributes for this abbreviation
-    base.push_directive(Directive::Byte(0));
-    base.push_directive(Directive::Byte(0));
-
-    // End of abbreviation table
-    base.push_directive(Directive::Byte(0));
+    // A zero code ends the table.
+    base.push_directive(Directive::Uleb128(0));
 }
 
-/// Generate the .debug_info section with compile unit DIE.
+/// The type DIEs a set of functions needs, and where each one will sit.
+///
+/// Types are reached transitively -- a pointer needs its pointee, an array its
+/// element. Emission follows `order`, the sequence in which they were first
+/// reached, so the table does not depend on hash iteration order.
+struct TypeDies {
+    /// Type -> index, which names its label `.Ldie_ty<N>`. Lookup only:
+    /// emission walks `order`, so hash iteration never reaches the output.
+    index: HashMap<TypeId, usize>,
+    /// Emission order, so a DIE is written once and the table is stable.
+    order: Vec<TypeId>,
+}
+
+impl TypeDies {
+    fn collect(fns: &[FnDie], types: &TypeTable) -> Self {
+        let mut this = TypeDies {
+            index: HashMap::new(),
+            order: Vec::new(),
+        };
+        for f in fns {
+            if let Some(t) = f.ret_typ {
+                this.add(t, types, 0);
+            }
+            for v in &f.vars {
+                this.add(v.typ, types, 0);
+            }
+        }
+        this
+    }
+
+    /// Record `id` and whatever it refers to.
+    ///
+    /// `depth` guards against a type that reaches itself -- `struct s { struct
+    /// s *next; };` is ordinary C, and the pointer arm would otherwise recurse
+    /// forever. Aggregates emit no members here, so the walk stops at them
+    /// anyway; the cap is for the pointer and array chains.
+    fn add(&mut self, id: TypeId, types: &TypeTable, depth: u32) {
+        if depth > 16 || self.index.contains_key(&id) {
+            return;
+        }
+        let kind = types.kind(id);
+        // A type c17 has no DIE shape for is left out; the variable using it
+        // then has no `DW_AT_type` and is skipped rather than mislabelled.
+        if !describable(kind) {
+            return;
+        }
+        self.index.insert(id, self.order.len());
+        self.order.push(id);
+        if matches!(kind, TypeKind::Pointer | TypeKind::Array) {
+            if let Some(base) = types.base_type(id) {
+                self.add(base, types, depth + 1);
+            }
+        }
+    }
+
+    fn label(&self, id: TypeId) -> Option<String> {
+        self.index.get(&id).map(|n| format!(".Ldie_ty{}", n))
+    }
+}
+
+/// Whether this kind of type has a DIE shape in the abbreviation table.
+fn describable(kind: TypeKind) -> bool {
+    matches!(
+        kind,
+        TypeKind::Bool
+            | TypeKind::Char
+            | TypeKind::Short
+            | TypeKind::Int
+            | TypeKind::Long
+            | TypeKind::LongLong
+            | TypeKind::Float
+            | TypeKind::Double
+            | TypeKind::LongDouble
+            | TypeKind::Enum
+            | TypeKind::Pointer
+            | TypeKind::Array
+            | TypeKind::Struct
+            | TypeKind::Union
+    )
+}
+
+/// The DWARF encoding for a scalar: how a debugger should interpret its bytes.
+fn base_encoding(id: TypeId, types: &TypeTable) -> u64 {
+    match types.kind(id) {
+        TypeKind::Bool => DW_ATE_BOOLEAN,
+        TypeKind::Float | TypeKind::Double | TypeKind::LongDouble => DW_ATE_FLOAT,
+        TypeKind::Char => {
+            if types.is_unsigned(id) {
+                DW_ATE_UNSIGNED_CHAR
+            } else {
+                DW_ATE_SIGNED_CHAR
+            }
+        }
+        _ => {
+            if types.is_unsigned(id) {
+                DW_ATE_UNSIGNED
+            } else {
+                DW_ATE_SIGNED
+            }
+        }
+    }
+}
+
+/// A CU-relative reference to another DIE (`DW_FORM_ref4`).
+fn type_ref<I: LirInst + EmitAsm>(base: &mut CodeGenBase<I>, label: &str) {
+    base.push_directive(Directive::Raw(format!(
+        "    .long {} - .Ldebug_info0",
+        label
+    )));
+}
+
+/// Emit one DIE per collected type.
+fn emit_type_dies<I: LirInst + EmitAsm>(
+    base: &mut CodeGenBase<I>,
+    dies: &TypeDies,
+    types: &TypeTable,
+) {
+    for (n, &id) in dies.order.iter().enumerate() {
+        base.push_directive(Directive::local_label(format!(".Ldie_ty{}", n)));
+        let size = types.size_bytes(id) as i64;
+        match types.kind(id) {
+            TypeKind::Pointer => match types.base_type(id).and_then(|b| dies.label(b)) {
+                Some(pointee) => {
+                    base.push_directive(Directive::Uleb128(ABBREV_POINTER));
+                    base.push_directive(Directive::Byte(size));
+                    type_ref(base, &pointee);
+                }
+                None => {
+                    base.push_directive(Directive::Uleb128(ABBREV_POINTER_VOID));
+                    base.push_directive(Directive::Byte(size));
+                }
+            },
+            TypeKind::Array => {
+                let elem = types.base_type(id).and_then(|b| dies.label(b));
+                let Some(elem) = elem else {
+                    // No element DIE: describe it as an opaque block of bytes
+                    // rather than claiming an element type it does not have.
+                    base.push_directive(Directive::Uleb128(ABBREV_STRUCT));
+                    base.push_directive(Directive::Long(size));
+                    continue;
+                };
+                base.push_directive(Directive::Uleb128(ABBREV_ARRAY));
+                type_ref(base, &elem);
+                // One subrange child giving the last valid index.
+                let elem_size = types
+                    .base_type(id)
+                    .map(|b| types.size_bytes(b) as i64)
+                    .unwrap_or(1)
+                    .max(1);
+                base.push_directive(Directive::Uleb128(ABBREV_SUBRANGE));
+                base.push_directive(Directive::Long((size / elem_size - 1).max(0)));
+                base.push_directive(Directive::Byte(0)); // end of children
+            }
+            TypeKind::Struct => {
+                base.push_directive(Directive::Uleb128(ABBREV_STRUCT));
+                base.push_directive(Directive::Long(size));
+            }
+            TypeKind::Union => {
+                base.push_directive(Directive::Uleb128(ABBREV_UNION));
+                base.push_directive(Directive::Long(size));
+            }
+            _ => {
+                base.push_directive(Directive::Uleb128(ABBREV_BASE_TYPE));
+                base.push_directive(Directive::Asciz(types.format_type(id, None)));
+                base.push_directive(Directive::Byte(size));
+                base.push_directive(Directive::Byte(base_encoding(id, types) as i64));
+            }
+        }
+    }
+}
+
+/// Emit the DIEs for one function and the variables inside it.
+fn emit_fn_die<I: LirInst + EmitAsm>(base: &mut CodeGenBase<I>, f: &FnDie, dies: &TypeDies) {
+    let ret = f.ret_typ.and_then(|t| dies.label(t));
+    base.push_directive(Directive::Uleb128(match ret {
+        Some(_) => ABBREV_SUBPROGRAM_TYPED,
+        None => ABBREV_SUBPROGRAM_VOID,
+    }));
+    base.push_directive(Directive::Byte(if f.external { 1 } else { 0 }));
+    base.push_directive(Directive::Asciz(f.name.clone()));
+    base.push_directive(Directive::Byte(1)); // DW_AT_decl_file
+    base.push_directive(Directive::Long(f.decl_line as i64));
+    base.push_directive(Directive::QuadSym(Symbol::global(&f.name)));
+    base.push_directive(Directive::QuadSym(Symbol::local(&f.end_label)));
+    if let Some(r) = ret {
+        type_ref(base, &r);
+    }
+
+    for v in &f.vars {
+        // Without a type DIE there is nothing for a debugger to interpret the
+        // bytes as, so the variable is left out rather than described wrongly.
+        let Some(ty) = dies.label(v.typ) else {
+            continue;
+        };
+        let code = match (v.is_param, v.loc.is_some()) {
+            (true, true) => ABBREV_PARAM_LOC,
+            (true, false) => ABBREV_PARAM_NOLOC,
+            (false, true) => ABBREV_VAR_LOC,
+            (false, false) => ABBREV_VAR_NOLOC,
+        };
+        base.push_directive(Directive::Uleb128(code));
+        base.push_directive(Directive::Asciz(debug_name(&v.name).to_string()));
+        base.push_directive(Directive::Byte(1)); // DW_AT_decl_file
+        base.push_directive(Directive::Long(v.decl_line as i64));
+        type_ref(base, &ty);
+        if let Some(loc) = v.loc {
+            // A `DW_FORM_block1` expression: one byte of length, then
+            // `DW_OP_breg<reg>` and a signed offset. Naming the base register
+            // directly rather than going through `DW_AT_frame_base` keeps this
+            // true for a frame whose locals are not addressed from the frame
+            // pointer.
+            //
+            // The length is computed rather than measured between labels: a
+            // label pair would have to be unique across every variable in the
+            // translation unit, and one keyed by register and offset collides
+            // the moment two functions put a variable in the same place.
+            base.push_directive(Directive::Byte(1 + sleb128_len(loc.offset) as i64));
+            base.push_directive(Directive::Byte(DW_OP_BREG0 + loc.reg as i64));
+            base.push_directive(Directive::Sleb128(loc.offset));
+        }
+    }
+
+    base.push_directive(Directive::Byte(0)); // end of this subprogram's children
+}
+
+/// The name a debugger should show, without the linearizer's uniquing suffix.
+///
+/// A local is keyed as `c.4` in `func.locals` -- the trailing number keeps two
+/// `c`s in different scopes apart. C identifiers cannot contain a `.`, so
+/// everything from the last one is the compiler's and not the programmer's.
+pub fn debug_name(name: &str) -> &str {
+    match name.rsplit_once('.') {
+        Some((head, tail)) if !head.is_empty() && tail.bytes().all(|b| b.is_ascii_digit()) => head,
+        _ => name,
+    }
+}
+
+/// How many bytes `.sleb128 v` occupies.
+///
+/// Needed because a `DW_FORM_block1` location expression states its own length
+/// up front, and the assembler will not compute it for us without a label pair
+/// that would have to be unique across the whole unit.
+fn sleb128_len(mut v: i64) -> usize {
+    let mut n = 1;
+    loop {
+        let byte = (v & 0x7f) as u8;
+        v >>= 7;
+        // The encoding stops when the remaining bits are all copies of the
+        // sign bit already carried by this byte.
+        let done = (v == 0 && byte & 0x40 == 0) || (v == -1 && byte & 0x40 != 0);
+        if done {
+            return n;
+        }
+        n += 1;
+    }
+}
+
+/// What the compile-unit DIE says about the translation unit as a whole.
+pub struct UnitInfo<'a> {
+    pub producer: &'a str,
+    pub source_name: &'a str,
+    pub comp_dir: &'a str,
+    /// Labels bounding the unit's code; `None` for a file with no functions.
+    pub low_pc_label: Option<&'a str>,
+    pub high_pc_label: Option<&'a str>,
+}
+
 pub fn generate_debug_info<I: LirInst + EmitAsm>(
     base: &mut CodeGenBase<I>,
-    producer: &str,
-    source_name: &str,
-    comp_dir: &str,
-    low_pc_label: Option<&str>,
-    high_pc_label: Option<&str>,
+    unit: &UnitInfo<'_>,
+    fns: &[FnDie],
+    types: &TypeTable,
 ) {
+    let UnitInfo {
+        producer,
+        source_name,
+        comp_dir,
+        low_pc_label,
+        high_pc_label,
+    } = *unit;
+    let dies = TypeDies::collect(fns, types);
     // Switch to .debug_info section
     base.push_directive(Directive::DebugInfo);
 
@@ -157,6 +639,14 @@ pub fn generate_debug_info<I: LirInst + EmitAsm>(
     } else {
         base.push_directive(Directive::Quad(0));
     }
+
+    // The compile unit's children: every type the functions mention, then the
+    // functions themselves. A zero byte closes the list.
+    emit_type_dies(base, &dies, types);
+    for f in fns {
+        emit_fn_die(base, f, &dies);
+    }
+    base.push_directive(Directive::Byte(0));
 
     // End label for unit length computation
     base.push_directive(Directive::local_label(".Ldebug_info_end"));

--- a/cc/arch/dwarf.rs
+++ b/cc/arch/dwarf.rs
@@ -485,7 +485,37 @@ fn emit_fn_die<I: LirInst + EmitAsm>(base: &mut CodeGenBase<I>, f: &FnDie, dies:
         type_ref(base, &r);
     }
 
-    for v in &f.vars {
+    // Two variables may share a source name: an inner block shadowing an outer
+    // one, or a local shadowing a parameter. Their DIEs are siblings here --
+    // there are no `DW_TAG_lexical_block` DIEs yet to nest them in -- and two
+    // siblings with the same `DW_AT_name` leave a debugger to pick one. gdb
+    // picks the last, so `print x` at a point where the *outer* `x` is in
+    // scope answered with the inner one's value: a wrong answer, silently.
+    //
+    // Where a name collides, every DIE carrying it keeps the linearizer's
+    // uniquing suffix instead, so `x.4` and `x.9` name one variable each. That
+    // is not what a debugger should show -- the real fix is lexical blocks --
+    // but every variable stays reachable and none of them answers to a name
+    // that means another.
+    let display: Vec<&str> = {
+        let mut seen: HashMap<&str, usize> = HashMap::new();
+        for v in &f.vars {
+            *seen.entry(debug_name(&v.name)).or_insert(0) += 1;
+        }
+        f.vars
+            .iter()
+            .map(|v| {
+                let short = debug_name(&v.name);
+                if seen.get(short).copied().unwrap_or(0) > 1 {
+                    v.name.as_str()
+                } else {
+                    short
+                }
+            })
+            .collect()
+    };
+
+    for (v, name) in f.vars.iter().zip(display) {
         // Without a type DIE there is nothing for a debugger to interpret the
         // bytes as, so the variable is left out rather than described wrongly.
         let Some(ty) = dies.label(v.typ) else {
@@ -498,7 +528,7 @@ fn emit_fn_die<I: LirInst + EmitAsm>(base: &mut CodeGenBase<I>, f: &FnDie, dies:
             (false, false) => ABBREV_VAR_NOLOC,
         };
         base.push_directive(Directive::Uleb128(code));
-        base.push_directive(Directive::Asciz(debug_name(&v.name).to_string()));
+        base.push_directive(Directive::Asciz(name.to_string()));
         base.push_directive(Directive::Byte(1)); // DW_AT_decl_file
         base.push_directive(Directive::Long(v.decl_line as i64));
         type_ref(base, &ty);

--- a/cc/arch/lir.rs
+++ b/cc/arch/lir.rs
@@ -813,6 +813,8 @@ pub enum Directive {
 
     /// .uleb128 value - unsigned LEB128 encoding for DWARF
     Uleb128(u64),
+    /// A signed LEB128 -- DWARF location expressions take frame offsets this way.
+    Sleb128(i64),
 
     /// .2byte value - 16-bit value (for DWARF version)
     TwoBytes(u16),
@@ -1301,6 +1303,9 @@ impl EmitAsm for Directive {
             },
             Directive::Uleb128(v) => {
                 let _ = writeln!(out, "    .uleb128 {}", v);
+            }
+            Directive::Sleb128(v) => {
+                let _ = writeln!(out, "    .sleb128 {}", v);
             }
             Directive::TwoBytes(v) => {
                 let _ = writeln!(out, "    .2byte {}", v);

--- a/cc/arch/x86_64/codegen.rs
+++ b/cc/arch/x86_64/codegen.rs
@@ -1503,14 +1503,15 @@ impl CodeGenerator for X86_64CodeGen {
             };
 
             super::super::dwarf::generate_abbrev_table(&mut self.base);
-            super::super::dwarf::generate_debug_info(
-                &mut self.base,
-                &producer,
+            let fns = std::mem::take(&mut self.base.fn_dies);
+            let unit = super::super::dwarf::UnitInfo {
+                producer: &producer,
                 source_name,
                 comp_dir,
-                low_pc,
-                high_pc,
-            );
+                low_pc_label: low_pc,
+                high_pc_label: high_pc,
+            };
+            super::super::dwarf::generate_debug_info(&mut self.base, &unit, &fns, types);
         }
 
         // Emit .note.GNU-stack section to mark stack as non-executable (ELF only)

--- a/cc/arch/x86_64/frame.rs
+++ b/cc/arch/x86_64/frame.rs
@@ -224,9 +224,74 @@ impl X86_64CodeGen {
             self.push_lir(X86Inst::Directive(Directive::CfiEndProc));
         }
 
+        // The label `DW_AT_high_pc` names, before `.size` so it marks the end
+        // of the code rather than a point after the directive.
+        if self.base.emit_debug {
+            let end = format!(".Lfunc_end_{}", self.base.current_fn);
+            self.push_lir(X86Inst::Directive(Directive::local_label(&end)));
+            self.collect_fn_die(func, types, end);
+        }
+
         // `.size f, .-f`: without it the symbol records st_size = 0 and a
         // debugger cannot tell which function owns an address inside it.
         self.push_lir(X86Inst::Directive(Directive::size_to_here(&func.name)));
+    }
+
+    /// Record what `-g` has to say about this function.
+    ///
+    /// Only here can it be said: a variable's home is the register allocator's
+    /// answer for *this* function, and `self.locations` is overwritten by the
+    /// next one. A local with no stack slot -- promoted to a register, or gone
+    /// entirely -- gets no location rather than a made-up one.
+    fn collect_fn_die(&mut self, func: &Function, types: &TypeTable, end_label: String) {
+        let params: std::collections::HashSet<&str> =
+            func.params.iter().map(|(n, _)| n.as_str()).collect();
+        let mut names: Vec<&String> = func.locals.keys().collect();
+        names.sort();
+
+        let mut vars = Vec::new();
+        for name in names {
+            let local = &func.locals[name];
+            // Compiler-introduced storage has no name a debugger should show.
+            if name.starts_with("__") || name.starts_with('.') {
+                continue;
+            }
+            let loc = match self.locations.get_ref(local.sym) {
+                Some(Loc::Stack(off)) => match self.stack_mem(*off) {
+                    MemAddr::BaseOffset { base, offset } => Some(crate::arch::dwarf::VarLocation {
+                        reg: base.dwarf_number(),
+                        offset: offset as i64,
+                    }),
+                    _ => None,
+                },
+                _ => None,
+            };
+            vars.push(crate::arch::dwarf::VarDie {
+                name: name.clone(),
+                typ: local.typ,
+                decl_line: 0,
+                is_param: params.contains(name.as_str()),
+                loc,
+            });
+        }
+
+        let ret_typ = (types.kind(func.return_type) != TypeKind::Void).then_some(func.return_type);
+        let decl_line = func
+            .blocks
+            .iter()
+            .flat_map(|b| b.insns.iter())
+            .find_map(|i| i.pos.as_ref())
+            .map(|p| p.line)
+            .unwrap_or(0);
+
+        self.base.fn_dies.push(crate::arch::dwarf::FnDie {
+            name: func.name.clone(),
+            external: !func.is_static,
+            decl_line,
+            end_label,
+            ret_typ,
+            vars,
+        });
     }
 
     /// Emit function header directives (text section, visibility, type, label, CFI start)

--- a/cc/arch/x86_64/regalloc.rs
+++ b/cc/arch/x86_64/regalloc.rs
@@ -171,6 +171,32 @@ impl Reg {
         }
     }
 
+    /// This register's DWARF number, for debug location expressions.
+    ///
+    /// The System V AMD64 psABI fixes the mapping (figure 3.36) and it is not
+    /// the encoding order: `%rbx` is 3 and `%rcx` is 2, where the instruction
+    /// encoding has them the other way round.
+    pub fn dwarf_number(&self) -> u16 {
+        match self {
+            Reg::Rax => 0,
+            Reg::Rdx => 1,
+            Reg::Rcx => 2,
+            Reg::Rbx => 3,
+            Reg::Rsi => 4,
+            Reg::Rdi => 5,
+            Reg::Rbp => 6,
+            Reg::Rsp => 7,
+            Reg::R8 => 8,
+            Reg::R9 => 9,
+            Reg::R10 => 10,
+            Reg::R11 => 11,
+            Reg::R12 => 12,
+            Reg::R13 => 13,
+            Reg::R14 => 14,
+            Reg::R15 => 15,
+        }
+    }
+
     pub fn is_callee_saved(&self) -> bool {
         matches!(
             self,

--- a/cc/tests/codegen/debug_info.rs
+++ b/cc/tests/codegen/debug_info.rs
@@ -109,3 +109,79 @@ fn codegen_debug_directives_need_dash_g() {
         "no line-program label without -g:\n{asm}"
     );
 }
+
+/// Functions get a `DW_TAG_subprogram` DIE, with the things inside them as
+/// children.
+///
+/// The abbreviation table used to hold exactly one shape -- a compile unit with
+/// no children -- so a c17 binary described its files and nothing inside them.
+/// gdb fell back to the ELF symbol table for function names, which is why
+/// backtraces named functions while `info args`, `info locals` and `ptype` all
+/// came back empty.
+#[test]
+fn codegen_debug_emits_subprogram_dies() {
+    // `sink` takes an address, so `c` and `arr` keep a stack home instead of
+    // being promoted into registers -- a variable with no memory to point at
+    // gets no location, which is the honest answer but not what this checks.
+    let src = r#"
+        int sink(int *p);
+        int f(int a, int b) {
+            int c = a + b;
+            int arr[4];
+            arr[0] = c;
+            sink(&c);
+            sink(arr);
+            return c;
+        }
+    "#;
+
+    for (triple, fp) in [(X86_64_LINUX, "rbp"), (AARCH64_LINUX, "x29")] {
+        let asm = asm_for_with("debug_subprogram", triple, src, &["-g", "-O0"]);
+
+        // The subprogram tag, and a base type for `int` to point at.
+        assert!(
+            asm.contains(".uleb128 0x2e") || asm.contains(".uleb128 46"),
+            "{triple}: no DW_TAG_subprogram in the abbreviation table:\n{asm}"
+        );
+        // A function's extent needs an end label to measure against.
+        assert!(
+            asm.contains(".Lfunc_end_f"),
+            "{triple}: DW_AT_high_pc needs a label at the end of the function:\n{asm}"
+        );
+        // The variables that kept a stack slot are described, by name.
+        for name in ["c", "arr"] {
+            assert!(
+                asm.contains(&format!("\"{name}\"")) || asm.contains(&format!(".asciz \"{name}\"")),
+                "{triple}: {name} should appear as a DIE name:\n{asm}"
+            );
+        }
+        let _ = fp;
+    }
+}
+
+/// A variable's location names the register the code generator actually used.
+///
+/// The location is built from the same address computation the loads and stores
+/// go through, rather than re-derived from the frame layout, so it stays true
+/// for a frame whose locals are not addressed from the frame pointer at all.
+#[test]
+fn codegen_debug_variable_locations_use_the_real_base() {
+    let src = r#"
+        int sink(int *p);
+        int f(void) { int c = 7; sink(&c); return c; }
+    "#;
+
+    // The DWARF register number of each target's frame pointer: 6 for %rbp,
+    // 29 for x29. DW_OP_breg0 is 0x70, so the opcode byte is 0x70 + N.
+    for (triple, op) in [(X86_64_LINUX, 0x70 + 6), (AARCH64_LINUX, 0x70 + 29)] {
+        let asm = asm_for_with("debug_var_loc", triple, src, &["-g", "-O0"]);
+        assert!(
+            asm.contains(&format!(".byte {op}")),
+            "{triple}: a local's location should be DW_OP_breg{} ({op}); \
+             aarch64 omits x18 from its register enum, so a number taken from \
+             the discriminant lands one low and gdb reads the wrong \
+             register:\n{asm}",
+            op - 0x70
+        );
+    }
+}

--- a/cc/tests/codegen/debug_info.rs
+++ b/cc/tests/codegen/debug_info.rs
@@ -185,3 +185,80 @@ fn codegen_debug_variable_locations_use_the_real_base() {
         );
     }
 }
+
+/// No two variables in one function answer to the same name.
+///
+/// `debug_name` strips the linearizer's uniquing suffix so a debugger shows
+/// `c` rather than `c.4`. But there are no `DW_TAG_lexical_block` DIEs yet, so
+/// every local and parameter is a sibling directly under the subprogram -- and
+/// once two of them are shadowed into the same `DW_AT_name`, a debugger has to
+/// pick one. gdb picks the last, so `print x` where the *outer* `x` is in scope
+/// answered with the inner one's value: a wrong answer, silently, on ordinary C.
+///
+/// Where a name collides the suffix is kept, so each DIE names one variable.
+/// That is not what a debugger should ideally show -- lexical blocks are the
+/// real answer -- but no variable answers to a name that means another.
+#[test]
+fn codegen_debug_shadowed_variables_get_distinct_names() {
+    let src = r#"
+        int sink(int *p);
+        int f(int x) {
+            int y = 1;
+            sink(&x);
+            sink(&y);
+            {
+                int y = 2;      /* shadows the outer y */
+                sink(&y);
+                {
+                    int y = 3;  /* and again */
+                    sink(&y);
+                }
+            }
+            return y;
+        }
+    "#;
+
+    for triple in [X86_64_LINUX, AARCH64_LINUX] {
+        let asm = asm_for_with("debug_shadow", triple, src, &["-g", "-O0"]);
+        // Every name the DIEs carry, in emission order.
+        let names: Vec<&str> = asm
+            .lines()
+            .map(str::trim)
+            .filter_map(|l| l.strip_prefix(".asciz \""))
+            .filter_map(|l| l.strip_suffix('"'))
+            .collect();
+        let ys: Vec<&&str> = names.iter().filter(|n| n.starts_with('y')).collect();
+        assert!(
+            ys.len() >= 2,
+            "{triple}: expected several shadowed `y`s among {names:?}"
+        );
+        let mut uniq = ys.clone();
+        uniq.sort();
+        uniq.dedup();
+        assert_eq!(
+            uniq.len(),
+            ys.len(),
+            "{triple}: shadowed variables must not share a DW_AT_name; got {ys:?}"
+        );
+    }
+}
+
+/// A name that is not shadowed keeps its plain spelling.
+///
+/// The disambiguation above must not cost the ordinary case its readable
+/// names -- `c`, not `c.4`.
+#[test]
+fn codegen_debug_unshadowed_names_are_plain() {
+    let src = r#"
+        int sink(int *p);
+        int f(void) { int counter = 7; sink(&counter); return counter; }
+    "#;
+
+    for triple in [X86_64_LINUX, AARCH64_LINUX] {
+        let asm = asm_for_with("debug_plain_name", triple, src, &["-g", "-O0"]);
+        assert!(
+            asm.contains(".asciz \"counter\""),
+            "{triple}: an unshadowed local should be named plainly:\n{asm}"
+        );
+    }
+}


### PR DESCRIPTION
The abbreviation table held exactly one shape -- a compile unit with no children -- so a c17 binary described its files and nothing inside them. gdb fell back to the ELF symbol table for function names, which is why backtraces named functions while `info args`, `info locals`, `print x` and `ptype` all came back empty.

There are now DIEs for functions, for the parameters and locals inside them, and for the types they need: base types, pointers, arrays, and aggregates by size.

A variable's location is built from the same address computation the loads and stores go through -- `stack_mem` on x86-64, `loc_addr_parts` on aarch64 -- and emitted as `DW_OP_breg<n> <offset>`, naming the base register directly rather than going through `DW_AT_frame_base`. That keeps it true for an over-aligned frame, whose locals are not addressed from the frame pointer at all, and it means a location cannot disagree with the code that reads the variable.

    (gdb) info locals
    arr = {5, 0, 0, 0}
    c = 5

A variable with no memory to point at gets no location rather than a made-up one, and gdb says "optimized out" on its own.

Two things bit while building it, both worth the comments they now carry. aarch64's register enum omits x18 -- platform-reserved, never allocated -- so every variant after X17 sits one below its register number, and a DWARF number taken from the discriminant made the frame pointer x29 come out as 28. And a `DW_FORM_block1` states its own length, which cannot be measured between labels here: a label keyed by register and offset collides the moment two functions put a variable in the same place, which it did, in about three hundred tests.

Known gaps, both stated rather than papered over:

  - A local that SSA promoted into registers has no stack home and so no location. At -O0 that is most of them, because c17 promotes at every optimization level. Describing those needs either location lists or a decision not to promote under -g; the second is a codegen change and wants its own commit.
  - Aggregates carry `DW_AT_byte_size` and no members, so gdb prints a struct as `{<No data fields>}`. A member's name is a `StringId` and no string table reaches the backend, so member DIEs need the `CodeGenerator` trait widened first.