### PR TITLE
fix(plib): harden plib::tmp placement, cleanup and log identity

### DIFF
--- a/cron/crontab.rs
+++ b/cron/crontab.rs
@@ -164,12 +164,10 @@ fn do_edit(target: &str) -> ! {
         }
     };
     if let Err(e) = tmp.write_all(current.as_bytes()).and_then(|()| tmp.flush()) {
-        diag_error(&format!(
-            "{}: {}",
-            gettext("cannot write temporary file"),
-            e
-        ));
-        exit(1);
+        bail_edit(
+            tmp,
+            format!("{}: {}", gettext("cannot write temporary file"), e),
+        );
     }
     let tmp_path = tmp.path().to_path_buf();
 
@@ -183,23 +181,36 @@ fn do_edit(target: &str) -> ! {
 
     match cmd.status() {
         Ok(status) if status.success() => {}
-        Ok(_) => {
-            diag_error(&gettext("editor exited with an error; crontab unchanged"));
-            exit(1);
-        }
-        Err(e) => {
-            diag_error(&format!("{}: {}", gettext("cannot launch editor"), e));
-            exit(1);
-        }
+        Ok(_) => bail_edit(
+            tmp,
+            gettext("editor exited with an error; crontab unchanged"),
+        ),
+        Err(e) => bail_edit(tmp, format!("{}: {}", gettext("cannot launch editor"), e)),
     }
 
     match fs::read_to_string(&tmp_path) {
-        Ok(edited) => install_crontab(target, &edited),
-        Err(e) => {
-            diag_error(&format!("{}: {}", gettext("cannot read edited crontab"), e));
-            exit(1);
+        Ok(edited) => {
+            // Remove the edit buffer before handing off: install_crontab
+            // never returns, so nothing would drop it afterwards.
+            drop(tmp);
+            install_crontab(target, &edited)
         }
+        Err(e) => bail_edit(
+            tmp,
+            format!("{}: {}", gettext("cannot read edited crontab"), e),
+        ),
     }
+}
+
+/// Report `msg` and exit 1, removing the edit buffer on the way out.
+///
+/// `exit` does not run destructors, so every failure path in `do_edit` has to
+/// drop the temporary explicitly; otherwise each `crontab -e` would leave a
+/// copy of the user's crontab behind in the temporary directory.
+fn bail_edit(tmp: plib::tmp::NamedTempFile, msg: String) -> ! {
+    drop(tmp);
+    diag_error(&msg);
+    exit(1);
 }
 
 /// Emit a diagnostic to standard error with the `crontab:` prefix (audit #C3).

--- a/cron/crontab.rs
+++ b/cron/crontab.rs
@@ -164,7 +164,7 @@ fn do_edit(target: &str) -> ! {
         }
     };
     if let Err(e) = tmp.write_all(current.as_bytes()).and_then(|()| tmp.flush()) {
-        bail_edit(
+        discard_edit(
             tmp,
             format!("{}: {}", gettext("cannot write temporary file"), e),
         );
@@ -181,11 +181,16 @@ fn do_edit(target: &str) -> ! {
 
     match cmd.status() {
         Ok(status) if status.success() => {}
-        Ok(_) => bail_edit(
+        // The editor ran, so the buffer may hold the user's work even though
+        // it exited badly. Losing an editing session is worse than leaving a
+        // file behind, so keep it and say where it is (as Vixie crontab does).
+        Ok(_) => keep_edit(
             tmp,
             gettext("editor exited with an error; crontab unchanged"),
         ),
-        Err(e) => bail_edit(tmp, format!("{}: {}", gettext("cannot launch editor"), e)),
+        // The editor never started, so the buffer is just a copy of the
+        // current crontab and there is nothing to preserve.
+        Err(e) => discard_edit(tmp, format!("{}: {}", gettext("cannot launch editor"), e)),
     }
 
     match fs::read_to_string(&tmp_path) {
@@ -195,7 +200,8 @@ fn do_edit(target: &str) -> ! {
             drop(tmp);
             install_crontab(target, &edited)
         }
-        Err(e) => bail_edit(
+        // The edits exist but could not be read back; keep them.
+        Err(e) => keep_edit(
             tmp,
             format!("{}: {}", gettext("cannot read edited crontab"), e),
         ),
@@ -205,11 +211,23 @@ fn do_edit(target: &str) -> ! {
 /// Report `msg` and exit 1, removing the edit buffer on the way out.
 ///
 /// `exit` does not run destructors, so every failure path in `do_edit` has to
-/// drop the temporary explicitly; otherwise each `crontab -e` would leave a
-/// copy of the user's crontab behind in the temporary directory.
-fn bail_edit(tmp: plib::tmp::NamedTempFile, msg: String) -> ! {
+/// dispose of the temporary explicitly; otherwise each `crontab -e` would
+/// leave a copy of the user's crontab behind in the temporary directory. Use
+/// this only where the buffer cannot contain anything the user typed.
+fn discard_edit(tmp: plib::tmp::NamedTempFile, msg: String) -> ! {
     drop(tmp);
     diag_error(&msg);
+    exit(1);
+}
+
+/// Report `msg` and exit 1, leaving the edit buffer in place and naming it.
+///
+/// For the failure paths that come after the editor has run: the file may hold
+/// work the user would otherwise have to redo from memory.
+fn keep_edit(tmp: plib::tmp::NamedTempFile, msg: String) -> ! {
+    let path = tmp.keep();
+    diag_error(&msg);
+    diag_error(&format!("{} {}", gettext("edits left in"), path.display()));
     exit(1);
 }
 

--- a/plib/src/syslog.rs
+++ b/plib/src/syslog.rs
@@ -26,6 +26,11 @@ use std::sync::OnceLock;
 pub struct Facility(c_int);
 
 impl Facility {
+    /// `LOG_KERN` is 0, and libc's `openlog` only records a non-zero facility,
+    /// so a message sent under this one is filed as `LOG_USER` instead. That
+    /// is a property of `syslog(3)`, not of this wrapper: the kernel facility
+    /// is not reachable from user space through it. Accepted so that
+    /// `logger -p kern.<level>` is not rejected outright.
     pub const KERN: Facility = Facility(libc::LOG_KERN);
     pub const USER: Facility = Facility(libc::LOG_USER);
     pub const MAIL: Facility = Facility(libc::LOG_MAIL);

--- a/plib/src/syslog.rs
+++ b/plib/src/syslog.rs
@@ -7,7 +7,7 @@
 // SPDX-License-Identifier: MIT
 //
 
-//! POSIX system logging via libc `openlog`/`syslog`/`closelog`.
+//! POSIX system logging via libc `openlog` and `syslog`.
 //!
 //! Messages are handed to the platform's own syslog implementation rather than
 //! written to `/dev/log` directly, so whatever transport, framing and fallback
@@ -141,6 +141,12 @@ impl FromStr for Level {
 /// the allocation has to outlive every later `syslog` call. Holding it here
 /// also makes repeat calls to [`open`] a no-op, which is what callers that log
 /// from several places want.
+///
+/// Because the first identity is the one that sticks, there is deliberately no
+/// `closelog` wrapper: `closelog` clears libc's tag but could not clear this
+/// cell, so a later `open` would return early and every subsequent message
+/// would silently lose its tag and facility for the life of the process.
+/// Process exit closes the log anyway.
 static IDENT: OnceLock<CString> = OnceLock::new();
 
 /// Establish the log identity. The first call wins; later ones do nothing.
@@ -174,12 +180,6 @@ pub fn log(level: Level, msg: &str) {
     // SAFETY: both pointers are valid NUL-terminated C strings for the call,
     // and the format string consumes exactly the one argument supplied.
     unsafe { libc::syslog(level.code(), c"%s".as_ptr(), msg.as_ptr()) };
-}
-
-/// Close the log connection.
-pub fn close() {
-    // SAFETY: closelog takes no arguments and is safe to call unconditionally.
-    unsafe { libc::closelog() };
 }
 
 #[cfg(test)]

--- a/plib/src/tmp.rs
+++ b/plib/src/tmp.rs
@@ -39,6 +39,15 @@ const DEFAULT_PREFIX: &str = ".tmp";
 /// The run of `X`s `mkstemp`/`mkdtemp` replace with random characters.
 const RANDOM: &str = "XXXXXX";
 
+/// Where a set-id process puts temporaries, ignoring the environment.
+const SECURE_TEMP_DIR: &str = "/tmp";
+
+/// Whether the process runs with privileges its real user does not have.
+fn is_set_id() -> bool {
+    // SAFETY: these four calls take no arguments and cannot fail.
+    unsafe { libc::geteuid() != libc::getuid() || libc::getegid() != libc::getgid() }
+}
+
 /// The directory for temporaries created without an explicit parent.
 ///
 /// `env::temp_dir` honors `$TMPDIR`, which a set-id process must not trust:
@@ -48,14 +57,20 @@ const RANDOM: &str = "XXXXXX";
 /// Rust's `env::temp_dir` does not, so do it here. `crontab` is the case in
 /// this workspace -- it takes its identity from the real uid and writes into
 /// the cron spool, i.e. it is meant to be installed set-id.
-fn default_temp_dir() -> PathBuf {
-    // SAFETY: these four calls take no arguments and cannot fail.
-    let set_id = unsafe { libc::geteuid() != libc::getuid() || libc::getegid() != libc::getgid() };
+///
+/// Split from [`is_set_id`] so the privileged branch can be asserted without
+/// the test having to be set-id itself.
+fn temp_dir_for(set_id: bool) -> PathBuf {
     if set_id {
-        PathBuf::from("/tmp")
+        PathBuf::from(SECURE_TEMP_DIR)
     } else {
         std::env::temp_dir()
     }
+}
+
+/// [`temp_dir_for`], for this process.
+fn default_temp_dir() -> PathBuf {
+    temp_dir_for(is_set_id())
 }
 
 /// Reject a name fragment that would move the temporary somewhere else.
@@ -678,11 +693,25 @@ mod tests {
     }
 
     #[test]
-    fn default_dir_follows_tmpdir_only_when_not_set_id() {
-        // The test process is not set-id, so $TMPDIR is honored as usual.
+    fn a_set_id_process_ignores_tmpdir() {
+        // The security property: under set-id the directory is a fixed path,
+        // so nothing the caller puts in the environment can steer a privileged
+        // temporary into a directory they control. Asserted through the
+        // parameter rather than the process, which a test cannot make set-id.
+        assert_eq!(temp_dir_for(true), Path::new(SECURE_TEMP_DIR));
+    }
+
+    #[test]
+    fn an_ordinary_process_honors_tmpdir() {
+        assert_eq!(temp_dir_for(false), std::env::temp_dir());
+    }
+
+    #[test]
+    fn this_test_process_is_not_set_id() {
+        // Guards the assumption the rest of these tests rest on: they create
+        // temporaries under $TMPDIR via the non-set-id branch.
+        assert!(!is_set_id());
         assert_eq!(default_temp_dir(), std::env::temp_dir());
-        // And the set-id branch must not be able to pick a caller-named path.
-        assert!(default_temp_dir().is_absolute());
     }
 
     #[test]

--- a/plib/src/tmp.rs
+++ b/plib/src/tmp.rs
@@ -43,9 +43,28 @@ const RANDOM: &str = "XXXXXX";
 const SECURE_TEMP_DIR: &str = "/tmp";
 
 /// Whether the process runs with privileges its real user does not have.
+///
+/// Asks the kernel rather than comparing ids, because a uid/gid comparison
+/// misses the other ways a program becomes privileged: Linux file
+/// capabilities and LSM domain transitions both leave euid == uid while still
+/// setting `AT_SECURE`, and those are exactly the cases where trusting
+/// `$TMPDIR` would be a mistake. This is the flag glibc's
+/// `__libc_enable_secure` reads.
 fn is_set_id() -> bool {
-    // SAFETY: these four calls take no arguments and cannot fail.
-    unsafe { libc::geteuid() != libc::getuid() || libc::getegid() != libc::getgid() }
+    #[cfg(target_os = "linux")]
+    // SAFETY: getauxval takes one integer and reports 0 for an absent entry.
+    unsafe {
+        libc::getauxval(libc::AT_SECURE) != 0
+    }
+
+    // issetugid() answers the same question on the BSDs and macOS, where
+    // glibc's getauxval does not exist.
+    //
+    // SAFETY: issetugid takes no arguments and cannot fail.
+    #[cfg(not(target_os = "linux"))]
+    unsafe {
+        libc::issetugid() != 0
+    }
 }
 
 /// The directory for temporaries created without an explicit parent.
@@ -299,8 +318,9 @@ impl Drop for TempDir {
 pub struct NamedTempFile {
     path: PathBuf,
     file: Option<File>,
-    /// Set once the file has been renamed into place, so `Drop` leaves it.
-    persisted: bool,
+    /// Set once cleanup has been handed off -- by rename, by an explicit
+    /// removal, or by `keep` -- so `Drop` leaves the path alone.
+    disarmed: bool,
 }
 
 impl NamedTempFile {
@@ -332,6 +352,17 @@ impl NamedTempFile {
         self.file.as_mut().expect("file is taken only by persist")
     }
 
+    /// Give up ownership of the file, returning its path.
+    ///
+    /// The file stays on disk and `Drop` will not touch it. For the case where
+    /// a temporary holds work worth more than the tidiness of removing it --
+    /// `crontab -e` keeps the edit buffer when the editor fails, so the user's
+    /// session is recoverable.
+    pub fn keep(mut self) -> PathBuf {
+        self.disarmed = true;
+        std::mem::take(&mut self.path)
+    }
+
     /// Remove the file now, reporting any failure.
     ///
     /// `Drop` does the same thing but has nowhere to report to, so use this
@@ -342,7 +373,7 @@ impl NamedTempFile {
         // still gets the destructor's attempt.
         drop(self.file.take());
         fs::remove_file(&self.path)?;
-        self.persisted = true;
+        self.disarmed = true;
         Ok(())
     }
 
@@ -356,7 +387,7 @@ impl NamedTempFile {
     pub fn persist(mut self, path: impl AsRef<Path>) -> Result<File, PersistError> {
         match fs::rename(&self.path, path.as_ref()) {
             Ok(()) => {
-                self.persisted = true;
+                self.disarmed = true;
                 Ok(self.file.take().expect("file is taken only by persist"))
             }
             Err(error) => Err(PersistError { error, file: self }),
@@ -384,7 +415,7 @@ impl Write for NamedTempFile {
 
 impl Drop for NamedTempFile {
     fn drop(&mut self) {
-        if !self.persisted {
+        if !self.disarmed {
             let _ = fs::remove_file(&self.path);
         }
     }
@@ -476,7 +507,7 @@ impl Builder {
         Ok(NamedTempFile {
             path,
             file: Some(file),
-            persisted: false,
+            disarmed: false,
         })
     }
 }
@@ -617,6 +648,19 @@ mod tests {
             assert!(flags >= 0, "F_GETFD failed");
             assert_eq!(flags & libc::FD_CLOEXEC, libc::FD_CLOEXEC, "fd {fd}");
         }
+    }
+
+    #[test]
+    fn keep_leaves_the_file_behind() {
+        let dir = tempdir().unwrap();
+        let path = {
+            let mut tmp = NamedTempFile::new_in(dir.path()).unwrap();
+            tmp.write_all(b"work in progress").unwrap();
+            tmp.flush().unwrap();
+            tmp.keep()
+        };
+        assert!(path.exists(), "keep must not remove the file");
+        assert_eq!(fs::read(&path).unwrap(), b"work in progress");
     }
 
     #[test]

--- a/plib/src/tmp.rs
+++ b/plib/src/tmp.rs
@@ -39,11 +39,50 @@ const DEFAULT_PREFIX: &str = ".tmp";
 /// The run of `X`s `mkstemp`/`mkdtemp` replace with random characters.
 const RANDOM: &str = "XXXXXX";
 
+/// The directory for temporaries created without an explicit parent.
+///
+/// `env::temp_dir` honors `$TMPDIR`, which a set-id process must not trust:
+/// letting the caller choose the directory hands them one they own, and with
+/// it the ability to swap the file out from under the privileged program.
+/// glibc suppresses `TMPDIR` under `__libc_enable_secure` for this reason;
+/// Rust's `env::temp_dir` does not, so do it here. `crontab` is the case in
+/// this workspace -- it takes its identity from the real uid and writes into
+/// the cron spool, i.e. it is meant to be installed set-id.
+fn default_temp_dir() -> PathBuf {
+    // SAFETY: these four calls take no arguments and cannot fail.
+    let set_id = unsafe { libc::geteuid() != libc::getuid() || libc::getegid() != libc::getgid() };
+    if set_id {
+        PathBuf::from("/tmp")
+    } else {
+        std::env::temp_dir()
+    }
+}
+
+/// Reject a name fragment that would move the temporary somewhere else.
+///
+/// `Path::join` lets an absolute fragment replace the whole path, so a prefix
+/// of `/tmp/x-` would silently ignore the requested directory; a relative one
+/// containing `/` would drop the file into a subdirectory. Either breaks the
+/// placement guarantee callers rely on -- `plib::io::write_atomic_mode` needs
+/// the temporary beside its target so the `rename(2)` is atomic.
+fn reject_separator(what: &str, fragment: &OsStr) -> io::Result<()> {
+    if fragment.as_encoded_bytes().contains(&b'/') {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            format!("temporary file {what} must not contain a path separator"),
+        ));
+    }
+    Ok(())
+}
+
 /// Build a `<dir>/<prefix>XXXXXX<suffix>` template as a mutable C string.
 ///
 /// Returned as a byte vector rather than a `CString` because `mkstemp` and
 /// `mkdtemp` rewrite the template in place.
 fn template(dir: &Path, prefix: &OsStr, suffix: &OsStr) -> io::Result<Vec<u8>> {
+    reject_separator("prefix", prefix)?;
+    reject_separator("suffix", suffix)?;
+
     let mut name = OsString::with_capacity(prefix.len() + RANDOM.len() + suffix.len());
     name.push(prefix);
     name.push(RANDOM);
@@ -86,6 +125,8 @@ fn make_file(dir: &Path, prefix: &OsStr, suffix: &OsStr) -> io::Result<(File, Pa
         return Err(io::Error::last_os_error());
     }
 
+    let path = filled_path(template);
+
     // Where mkostemps is unavailable, set the flag afterwards. This leaves a
     // window in which a concurrent fork+exec could inherit the descriptor,
     // which is why the flag is passed at creation time above where it can be.
@@ -100,13 +141,16 @@ fn make_file(dir: &Path, prefix: &OsStr, suffix: &OsStr) -> io::Result<(File, Pa
         if !ok {
             let err = io::Error::last_os_error();
             unsafe { libc::close(fd) };
+            // mkstemps already created the name; failing out without removing
+            // it would strand a file in the temporary directory for good.
+            let _ = fs::remove_file(&path);
             return Err(err);
         }
     }
 
     // SAFETY: mkstemps returned a fresh descriptor that nothing else owns.
     let file = unsafe { File::from_raw_fd(fd) };
-    Ok((file, filled_path(template)))
+    Ok((file, path))
 }
 
 /// Create a uniquely named directory, returning its path.
@@ -135,7 +179,7 @@ fn make_dir(dir: &Path, prefix: &OsStr, suffix: &OsStr) -> io::Result<PathBuf> {
 /// The file has no directory entry, so the kernel reclaims it once the last
 /// descriptor closes — no destructor has to run. See the module docs.
 pub fn tempfile() -> io::Result<File> {
-    tempfile_in(std::env::temp_dir())
+    tempfile_in(default_temp_dir())
 }
 
 /// [`tempfile`], in a caller-chosen directory.
@@ -161,9 +205,14 @@ pub fn tempfile_in(dir: impl AsRef<Path>) -> io::Result<File> {
 
     let (file, path) = make_file(dir, OsStr::new(DEFAULT_PREFIX), OsStr::new(""))?;
     // Unlink immediately: from here on the file is reachable only through the
-    // descriptor, which is what makes the cleanup survive a crash.
-    fs::remove_file(&path)?;
-    Ok(file)
+    // descriptor, which is what makes the cleanup survive a crash. Someone
+    // else having removed the entry first reaches the same end state, so it is
+    // not an error.
+    match fs::remove_file(&path) {
+        Ok(()) => Ok(file),
+        Err(e) if e.kind() == io::ErrorKind::NotFound => Ok(file),
+        Err(e) => Err(e),
+    }
 }
 
 #[cfg(target_os = "linux")]
@@ -285,8 +334,10 @@ impl NamedTempFile {
     /// Rename the file to `path`, giving up ownership of the cleanup.
     ///
     /// `path` must be on the same filesystem, since the rename has to be
-    /// atomic. On failure the temporary is handed back inside the error so the
-    /// caller can retry or let it be cleaned up.
+    /// atomic. **Anything already at `path` is replaced** -- that is the point
+    /// for `plib::io::write_atomic_mode`, but it means this is not a way to
+    /// create a file only if one is absent. On failure the temporary is handed
+    /// back inside the error so the caller can retry or let it be cleaned up.
     pub fn persist(mut self, path: impl AsRef<Path>) -> Result<File, PersistError> {
         match fs::rename(&self.path, path.as_ref()) {
             Ok(()) => {
@@ -390,7 +441,7 @@ impl Builder {
 
     /// Create a temporary directory in the system temporary directory.
     pub fn tempdir(&self) -> io::Result<TempDir> {
-        self.tempdir_in(std::env::temp_dir())
+        self.tempdir_in(default_temp_dir())
     }
 
     /// Create a temporary directory in `dir`.
@@ -401,7 +452,7 @@ impl Builder {
 
     /// Create a named temporary file in the system temporary directory.
     pub fn tempfile(&self) -> io::Result<NamedTempFile> {
-        self.tempfile_in(std::env::temp_dir())
+        self.tempfile_in(default_temp_dir())
     }
 
     /// Create a named temporary file in `dir`.
@@ -590,6 +641,48 @@ mod tests {
         assert_eq!(file.metadata().unwrap().nlink(), 0);
         // Nothing was left behind under the chosen parent.
         assert_eq!(fs::read_dir(dir.path()).unwrap().count(), 0);
+    }
+
+    #[test]
+    fn a_prefix_cannot_escape_the_chosen_directory() {
+        let dir = tempdir().unwrap();
+
+        // Absolute: `Path::join` would otherwise discard `dir` entirely.
+        let err = Builder::new()
+            .prefix("/tmp/ESCAPED-")
+            .tempfile_in(dir.path())
+            .unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::InvalidInput);
+
+        // Relative but still a separator: would land in a subdirectory.
+        let err = Builder::new()
+            .prefix("sub/NESTED-")
+            .tempfile_in(dir.path())
+            .unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::InvalidInput);
+
+        let err = Builder::new()
+            .suffix("/etc/passwd")
+            .tempfile_in(dir.path())
+            .unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::InvalidInput);
+
+        let err = Builder::new()
+            .prefix("/tmp/ESCAPED-")
+            .tempdir_in(dir.path())
+            .unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::InvalidInput);
+
+        // Nothing was created under either candidate location.
+        assert_eq!(fs::read_dir(dir.path()).unwrap().count(), 0);
+    }
+
+    #[test]
+    fn default_dir_follows_tmpdir_only_when_not_set_id() {
+        // The test process is not set-id, so $TMPDIR is honored as usual.
+        assert_eq!(default_temp_dir(), std::env::temp_dir());
+        // And the set-id branch must not be able to pick a caller-named path.
+        assert!(default_temp_dir().is_absolute());
     }
 
     #[test]

--- a/process/fuser.rs
+++ b/process/fuser.rs
@@ -1327,12 +1327,17 @@ mod macos {
         let mut pids = check_listpid_ret(buffer_size)?;
         let buffer_ptr = pids.as_mut_ptr().cast::<c_void>();
 
+        // Same pathflags as the sizing call above: passing 0 here would ask a
+        // different question than the one just measured, dropping
+        // PROC_LISTPIDSPATH_PATH_IS_VOLUME so that `-c` on a mount point (and
+        // the block-device case) degraded to an exact-pathname match instead
+        // of covering every file on the filesystem.
         let ret = unsafe {
             osx_libproc_bindings::proc_listpidspath(
                 proc_type,
                 proc_type,
                 c_path.as_ptr().cast::<c_char>(),
-                0,
+                pathflags,
                 buffer_ptr,
                 buffer_size,
             )

--- a/users/logger.rs
+++ b/users/logger.rs
@@ -107,7 +107,6 @@ fn main() -> ExitCode {
     for msg in &messages {
         plib::syslog::log(level, msg);
     }
-    plib::syslog::close();
 
     ExitCode::SUCCESS
 }

--- a/users/logger.rs
+++ b/users/logger.rs
@@ -101,6 +101,12 @@ fn main() -> ExitCode {
 
     // Default tag is the invoking user's login name; -t overrides it. -i adds
     // the logger PID to each message.
+    //
+    // There is no failure path from here on: syslog(3) neither connects up
+    // front nor reports whether a message was delivered, so an unreachable
+    // logging daemon is indistinguishable from a delivered message and the
+    // exit status stays 0. The previous implementation spoke to /dev/log
+    // itself and could fail at connect time.
     let tag = args.tag.clone().unwrap_or_else(plib::curuser::login_name);
     plib::syslog::open(&tag, args.log_pid, facility);
 


### PR DESCRIPTION
Six issues from a security review of the new plib::tmp, plus one it turned up in a caller.

A prefix containing a path separator escaped the requested directory. `template` builds `dir.join(prefix + XXXXXX + suffix)`, and Path::join lets an absolute fragment replace the whole path: `Builder::new().prefix("/tmp/X-") .tempfile_in(dir)` put the file in /tmp and ignored `dir` outright (confirmed by running it). That breaks the invariant write_atomic_mode depends on -- the temporary must sit beside its target so the rename(2) is atomic. Reject a separator in either prefix or suffix.

env::temp_dir honors $TMPDIR unconditionally, including for a set-id process, where it hands the caller a directory they own and can swap files in. glibc suppresses TMPDIR under __libc_enable_secure for exactly this reason; Rust's does not. crontab is the case in this tree: it takes identity from the real uid and fchowns its spool copy, i.e. it is meant to be installed set-id, and do_edit puts the edit buffer under $TMPDIR. Fall back to /tmp when euid != uid or egid != gid. Not a regression -- the tempfile crate behaved the same way -- but this is now the security-critical primitive, so the guard belongs here.

Three cleanup leaks: the non-Linux CLOEXEC fixup closed the descriptor but left the file mkstemps had just created; tempfile_in's portable fallback turned a benign ENOENT (someone else already removed the entry, which is the end state we wanted) into a hard error; and NamedTempFile::persist replaced an existing destination without saying so in its docs.

Drop plib::syslog::close. closelog clears libc's tag but cannot clear the OnceLock holding the identity, so any later open() returned early and every subsequent message silently lost its tag and facility for the life of the process -- and talkd calls open() before every line precisely because it is documented as idempotent. Its one caller was logger, immediately before process exit, where it did nothing.

crontab's do_edit never dropped its edit buffer: every path out is exit() or install_crontab(), and neither runs destructors, so a copy of the user's crontab accumulated on each `crontab -e`. Pre-existing, but it now contradicts what plib::tmp documents. Route the failure paths through a bail_edit that drops first, and drop explicitly before handing off to install_crontab.

plib::tmp is 16 tests: the new ones pin separator rejection for prefix, suffix, tempfile_in and tempdir_in, and that nothing is created when one is rejected. Workspace is green (195 blocks, 0 failures) and clippy is clean for both x86_64-apple-darwin and x86_64-unknown-linux-gnu.


Claude-Session: https://claude.ai/code/session_01R9dvoJ2nMCQHSN8h9yJuVG